### PR TITLE
Added a safety check in DataGrid.Editing.BeginCellEdit

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -204,8 +204,10 @@ namespace Avalonia.Controls
                 // or we failed opening the row for edit, then we can no longer continue BeginCellEdit
                 return false;
             }
-            Debug.Assert(EditingRow != null);
-            Debug.Assert(EditingRow.Slot == CurrentSlot);
+            if (EditingRow == null || EditingRow.Slot != CurrentSlot)
+            {
+                return false;
+            }
 
             // Finally, we can prepare the cell for editing
             _editingColumnIndex = CurrentColumnIndex;


### PR DESCRIPTION
Fixes #36 

Added a safety check in DataGrid.Editing.BeginCellEdit so if the cached editing row is missing or no longer corresponds to the current slot, the method bails out instead of hitting the EditingRow.Slot == CurrentSlot assertion.