### PR TITLE
Preserved multi-selection

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridSelectedItemsTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridSelectedItemsTests.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
@@ -117,6 +119,64 @@ public class DataGridSelectedItemsTests
         Assert.All(rows.Where(x => x.Index != 2 && x.Index != 4), r => Assert.False(r.IsSelected));
     }
 
+    [AvaloniaFact]
+    public void SelectedItems_Preserved_When_Adding_Item_Before_Current_In_Sorted_View()
+    {
+        var items = new ObservableCollection<SortableItem>(Enumerable.Range(1, 5).Select(i => new SortableItem(i)));
+        var view = new DataGridCollectionView(items);
+        var grid = CreateSortableGrid(view);
+
+        ApplyIdSort(view, ListSortDirection.Descending);
+        grid.UpdateLayout();
+
+        grid.SelectedItem = items[1];
+        grid.SelectedItems.Add(items[2]);
+        grid.UpdateLayout();
+
+        var selectedIds = grid.SelectedItems.Cast<SortableItem>().Select(x => x.Id).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { 2, 3 }, selectedIds);
+
+        items.Add(new SortableItem(6));
+        grid.UpdateLayout();
+
+        selectedIds = grid.SelectedItems.Cast<SortableItem>().Select(x => x.Id).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { 2, 3 }, selectedIds);
+        Assert.Equal(view.IndexOf(items[1]), grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void SelectedItems_Survive_Repeated_Adds_And_Sorts()
+    {
+        var items = new ObservableCollection<SortableItem>(Enumerable.Range(1, 6).Select(i => new SortableItem(i)));
+        var view = new DataGridCollectionView(items);
+        var grid = CreateSortableGrid(view);
+
+        grid.UpdateLayout();
+
+        grid.SelectedItem = items[0];
+        grid.SelectedItems.Add(items[1]);
+        grid.SelectedItems.Add(items[2]);
+        grid.UpdateLayout();
+
+        items.Add(new SortableItem(7));
+
+        ApplyIdSort(view, ListSortDirection.Ascending);
+        grid.UpdateLayout();
+
+        items.Add(new SortableItem(8));
+
+        ApplyIdSort(view, ListSortDirection.Descending);
+        grid.UpdateLayout();
+
+        items.Add(new SortableItem(9));
+        grid.UpdateLayout();
+
+        var selectedIds = grid.SelectedItems.Cast<SortableItem>().Select(x => x.Id).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { 1, 2, 3 }, selectedIds);
+        var current = Assert.IsType<SortableItem>(grid.SelectedItem);
+        Assert.Contains(current, grid.SelectedItems.Cast<SortableItem>());
+    }
+
     private static DataGrid CreateGrid(IList items)
     {
         var root = new Window
@@ -149,9 +209,70 @@ public class DataGridSelectedItemsTests
         return grid;
     }
 
+    private static DataGrid CreateSortableGrid(IEnumerable items)
+    {
+        var root = new Window
+        {
+            Width = 250,
+            Height = 150,
+            Styles =
+            {
+                new StyleInclude((Uri?)null)
+                {
+                    Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Simple.xaml")
+                },
+            }
+        };
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            SelectionMode = DataGridSelectionMode.Extended,
+        };
+
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Id",
+            Binding = new Binding(nameof(SortableItem.Id)),
+            SortMemberPath = nameof(SortableItem.Id)
+        });
+
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(SortableItem.Name))
+        });
+
+        root.Content = grid;
+        root.Show();
+        return grid;
+    }
+
+    private static void ApplyIdSort(DataGridCollectionView view, ListSortDirection direction)
+    {
+        using (view.DeferRefresh())
+        {
+            view.SortDescriptions.Clear();
+            view.SortDescriptions.Add(DataGridSortDescription.FromPath(nameof(SortableItem.Id), direction));
+        }
+    }
+
     private static IReadOnlyList<DataGridRow> GetRows(DataGrid grid)
     {
         return grid.GetSelfAndVisualDescendants().OfType<DataGridRow>().ToList();
+    }
+
+    private class SortableItem
+    {
+        public SortableItem(int id, string? name = null)
+        {
+            Id = id;
+            Name = name ?? $"Item {id}";
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
     }
 
     private class SelectionViewModel

--- a/src/Avalonia.Controls.DataGrid/DataGrid.DataSource.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.DataSource.cs
@@ -209,6 +209,11 @@ namespace Avalonia.Controls
             }
             _desiredCurrentColumnIndex = -1;
 
+            int slot = currentItem != null ? SlotFromRowIndex(currentPosition) : -1;
+            bool currentInSelection = currentItem != null &&
+                slot >= 0 &&
+                _selectedItems.ContainsSlot(slot);
+
             try
             {
                 _noSelectionChangeCount++;
@@ -219,14 +224,18 @@ namespace Avalonia.Controls
                     CancelEdit(DataGridEditingUnit.Row, false);
                 }
 
-                ClearRowSelection(true);
                 if (currentItem == null)
                 {
+                    ClearRowSelection(true);
                     SetCurrentCellCore(-1, -1);
+                }
+                else if (currentInSelection)
+                {
+                    ProcessSelectionAndCurrency(columnIndex, currentItem, slot, DataGridSelectionAction.None, false);
                 }
                 else
                 {
-                    int slot = SlotFromRowIndex(currentPosition);
+                    ClearRowSelection(true);
                     ProcessSelectionAndCurrency(columnIndex, currentItem, slot, DataGridSelectionAction.SelectCurrent, false);
                 }
             }


### PR DESCRIPTION
Preserved multi-selection when currency shifts by keeping the existing selection if the collection view’s current item is already selected; the current cell still moves but we no longer clear selections on these internal CurrentChanged events (src/Avalonia.Controls.DataGrid/DataGrid.DataSource.cs).

Added two headless repro tests that mirror the reported scenario: one for a sorted view inserting before the current item and one covering repeated add/sort cycles to ensure SelectedItems stays intact (src/Avalonia.Controls.DataGrid.UnitTests/DataGridSelectedItemsTests.cs with new SortableItem, sortable grid helper, and sort helper).

Fixes #32 