### PR TITLE
Guarded template column refresh

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -637,7 +637,10 @@ namespace Avalonia.Controls
                     {
                         if (columns[ci] is DataGridTemplateColumn column)
                         {
-                            column.RefreshCellContent((Control)this.Cells[column.Index].Content, nameof(DataGridTemplateColumn.CellTemplate));
+                            if (column.Index >= 0 && column.Index < Cells.Count)
+                            {
+                                column.RefreshCellContent((Control)Cells[column.Index].Content, nameof(DataGridTemplateColumn.CellTemplate));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Added a regression test in src/Avalonia.Controls.DataGrid.UnitTests/DataGridScrollingTests.cs that reproduces the UseLogicalScrollable crash when a new template column is added while rows are recycled and then scrolled back into view.

- Guarded template column refresh in src/Avalonia.Controls.DataGrid/DataGridRow.cs so recycled rows skip columns that don’t yet have realized cells, preventing the out-of-range exception seen in issue #55.

The crash came from DataGridRow.OnPropertyChanged (src/Avalonia.Controls.DataGrid/DataGridRow.cs), which refreshes template-column cells when a recycled row gets a new DataContext. The code assumed every column index already had a matching entry in Cells, and did:

`column.RefreshCellContent((Control)Cells[column.Index].Content, ...)`

When UseLogicalScrollable is true, rows are recycled aggressively. If the column set changes (or a template column is added) while a row is off-screen, the recycled row’s Cells collection can still reflect the old column count. On the next scroll back into view, DataContext is reassigned, the refresh loop runs, and Cells[column.Index] is called with an index that is >= Cells.Count, throwing the out-of-range exception seen in issue #55.

The fix guards the refresh with a bounds check so recycled rows skip columns that don’t yet have realized cells, preventing the invalid access. A regression test was added to reproduce the scenario by adding a template column while rows are recycled under logical scrolling.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/55