### PR TITLE
Add keyboard gesture override support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,47 @@ Basic setup with common column types and width modes (pixel, auto, star):
 
 Widths accept pixel values (`"80"`), `Auto` (content-based), `*` or weighted stars (e.g., `2*`) that share remaining space.
 
+## Keyboard shortcuts
+
+### Default gestures
+
+| Action | Default | Notes |
+| --- | --- | --- |
+| Tab | `Tab` | Moves to the next/previous editable cell while editing; `Shift+Tab` reverses. When not editing, focus can leave the grid. |
+| MoveUp | `Up` | Moves selection up. `Ctrl+Up` jumps to the first row. `Shift` extends selection in `SelectionMode=Extended`. |
+| MoveDown | `Down` | Moves selection down. `Ctrl+Down` jumps to the last row. `Shift` extends selection in `SelectionMode=Extended`. |
+| MoveLeft | `Left` | Moves to the previous column. `Ctrl+Left` jumps to the first column. Collapses row groups or hierarchical nodes; `Alt+Left` collapses the subtree. |
+| MoveRight | `Right` | Moves to the next column. `Ctrl+Right` jumps to the last column. Expands row groups or hierarchical nodes; `Alt+Right` expands the subtree. |
+| MovePageUp | `PageUp` | Moves up by a viewport page. `Shift` extends selection in `SelectionMode=Extended`. |
+| MovePageDown | `PageDown` | Moves down by a viewport page. `Shift` extends selection in `SelectionMode=Extended`. |
+| MoveHome | `Home` | Moves to the first column. `Ctrl+Home` jumps to the first row. |
+| MoveEnd | `End` | Moves to the last column. `Ctrl+End` jumps to the last row. |
+| Enter | `Enter` | Commits edits and moves down one row. `Ctrl+Enter` commits without moving. |
+| CancelEdit | `Escape` | Cancels cell/row editing. |
+| BeginEdit | `F2` | Begins editing the current cell (default also honors `Alt+F2`). |
+| SelectAll | `Ctrl/Cmd+A` | Selects all rows/cells when `SelectionMode=Extended`. |
+| Copy | `Ctrl/Cmd+C` | Copies selection to the clipboard (requires `ClipboardCopyMode` to be enabled). |
+| CopyAlternate | `Ctrl/Cmd+Insert` | Alternate copy gesture. |
+| Delete | `Delete` | Removes selected rows when `CanUserDeleteRows` and the data source allows deletion. |
+| ExpandAll | `Multiply` | Expands all children under the current hierarchical node or group. |
+
+### Override defaults
+
+Use `DataGrid.KeyboardGestureOverrides` to remap built-in actions. Any non-null gesture replaces the default mapping for that action; set `Key.None` to disable an action. Built-in handling always respects `e.Handled`, so custom `KeyDown` handlers can opt out of the defaults.
+
+```xml
+<DataGrid KeyboardGestureOverrides="{Binding KeyboardGestureOverrides}" />
+```
+
+```csharp
+KeyboardGestureOverrides = new DataGridKeyboardGestures
+{
+    MoveDown = new KeyGesture(Key.J),
+    MoveUp = new KeyGesture(Key.K),
+    ExpandAll = new KeyGesture(Key.E)
+};
+```
+
 ### Public API comparison with WPF DataGrid
 
 - Build ProDataGrid: `dotnet build src/Avalonia.Controls.DataGrid/Avalonia.Controls.DataGrid.csproj -c Release -f net8.0`

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Clipboard/DataGridClipboardExportTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Clipboard/DataGridClipboardExportTests.cs
@@ -9,8 +9,8 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
-using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Headless.XUnit;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
@@ -375,7 +375,7 @@ public class DataGridClipboardExportTests
             return false;
         }
 
-        return method.Invoke(grid, new object[] { KeyModifiers.Control }) is true;
+        return method.Invoke(grid, Array.Empty<object>()) is true;
     }
 
     private static async Task<IAsyncDataTransfer?> WaitForClipboardAsync(TopLevel root)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridAllCellsEditingHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridAllCellsEditingHeadlessTests.cs
@@ -1203,6 +1203,7 @@ public class DataGridAllCellsEditingHeadlessTests
         return new KeyEventArgs
         {
             RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
             Key = key,
             KeyModifiers = modifiers,
             Source = target

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputMouseSelectionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputMouseSelectionTests.cs
@@ -102,6 +102,31 @@ public class DataGridInputMouseSelectionTests
     }
 
     [AvaloniaFact]
+    public void PointerPressed_Does_Not_Change_Selection_When_Handled()
+    {
+        var (grid, items) = CreateGrid(selectionUnit: DataGridSelectionUnit.FullRow, selectionMode: DataGridSelectionMode.Extended);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        Assert.Single(grid.SelectedItems);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
+
+        var slot = grid.SlotFromRowIndex(1);
+        var row = grid.DisplayData.GetDisplayedElement(slot) as DataGridRow;
+        Assert.NotNull(row);
+
+        var cell = row!.Cells[0];
+        Assert.NotNull(cell);
+
+        var args = CreateLeftPointerArgs(cell);
+        cell.AddHandler(InputElement.PointerPressedEvent, (_, eventArgs) => eventArgs.Handled = true, RoutingStrategies.Tunnel);
+
+        cell.RaiseEvent(args);
+
+        Assert.Single(grid.SelectedItems);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
+    }
+
+    [AvaloniaFact]
     public void MouseLeft_CellSelection_Single_Replaces_Selection()
     {
         var (grid, _) = CreateGrid(selectionUnit: DataGridSelectionUnit.Cell, selectionMode: DataGridSelectionMode.Single);

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.Utils;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Input;
+
+public class DataGridKeyboardGestureOverrideTests
+{
+    [AvaloniaFact]
+    public void KeyDown_Handler_Can_Block_BuiltIn_When_AfterHandlers()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        var invoked = false;
+        grid.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Down)
+            {
+                invoked = true;
+                e.Handled = true;
+            }
+        };
+
+        var handledArgs = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.Down,
+            Source = grid,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        grid.RaiseEvent(handledArgs);
+        InvokeDataGridKeyDown(grid, handledArgs);
+
+        Assert.True(invoked);
+        Assert.Equal(0, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void BuiltIn_Still_Runs_When_Not_Handled_AfterHandlers()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.Down,
+            Source = grid,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        InvokeDataGridKeyDown(grid, args);
+
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Replace_Default_Mapping()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveDown = new KeyGesture(Key.J)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        PressKey(grid, Key.Down);
+        Assert.Equal(0, grid.SelectedIndex);
+
+        PressKey(grid, Key.J);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Tab_Allows_Ctrl_When_Configured()
+    {
+        var (grid, _) = CreateGrid(columnCount: 3);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        Assert.True(grid.BeginEdit());
+
+        var ctrl = GetCtrlOrCmdModifier(grid);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            Tab = new KeyGesture(Key.T, ctrl)
+        };
+
+        PressKey(grid, Key.Tab);
+        Assert.Equal(0, grid.CurrentColumnIndex);
+
+        PressKey(grid, Key.T, ctrl);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_MoveUp_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveUp = new KeyGesture(Key.K)
+        };
+        SetCurrentCell(grid, rowIndex: 1, columnIndex: 0);
+
+        PressKey(grid, Key.Up);
+        Assert.Equal(1, grid.SelectedIndex);
+
+        PressKey(grid, Key.K);
+        Assert.Equal(0, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_MoveLeftRight_Use_Custom_Gestures()
+    {
+        var (grid, _) = CreateGrid(columnCount: 3);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveLeft = new KeyGesture(Key.H),
+            MoveRight = new KeyGesture(Key.L)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 1);
+
+        PressKey(grid, Key.Left);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+
+        PressKey(grid, Key.H);
+        Assert.Equal(0, grid.CurrentColumnIndex);
+
+        PressKey(grid, Key.L);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_MoveHomeEnd_Use_Custom_Gestures()
+    {
+        var (grid, _) = CreateGrid(columnCount: 3);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveHome = new KeyGesture(Key.G),
+            MoveEnd = new KeyGesture(Key.M)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 1);
+
+        PressKey(grid, Key.Home);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+
+        PressKey(grid, Key.G);
+        Assert.Equal(0, grid.CurrentColumnIndex);
+
+        PressKey(grid, Key.M);
+        Assert.Equal(2, grid.CurrentColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_PageDown_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid(rowCount: 6);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MovePageDown = new KeyGesture(Key.D)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        SetDisplayedScrollingElements(grid, 1);
+
+        PressKey(grid, Key.PageDown);
+        Assert.Equal(0, grid.SelectedIndex);
+
+        PressKey(grid, Key.D);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_PageUp_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid(rowCount: 6);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MovePageUp = new KeyGesture(Key.U)
+        };
+        SetCurrentCell(grid, rowIndex: 2, columnIndex: 0);
+        SetDisplayedScrollingElements(grid, 1);
+
+        PressKey(grid, Key.PageUp);
+        Assert.Equal(2, grid.SelectedIndex);
+
+        PressKey(grid, Key.U);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Enter_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            Enter = new KeyGesture(Key.N)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        PressKey(grid, Key.Enter);
+        Assert.Equal(0, grid.SelectedIndex);
+
+        PressKey(grid, Key.N);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_BeginEdit_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            BeginEdit = new KeyGesture(Key.B)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        PressKey(grid, Key.F2);
+        Assert.Equal(-1, grid.EditingColumnIndex);
+
+        PressKey(grid, Key.B);
+        Assert.Equal(0, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_CancelEdit_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            CancelEdit = new KeyGesture(Key.Q)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        Assert.True(grid.BeginEdit());
+
+        PressKey(grid, Key.Escape);
+        Assert.NotEqual(-1, grid.EditingColumnIndex);
+
+        PressKey(grid, Key.Q);
+        Assert.Equal(-1, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_SelectAll_Uses_Custom_Gesture()
+    {
+        var (grid, items) = CreateGrid(selectionMode: DataGridSelectionMode.Extended);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            SelectAll = new KeyGesture(Key.S)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        var ctrl = GetCtrlOrCmdModifier(grid);
+
+        PressKey(grid, Key.A, ctrl);
+        Assert.Equal(1, grid.SelectedItems.Count);
+
+        PressKey(grid, Key.S);
+        Assert.Equal(items.Count, grid.SelectedItems.Count);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Copy_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            Copy = new KeyGesture(Key.P),
+            CopyAlternate = new KeyGesture(Key.O)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        grid.ClipboardCopyMode = DataGridClipboardCopyMode.IncludeHeader;
+
+        var copyCount = 0;
+        grid.CopyingRowClipboardContent += (_, _) => copyCount++;
+
+        var ctrl = GetCtrlOrCmdModifier(grid);
+        PressKey(grid, Key.C, ctrl);
+        PressKey(grid, Key.Insert, ctrl);
+        Assert.Equal(0, copyCount);
+
+        PressKey(grid, Key.P);
+        Assert.True(copyCount > 0);
+
+        copyCount = 0;
+        PressKey(grid, Key.O);
+        Assert.True(copyCount > 0);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Delete_Uses_Custom_Gesture()
+    {
+        var (grid, items) = CreateGrid(canUserDeleteRows: true);
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            Delete = new KeyGesture(Key.X)
+        };
+        grid.SelectedIndex = 1;
+        grid.UpdateLayout();
+
+        PressKey(grid, Key.Delete);
+        Assert.Equal(5, items.Count);
+
+        PressKey(grid, Key.X);
+        Assert.Equal(4, items.Count);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_ExpandAll_Uses_Custom_Gesture()
+    {
+        var (grid, _) = CreateGrid(rowCount: 1, columnCount: 1);
+        var root = new HierarchyItem("root");
+        var child = new HierarchyItem("child");
+        root.Children.Add(child);
+
+        var (_, adapter) = EnableHierarchicalAdapter(
+            grid,
+            root,
+            item => ((HierarchyItem)item).Children,
+            treatGroupsAsNodes: false,
+            isLeafSelector: item => item is HierarchyItem node && node.Children.Count == 0);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            ExpandAll = new KeyGesture(Key.E)
+        };
+
+        Assert.False(adapter.NodeAt(0).IsExpanded);
+
+        PressKey(grid, Key.Multiply);
+        Assert.False(adapter.NodeAt(0).IsExpanded);
+
+        PressKey(grid, Key.E);
+        Assert.True(adapter.NodeAt(0).IsExpanded);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Disable_Action_With_KeyNone()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveDown = new KeyGesture(Key.None)
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        var args = PressKey(grid, Key.Down);
+
+        Assert.False(args.Handled);
+        Assert.Equal(0, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void GestureOverrides_Conflicting_Gestures_Use_First_Match()
+    {
+        var (grid, _) = CreateGrid();
+        grid.KeyboardGestureOverrides = new DataGridKeyboardGestures
+        {
+            MoveUp = new KeyGesture(Key.G),
+            MoveDown = new KeyGesture(Key.G)
+        };
+        SetCurrentCell(grid, rowIndex: 1, columnIndex: 0);
+
+        PressKey(grid, Key.G);
+
+        Assert.Equal(0, grid.SelectedIndex);
+    }
+
+    private static (DataGrid grid, ObservableCollection<InputRow> items) CreateGrid(
+        int rowCount = 5,
+        int columnCount = 3,
+        DataGridSelectionMode selectionMode = DataGridSelectionMode.Single,
+        DataGridSelectionUnit selectionUnit = DataGridSelectionUnit.FullRow,
+        bool canUserDeleteRows = false)
+    {
+        var items = new ObservableCollection<InputRow>();
+        for (var i = 0; i < rowCount; i++)
+        {
+            items.Add(new InputRow { A = i, B = i + 100, C = i + 200 });
+        }
+
+        var root = new Window
+        {
+            Width = 640,
+            Height = 480
+        };
+
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            SelectionMode = selectionMode,
+            SelectionUnit = selectionUnit,
+            CanUserAddRows = false,
+            CanUserDeleteRows = canUserDeleteRows,
+            AutoGenerateColumns = false
+        };
+
+        if (columnCount >= 1)
+        {
+            grid.ColumnsInternal.Add(new DataGridTextColumn
+            {
+                Header = "A",
+                Binding = new Binding(nameof(InputRow.A))
+            });
+        }
+
+        if (columnCount >= 2)
+        {
+            grid.ColumnsInternal.Add(new DataGridTextColumn
+            {
+                Header = "B",
+                Binding = new Binding(nameof(InputRow.B))
+            });
+        }
+
+        if (columnCount >= 3)
+        {
+            grid.ColumnsInternal.Add(new DataGridTextColumn
+            {
+                Header = "C",
+                Binding = new Binding(nameof(InputRow.C))
+            });
+        }
+
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        return (grid, items);
+    }
+
+    private static void SetCurrentCell(DataGrid grid, int rowIndex, int columnIndex)
+    {
+        var slot = grid.SlotFromRowIndex(rowIndex);
+        grid.UpdateSelectionAndCurrency(columnIndex, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: true);
+        grid.UpdateLayout();
+    }
+
+    private static KeyEventArgs PressKey(Control target, Key key, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = key,
+            KeyModifiers = modifiers,
+            Source = target,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        if (target is DataGrid grid)
+        {
+            InvokeDataGridKeyDown(grid, args);
+        }
+        target.UpdateLayout();
+        return args;
+    }
+
+    private static void InvokeDataGridKeyDown(DataGrid grid, KeyEventArgs args)
+    {
+        var method = typeof(DataGrid).GetMethod(
+            "DataGrid_KeyDown",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        method?.Invoke(grid, new object[] { grid, args });
+    }
+
+    private static KeyModifiers GetCtrlOrCmdModifier(Control target)
+    {
+        return KeyboardHelper.GetPlatformCtrlOrCmdKeyModifier(target);
+    }
+
+    private static void SetDisplayedScrollingElements(DataGrid grid, int count)
+    {
+        var property = typeof(DataGrid).GetProperty("DisplayData", BindingFlags.Instance | BindingFlags.NonPublic);
+        var displayData = property?.GetValue(grid);
+        var elementsProperty = displayData?.GetType().GetProperty("NumTotallyDisplayedScrollingElements");
+        elementsProperty?.SetValue(displayData, count);
+    }
+
+    private static (HierarchicalModel Model, DataGridHierarchicalAdapter Adapter) EnableHierarchicalAdapter(
+        DataGrid grid,
+        object root,
+        Func<object, IEnumerable?>? childrenSelector,
+        bool treatGroupsAsNodes,
+        Func<object, bool>? isLeafSelector = null)
+    {
+        var options = new HierarchicalOptions
+        {
+            ChildrenSelector = childrenSelector,
+            TreatGroupsAsNodes = treatGroupsAsNodes,
+            IsLeafSelector = isLeafSelector
+        };
+        var model = new HierarchicalModel(options);
+        var adapter = new DataGridHierarchicalAdapter(model);
+        adapter.SetRoot(root);
+
+        SetPrivateField(grid, "_hierarchicalModel", model);
+        SetPrivateField(grid, "_hierarchicalAdapter", adapter);
+        SetPrivateField(grid, "_hierarchicalRowsEnabled", true);
+
+        return (model, adapter);
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object? value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        field?.SetValue(target, value);
+    }
+
+    private sealed class HierarchyItem
+    {
+        public HierarchyItem(string name)
+        {
+            Name = name;
+            Children = new List<HierarchyItem>();
+        }
+
+        public string Name { get; }
+
+        public List<HierarchyItem> Children { get; }
+    }
+
+    private sealed class InputRow : IEditableObject
+    {
+        public int A { get; set; }
+        public int B { get; set; }
+        public int C { get; set; }
+
+        private (int A, int B, int C)? _backup;
+
+        public void BeginEdit()
+        {
+            _backup = (A, B, C);
+        }
+
+        public void CancelEdit()
+        {
+            if (_backup.HasValue)
+            {
+                var value = _backup.Value;
+                A = value.A;
+                B = value.B;
+                C = value.C;
+            }
+            _backup = null;
+        }
+
+        public void EndEdit()
+        {
+            _backup = null;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
@@ -191,6 +191,30 @@ public class DataGridKeyboardInputTests
     }
 
     [AvaloniaFact]
+    public void Ctrl_C_Copies_When_Selection_Present()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        var ctrl = GetCtrlOrCmdModifier(grid);
+
+        var args = PressKey(grid, Key.C, ctrl);
+
+        Assert.True(args.Handled);
+    }
+
+    [AvaloniaFact]
+    public void Ctrl_Insert_Copies_When_Selection_Present()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        var ctrl = GetCtrlOrCmdModifier(grid);
+
+        var args = PressKey(grid, Key.Insert, ctrl);
+
+        Assert.True(args.Handled);
+    }
+
+    [AvaloniaFact]
     public void DownKey_Selects_First_Cell_When_No_Current_Cell()
     {
         var (grid, items) = CreateGrid();
@@ -508,6 +532,18 @@ public class DataGridKeyboardInputTests
     }
 
     [AvaloniaFact]
+    public void F2_Starts_Edit_When_Alt_Pressed()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        var args = PressKey(grid, Key.F2, KeyModifiers.Alt);
+
+        Assert.True(args.Handled);
+        Assert.Equal(0, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
     public void F2_Does_Not_Edit_When_Modifier_Pressed()
     {
         var (grid, _) = CreateGrid();
@@ -662,15 +698,27 @@ public class DataGridKeyboardInputTests
         var args = new KeyEventArgs
         {
             RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
             Key = key,
             KeyModifiers = modifiers,
             Source = target,
             KeyDeviceType = KeyDeviceType.Keyboard
         };
 
-        target.RaiseEvent(args);
+        if (target is DataGrid grid)
+        {
+            InvokeDataGridKeyDown(grid, args);
+        }
         target.UpdateLayout();
         return args;
+    }
+
+    private static void InvokeDataGridKeyDown(DataGrid grid, KeyEventArgs args)
+    {
+        var method = typeof(DataGrid).GetMethod(
+            "DataGrid_KeyDown",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        method?.Invoke(grid, new object[] { grid, args });
     }
 
     private static KeyModifiers GetCtrlOrCmdModifier(Control target)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionOriginTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionOriginTests.cs
@@ -123,6 +123,7 @@ public class DataGridSelectionOriginTests
         var keyArgs = new KeyEventArgs
         {
             RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
             Source = grid,
             Key = Key.Down,
             PhysicalKey = PhysicalKey.ArrowDown,
@@ -130,7 +131,7 @@ public class DataGridSelectionOriginTests
             KeyDeviceType = KeyDeviceType.Keyboard
         };
 
-        grid.RaiseEvent(keyArgs);
+        InvokeDataGridKeyDown(grid, keyArgs);
         grid.UpdateLayout();
 
         Assert.NotNull(args);
@@ -182,6 +183,14 @@ public class DataGridSelectionOriginTests
         root.Content = grid;
         root.Show();
         return grid;
+    }
+
+    private static void InvokeDataGridKeyDown(DataGrid grid, KeyEventArgs args)
+    {
+        var method = typeof(DataGrid).GetMethod(
+            "DataGrid_KeyDown",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        method?.Invoke(grid, new object[] { grid, args });
     }
 
     private static DataGrid CreateGrid(IEnumerable items, SelectionModel<string> selection)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Clipboard.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Clipboard.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
@@ -43,20 +42,17 @@ namespace Avalonia.Controls
 
 
         /// <summary>
-        /// Handles the case where a 'Copy' key ('C' or 'Insert') has been pressed.  If pressed in combination with
-        /// the control key, and the necessary prerequisites are met, the DataGrid will copy its contents
-        /// to the Clipboard as text.
+        /// Handles the case where a copy gesture has been invoked.
         /// </summary>
         /// <returns>Whether or not the DataGrid handled the key press.</returns>
-        private bool ProcessCopyKey(KeyModifiers modifiers)
+        private bool ProcessCopyKey()
         {
-            KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out bool shift, out bool alt);
-
-            if (ctrl && !shift && !alt && ClipboardCopyMode != DataGridClipboardCopyMode.None)
+            if (ClipboardCopyMode == DataGridClipboardCopyMode.None)
             {
-                return CopySelectionToClipboard();
+                return false;
             }
-            return false;
+
+            return CopySelectionToClipboard();
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.Keyboard.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.Keyboard.cs
@@ -20,29 +20,28 @@ namespace Avalonia.Controls
 {
     partial class DataGrid
     {
-        private bool ProcessAKey(KeyEventArgs e)
+        private bool ProcessAKey()
         {
-            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift, out bool alt);
-
-            if (ctrl && !shift && !alt && SelectionMode == DataGridSelectionMode.Extended)
+            if (SelectionMode != DataGridSelectionMode.Extended)
             {
-                if (SelectionUnit == DataGridSelectionUnit.FullRow)
-                {
-                    SelectAll();
-                }
-                else
-                {
-                    SelectAllCells();
-                }
-                return true;
+                return false;
             }
-            return false;
+
+            if (SelectionUnit == DataGridSelectionUnit.FullRow)
+            {
+                SelectAll();
+            }
+            else
+            {
+                SelectAllCells();
+            }
+            return true;
         }
 
         private bool ProcessTabKey(KeyEventArgs e)
         {
             KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
-            return ProcessTabKey(e, shift, ctrl);
+            return ProcessTabKey(e, shift, ctrl, allowCtrl: false);
         }
 
         internal bool ProcessDownKey(KeyEventArgs e)
@@ -297,11 +296,8 @@ namespace Avalonia.Controls
 
         private bool ProcessF2Key(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
-
-            if (!shift && !ctrl &&
-            _editingColumnIndex == -1 && CurrentColumnIndex != -1 && GetRowSelection(CurrentSlot) &&
-            !GetColumnEffectiveReadOnlyState(CurrentColumn))
+            if (_editingColumnIndex == -1 && CurrentColumnIndex != -1 && GetRowSelection(CurrentSlot) &&
+                !GetColumnEffectiveReadOnlyState(CurrentColumn))
             {
                 if (ScrollSlotIntoView(CurrentColumnIndex, CurrentSlot, forCurrentCellChange: false, forceHorizontalScroll: true))
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -564,6 +564,25 @@ namespace Avalonia.Controls
             set { SetValue(SelectionUnitProperty, value); }
         }
 
+        /// <summary>
+        /// Defines the <see cref="KeyboardGestureOverrides"/> property.
+        /// </summary>
+        public static readonly StyledProperty<DataGridKeyboardGestures> KeyboardGestureOverridesProperty =
+            AvaloniaProperty.Register<DataGrid, DataGridKeyboardGestures>(nameof(KeyboardGestureOverrides));
+
+        /// <summary>
+        /// Gets or sets gesture overrides for built-in keyboard handling.
+        /// </summary>
+        /// <remarks>
+        /// When set, any non-null gesture replaces the default mapping for that action.
+        /// Use <see cref="KeyGesture.Key"/> set to <see cref="Key.None"/> to disable an action.
+        /// </remarks>
+        public DataGridKeyboardGestures KeyboardGestureOverrides
+        {
+            get { return GetValue(KeyboardGestureOverridesProperty); }
+            set { SetValue(KeyboardGestureOverridesProperty, value); }
+        }
+
         public static readonly StyledProperty<IBrush> VerticalGridLinesBrushProperty =
             AvaloniaProperty.Register<DataGrid, IBrush>(nameof(VerticalGridLinesBrush));
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
@@ -180,6 +180,13 @@ namespace Avalonia.Controls
                             _selectionModelAdapter.Deselect(rowIndex);
                             break;
                         case DataGridSelectionAction.SelectFromAnchorToCurrent:
+                            if (_selectionModelAdapter.Model.SingleSelect)
+                            {
+                                _selectionModelAdapter.Clear();
+                                _selectionModelAdapter.Select(rowIndex);
+                                break;
+                            }
+
                             if (AnchorSlot != -1)
                             {
                                 int anchorIndex = SelectionIndexFromSlot(AnchorSlot);

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Template.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Template.cs
@@ -119,6 +119,7 @@ namespace Avalonia.Controls
             }
 
             TryExecutePendingAutoScroll();
+            UpdateKeyboardGestureSubscriptions();
         }
 
 
@@ -133,6 +134,7 @@ namespace Avalonia.Controls
             }
 
             DisposeSummaryService();
+            UpdateKeyboardGestureSubscriptions();
         }
 
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -441,9 +441,6 @@ namespace Avalonia.Controls
         /// </summary>
         public DataGrid()
         {
-            KeyDown += DataGrid_KeyDown;
-            KeyUp += DataGrid_KeyUp;
-
             //TODO: Check if override works
             GotFocus += DataGrid_GotFocus;
             LostFocus += DataGrid_LostFocus;
@@ -898,6 +895,11 @@ namespace Avalonia.Controls
 
         private void DataGrid_PointerActivity(object? sender, PointerEventArgs e)
         {
+            if (e.Handled)
+            {
+                return;
+            }
+
             _lastPointerPosition = e.GetPosition(this);
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Controls
         static DataGridCell()
         {
             PointerPressedEvent.AddClassHandler<DataGridCell>(
-                (x,e) => x.DataGridCell_PointerPressed(e), handledEventsToo: true);
+                (x,e) => x.DataGridCell_PointerPressed(e));
             FocusableProperty.OverrideDefaultValue<DataGridCell>(true);
             IsTabStopProperty.OverrideDefaultValue<DataGridCell>(false);
             AutomationProperties.IsOffscreenBehaviorProperty.OverrideDefaultValue<DataGridCell>(IsOffscreenBehavior.FromClip);
@@ -196,6 +196,11 @@ namespace Avalonia.Controls
         //TODO TabStop
         private void DataGridCell_PointerPressed(PointerPressedEventArgs e)
         {
+            if (e.Handled)
+            {
+                return;
+            }
+
             // OwningGrid is null for TopLeftHeaderCell and TopRightHeaderCell because they have no OwningRow
             if (OwningGrid == null)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridKeyboardGestures.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridKeyboardGestures.cs
@@ -1,0 +1,74 @@
+// This source is subject to the Microsoft Public License (Ms-PL).
+// Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
+// All other rights reserved.
+
+#nullable disable
+
+using Avalonia.Input;
+
+namespace Avalonia.Controls
+{
+#if !DATAGRID_INTERNAL
+    public
+#endif
+    sealed class DataGridKeyboardGestures
+    {
+        public KeyGesture Tab { get; set; }
+
+        public KeyGesture MoveUp { get; set; }
+
+        public KeyGesture MoveDown { get; set; }
+
+        public KeyGesture MoveLeft { get; set; }
+
+        public KeyGesture MoveRight { get; set; }
+
+        public KeyGesture MovePageUp { get; set; }
+
+        public KeyGesture MovePageDown { get; set; }
+
+        public KeyGesture MoveHome { get; set; }
+
+        public KeyGesture MoveEnd { get; set; }
+
+        public KeyGesture Enter { get; set; }
+
+        public KeyGesture CancelEdit { get; set; }
+
+        public KeyGesture BeginEdit { get; set; }
+
+        public KeyGesture SelectAll { get; set; }
+
+        public KeyGesture Copy { get; set; }
+
+        public KeyGesture CopyAlternate { get; set; }
+
+        public KeyGesture Delete { get; set; }
+
+        public KeyGesture ExpandAll { get; set; }
+
+        public static DataGridKeyboardGestures CreateDefault(KeyModifiers commandModifiers)
+        {
+            return new DataGridKeyboardGestures
+            {
+                Tab = new KeyGesture(Key.Tab),
+                MoveUp = new KeyGesture(Key.Up),
+                MoveDown = new KeyGesture(Key.Down),
+                MoveLeft = new KeyGesture(Key.Left),
+                MoveRight = new KeyGesture(Key.Right),
+                MovePageUp = new KeyGesture(Key.PageUp),
+                MovePageDown = new KeyGesture(Key.PageDown),
+                MoveHome = new KeyGesture(Key.Home),
+                MoveEnd = new KeyGesture(Key.End),
+                Enter = new KeyGesture(Key.Enter),
+                CancelEdit = new KeyGesture(Key.Escape),
+                BeginEdit = new KeyGesture(Key.F2),
+                SelectAll = new KeyGesture(Key.A, commandModifiers),
+                Copy = new KeyGesture(Key.C, commandModifiers),
+                CopyAlternate = new KeyGesture(Key.Insert, commandModifiers),
+                Delete = new KeyGesture(Key.Delete),
+                ExpandAll = new KeyGesture(Key.Multiply)
+            };
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -184,7 +184,7 @@ namespace Avalonia.Controls
             HeaderProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnHeaderChanged(e));
             DetailsTemplateProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnDetailsTemplateChanged(e));
             AreDetailsVisibleProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnAreDetailsVisibleChanged(e));
-            PointerPressedEvent.AddClassHandler<DataGridRow>((x, e) => x.DataGridRow_PointerPressed(e), handledEventsToo: true);
+            PointerPressedEvent.AddClassHandler<DataGridRow>((x, e) => x.DataGridRow_PointerPressed(e));
             IsTabStopProperty.OverrideDefaultValue<DataGridRow>(false);
             AutomationProperties.IsOffscreenBehaviorProperty.OverrideDefaultValue<DataGridRow>(IsOffscreenBehavior.FromClip);
         }
@@ -615,6 +615,11 @@ namespace Avalonia.Controls
 
         private void DataGridRow_PointerPressed(PointerPressedEventArgs e)
         {
+            if (e.Handled)
+            {
+                return;
+            }
+
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -158,7 +158,7 @@ namespace Avalonia.Controls
         /// </summary>
         public DataGridRowGroupHeader()
         {
-            AddHandler(InputElement.PointerPressedEvent, (s, e) => DataGridRowGroupHeader_PointerPressed(e), handledEventsToo: true);
+            AddHandler(InputElement.PointerPressedEvent, (s, e) => DataGridRowGroupHeader_PointerPressed(e));
         }
 
         internal DataGridRowHeader HeaderCell
@@ -359,6 +359,11 @@ namespace Avalonia.Controls
         private void DataGridRowGroupHeader_PointerPressed(PointerPressedEventArgs e)
         {
             if (OwningGrid == null)
+            {
+                return;
+            }
+
+            if (e.Handled)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public DataGridRowHeader()
         {
-            AddHandler(PointerPressedEvent, DataGridRowHeader_PointerPressed, handledEventsToo: true);
+            AddHandler(PointerPressedEvent, DataGridRowHeader_PointerPressed);
         }
 
         static DataGridRowHeader()
@@ -189,6 +189,11 @@ namespace Avalonia.Controls.Primitives
         private void DataGridRowHeader_PointerPressed(object sender, PointerPressedEventArgs e)
         {
             if (OwningGrid == null)
+            {
+                return;
+            }
+
+            if (e.Handled)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
+++ b/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
@@ -340,6 +340,11 @@ namespace Avalonia.Controls.DataGridDragDrop
 
         private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
+            if (e.Handled)
+            {
+                return;
+            }
+
             if (!ShouldHandlePointer(e))
             {
                 return;

--- a/src/DataGridSample/Controls/KeyboardGestureHelpPopup.axaml
+++ b/src/DataGridSample/Controls/KeyboardGestureHelpPopup.axaml
@@ -1,0 +1,45 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:DataGridSample.Controls"
+             x:Class="DataGridSample.Controls.KeyboardGestureHelpPopup"
+             x:DataType="controls:KeyboardGestureHelpPopup"
+             x:Name="Root">
+  <Border Padding="12"
+          Background="#FFF8F8F8"
+          BorderBrush="#22000000"
+          BorderThickness="1"
+          CornerRadius="6"
+          MinWidth="420"
+          MaxWidth="560">
+    <StackPanel Spacing="8">
+      <TextBlock Text="Keyboard shortcuts" Classes="h3" />
+
+      <Grid RowDefinitions="Auto,*">
+        <Grid ColumnDefinitions="2*,2*,2*" Margin="0 0 0 6">
+          <TextBlock Text="Action" FontWeight="Bold" />
+          <TextBlock Grid.Column="1" Text="Default" FontWeight="Bold" />
+          <TextBlock Grid.Column="2" Text="Override" FontWeight="Bold" />
+        </Grid>
+
+        <ScrollViewer Grid.Row="1" MaxHeight="360">
+          <ItemsControl ItemsSource="{Binding Items, ElementName=Root}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate x:DataType="controls:KeyboardGestureHelpItem">
+                <Grid ColumnDefinitions="2*,2*,2*" Margin="0 2">
+                  <TextBlock Text="{Binding Action}" />
+                  <TextBlock Grid.Column="1" Text="{Binding DefaultGesture}" />
+                  <TextBlock Grid.Column="2" Text="{Binding OverrideGesture}" />
+                </Grid>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </ScrollViewer>
+      </Grid>
+
+      <TextBlock Text="Override gestures by setting DataGrid.KeyboardGestureOverrides; use Key.None to disable an action."
+                 FontSize="11"
+                 Foreground="#666"
+                 TextWrapping="Wrap" />
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/src/DataGridSample/Controls/KeyboardGestureHelpPopup.axaml.cs
+++ b/src/DataGridSample/Controls/KeyboardGestureHelpPopup.axaml.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+
+namespace DataGridSample.Controls
+{
+    public sealed partial class KeyboardGestureHelpPopup : UserControl
+    {
+        public static readonly StyledProperty<DataGridKeyboardGestures?> OverridesProperty =
+            AvaloniaProperty.Register<KeyboardGestureHelpPopup, DataGridKeyboardGestures?>(nameof(Overrides));
+
+        private static readonly GestureDefinition[] Definitions =
+        [
+            new GestureDefinition("Tab", gestures => gestures.Tab),
+            new GestureDefinition("MoveUp", gestures => gestures.MoveUp),
+            new GestureDefinition("MoveDown", gestures => gestures.MoveDown),
+            new GestureDefinition("MoveLeft", gestures => gestures.MoveLeft),
+            new GestureDefinition("MoveRight", gestures => gestures.MoveRight),
+            new GestureDefinition("MovePageUp", gestures => gestures.MovePageUp),
+            new GestureDefinition("MovePageDown", gestures => gestures.MovePageDown),
+            new GestureDefinition("MoveHome", gestures => gestures.MoveHome),
+            new GestureDefinition("MoveEnd", gestures => gestures.MoveEnd),
+            new GestureDefinition("Enter", gestures => gestures.Enter),
+            new GestureDefinition("CancelEdit", gestures => gestures.CancelEdit),
+            new GestureDefinition("BeginEdit", gestures => gestures.BeginEdit),
+            new GestureDefinition("SelectAll", gestures => gestures.SelectAll),
+            new GestureDefinition("Copy", gestures => gestures.Copy),
+            new GestureDefinition("CopyAlternate", gestures => gestures.CopyAlternate),
+            new GestureDefinition("Delete", gestures => gestures.Delete),
+            new GestureDefinition("ExpandAll", gestures => gestures.ExpandAll)
+        ];
+
+        public KeyboardGestureHelpPopup()
+        {
+            InitializeComponent();
+        }
+
+        public DataGridKeyboardGestures? Overrides
+        {
+            get => GetValue(OverridesProperty);
+            set => SetValue(OverridesProperty, value);
+        }
+
+        public ObservableCollection<KeyboardGestureHelpItem> Items { get; } = new();
+
+        static KeyboardGestureHelpPopup()
+        {
+            OverridesProperty.Changed.AddClassHandler<KeyboardGestureHelpPopup>((control, _) => control.UpdateItems());
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            UpdateItems();
+        }
+
+        private void UpdateItems()
+        {
+            Items.Clear();
+
+            var defaults = DataGridKeyboardGestures.CreateDefault(GetCommandModifiers());
+            var overrides = Overrides;
+
+            foreach (var definition in Definitions)
+            {
+                var defaultGesture = definition.GetGesture(defaults);
+                var overrideGesture = overrides != null ? definition.GetGesture(overrides) : null;
+
+                Items.Add(new KeyboardGestureHelpItem(
+                    definition.Action,
+                    FormatGesture(defaultGesture),
+                    FormatOverride(overrideGesture)));
+            }
+        }
+
+        private KeyModifiers GetCommandModifiers()
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            return topLevel?.PlatformSettings?.HotkeyConfiguration.CommandModifiers ?? KeyModifiers.Control;
+        }
+
+        private static string FormatOverride(KeyGesture? gesture)
+        {
+            if (gesture == null)
+            {
+                return "Default";
+            }
+
+            if (gesture.Key == Key.None)
+            {
+                return "Disabled";
+            }
+
+            return FormatGesture(gesture);
+        }
+
+        private static string FormatGesture(KeyGesture? gesture)
+        {
+            if (gesture == null || gesture.Key == Key.None)
+            {
+                return "None";
+            }
+
+            var parts = new List<string>();
+            var modifiers = gesture.KeyModifiers;
+
+            if (modifiers.HasFlag(KeyModifiers.Control))
+            {
+                parts.Add("Ctrl");
+            }
+
+            if (modifiers.HasFlag(KeyModifiers.Meta))
+            {
+                parts.Add("Cmd");
+            }
+
+            if (modifiers.HasFlag(KeyModifiers.Shift))
+            {
+                parts.Add("Shift");
+            }
+
+            if (modifiers.HasFlag(KeyModifiers.Alt))
+            {
+                parts.Add("Alt");
+            }
+
+            parts.Add(gesture.Key.ToString());
+            return string.Join("+", parts);
+        }
+
+        private sealed class GestureDefinition
+        {
+            public GestureDefinition(string action, Func<DataGridKeyboardGestures, KeyGesture?> getGesture)
+            {
+                Action = action;
+                GetGesture = getGesture;
+            }
+
+            public string Action { get; }
+
+            public Func<DataGridKeyboardGestures, KeyGesture?> GetGesture { get; }
+        }
+    }
+
+    public sealed class KeyboardGestureHelpItem
+    {
+        public KeyboardGestureHelpItem(string action, string defaultGesture, string overrideGesture)
+        {
+            Action = action;
+            DefaultGesture = defaultGesture;
+            OverrideGesture = overrideGesture;
+        }
+
+        public string Action { get; }
+
+        public string DefaultGesture { get; }
+
+        public string OverrideGesture { get; }
+    }
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -98,6 +98,9 @@
     <TabItem Header="Routed events">
       <pages:RoutedEventsPage />
     </TabItem>
+    <TabItem Header="Keyboard Overrides">
+      <pages:KeyboardGestureHandlingPage />
+    </TabItem>
     <TabItem Header="Large Variable Height">
       <local:LargeVariableHeightPage />
     </TabItem>

--- a/src/DataGridSample/Pages/GroupedSelectionPage.axaml
+++ b/src/DataGridSample/Pages/GroupedSelectionPage.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:DataGridSample.Controls"
              xmlns:models="clr-namespace:DataGridSample.Models"
              xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
              x:Class="DataGridSample.Pages.GroupedSelectionPage"
@@ -13,6 +14,21 @@
       <TextBlock Classes="h2">Grouped Selection</TextBlock>
       <TextBlock Text="Rows are grouped by Region; selection is bound to SelectionModel and skips group headers. Selecting rows keeps state across expand/collapse."
                  TextWrapping="Wrap" />
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <CheckBox Content="Use Vim navigation (J/K)"
+                  VerticalAlignment="Center"
+                  IsChecked="{Binding UseVimNavigation}" />
+        <ToggleButton x:Name="KeyboardShortcutsToggle"
+                      VerticalAlignment="Center"
+                      Content="Keyboard shortcuts" />
+        <Popup PlacementTarget="{Binding #KeyboardShortcutsToggle}"
+               Placement="Bottom"
+               IsOpen="{Binding #KeyboardShortcutsToggle.IsChecked, Mode=TwoWay}"
+               IsLightDismissEnabled="True"
+               DataContext="{Binding #KeyboardShortcutsToggle.DataContext}">
+          <controls:KeyboardGestureHelpPopup Overrides="{Binding KeyboardGestureOverrides}" />
+        </Popup>
+      </StackPanel>
     </StackPanel>
 
     <DataGrid Grid.Row="1"
@@ -22,6 +38,7 @@
               SelectionMode="Extended"
               AutoGenerateColumns="True"
               HeadersVisibility="All"
+              KeyboardGestureOverrides="{Binding KeyboardGestureOverrides}"
               Height="420" />
 
     <StackPanel Grid.Row="1" Grid.Column="1" Spacing="8">

--- a/src/DataGridSample/Pages/HierarchicalSamplePage.axaml
+++ b/src/DataGridSample/Pages/HierarchicalSamplePage.axaml
@@ -10,6 +10,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
     xmlns:adapters="clr-namespace:DataGridSample.Adapters"
+    xmlns:controls="clr-namespace:DataGridSample.Controls"
     xmlns:hier="clr-namespace:Avalonia.Controls.DataGridHierarchical;assembly=Avalonia.Controls.DataGrid"
     x:DataType="viewModels:HierarchicalSampleViewModel"
     d:DesignHeight="720"
@@ -45,6 +46,19 @@
               Command="{Binding CollapseAllCommand}" />
       <Button Content="Refresh root"
               Command="{Binding RefreshRootCommand}" />
+      <CheckBox Content="Use overrides (J/K, E)"
+                VerticalAlignment="Center"
+                IsChecked="{Binding UseVimNavigation}" />
+      <ToggleButton x:Name="KeyboardShortcutsToggle"
+                    VerticalAlignment="Center"
+                    Content="Keyboard shortcuts" />
+      <Popup PlacementTarget="{Binding #KeyboardShortcutsToggle}"
+             Placement="Bottom"
+             IsOpen="{Binding #KeyboardShortcutsToggle.IsChecked, Mode=TwoWay}"
+             IsLightDismissEnabled="True"
+             DataContext="{Binding #KeyboardShortcutsToggle.DataContext}">
+        <controls:KeyboardGestureHelpPopup Overrides="{Binding KeyboardGestureOverrides}" />
+      </Popup>
     </StackPanel>
 
     <DataGrid Grid.Row="2"
@@ -57,7 +71,8 @@
               CanUserSortColumns="True"
               HeadersVisibility="Column"
               GridLinesVisibility="Horizontal"
-              SelectionMode="Single">
+              SelectionMode="Single"
+              KeyboardGestureOverrides="{Binding KeyboardGestureOverrides}">
       <DataGrid.Columns>
         <DataGridHierarchicalColumn Header="Name"
                                     SortMemberPath="Item.Name"

--- a/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml
+++ b/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml
@@ -1,0 +1,53 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:DataGridSample.Controls"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.KeyboardGestureHandlingPage"
+             x:DataType="viewModels:KeyboardGestureHandlingViewModel">
+  <UserControl.DataContext>
+    <viewModels:KeyboardGestureHandlingViewModel />
+  </UserControl.DataContext>
+
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8" Margin="12">
+    <StackPanel Grid.Row="0" Spacing="4">
+      <TextBlock Classes="h2">Keyboard overrides</TextBlock>
+      <TextBlock Text="Built-in key handling respects Handled and uses KeyboardGestureOverrides for remapping (try J/K for navigation)." TextWrapping="Wrap" />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="12">
+      <CheckBox VerticalAlignment="Center"
+                Content="Use Vim navigation (J/K)"
+                IsChecked="{Binding UseVimNavigation}" />
+      <ToggleButton x:Name="KeyboardShortcutsToggle"
+                    VerticalAlignment="Center"
+                    Content="Keyboard shortcuts" />
+      <Popup PlacementTarget="{Binding #KeyboardShortcutsToggle}"
+             Placement="Bottom"
+             IsOpen="{Binding #KeyboardShortcutsToggle.IsChecked, Mode=TwoWay}"
+             IsLightDismissEnabled="True"
+             DataContext="{Binding #KeyboardShortcutsToggle.DataContext}">
+        <controls:KeyboardGestureHelpPopup Overrides="{Binding KeyboardGestureOverrides}" />
+      </Popup>
+      <TextBlock VerticalAlignment="Center" Text="Last key:" />
+      <TextBlock VerticalAlignment="Center" Text="{Binding LastKey}" />
+    </StackPanel>
+
+    <DataGrid Grid.Row="2"
+              ItemsSource="{Binding People}"
+              KeyboardGestureOverrides="{Binding KeyboardGestureOverrides}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              CanUserDeleteRows="False"
+              SelectionMode="Single"
+              SelectionUnit="FullRow"
+              KeyDown="OnGridKeyDown">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="First" Binding="{Binding FirstName}" Width="2*" x:DataType="models:Person" />
+        <DataGridTextColumn Header="Last" Binding="{Binding LastName}" Width="2*" x:DataType="models:Person" />
+        <DataGridTextColumn Header="Age" Binding="{Binding Age}" Width="*" x:DataType="models:Person" />
+        <DataGridCheckBoxColumn Header="Is Banned" Binding="{Binding IsBanned}" Width="*" x:DataType="models:Person" />
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml.cs
+++ b/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml.cs
@@ -1,0 +1,26 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using DataGridSample.ViewModels;
+
+namespace DataGridSample.Pages
+{
+    public partial class KeyboardGestureHandlingPage : UserControl
+    {
+        public KeyboardGestureHandlingPage()
+        {
+            InitializeComponent();
+        }
+
+        private void OnGridKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (DataContext is not KeyboardGestureHandlingViewModel viewModel)
+            {
+                return;
+            }
+
+            var modifiers = e.KeyModifiers == KeyModifiers.None ? string.Empty : $" ({e.KeyModifiers})";
+            var handled = e.Handled ? " handled" : string.Empty;
+            viewModel.LastKey = $"{e.Key}{modifiers}{handled}";
+        }
+    }
+}

--- a/src/DataGridSample/ViewModels/GroupedSelectionViewModel.cs
+++ b/src/DataGridSample/ViewModels/GroupedSelectionViewModel.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using Avalonia.Collections;
+using Avalonia.Controls;
 using Avalonia.Controls.Selection;
+using Avalonia.Input;
 using DataGridSample.Models;
 using DataGridSample.Mvvm;
 
@@ -19,6 +21,9 @@ public class GroupedSelectionViewModel : ObservableObject
             SingleSelect = false,
             Source = GroupedView
         };
+
+        _useVimNavigation = false;
+        UpdateGestureOverrides();
     }
 
     public ObservableCollection<Country> Items { get; }
@@ -26,4 +31,42 @@ public class GroupedSelectionViewModel : ObservableObject
     public DataGridCollectionView GroupedView { get; }
 
     public SelectionModel<Country> SelectionModel { get; }
+
+    private bool _useVimNavigation;
+
+    public bool UseVimNavigation
+    {
+        get => _useVimNavigation;
+        set
+        {
+            if (SetProperty(ref _useVimNavigation, value))
+            {
+                UpdateGestureOverrides();
+            }
+        }
+    }
+
+    private DataGridKeyboardGestures? _keyboardGestureOverrides;
+
+    public DataGridKeyboardGestures? KeyboardGestureOverrides
+    {
+        get => _keyboardGestureOverrides;
+        set => SetProperty(ref _keyboardGestureOverrides, value);
+    }
+
+    private void UpdateGestureOverrides()
+    {
+        if (_useVimNavigation)
+        {
+            KeyboardGestureOverrides = new DataGridKeyboardGestures
+            {
+                MoveDown = new KeyGesture(Key.J),
+                MoveUp = new KeyGesture(Key.K)
+            };
+        }
+        else
+        {
+            KeyboardGestureOverrides = null;
+        }
+    }
 }

--- a/src/DataGridSample/ViewModels/HierarchicalSampleViewModel.cs
+++ b/src/DataGridSample/ViewModels/HierarchicalSampleViewModel.cs
@@ -8,8 +8,10 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Avalonia.Controls;
 using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.DataGridSorting;
+using Avalonia.Input;
 using DataGridSample.Mvvm;
 
 namespace DataGridSample.ViewModels
@@ -87,6 +89,9 @@ namespace DataGridSample.ViewModels
             {
                 Model.Refresh(Model.Root);
             });
+
+            _useVimNavigation = false;
+            UpdateGestureOverrides();
         }
 
         public HierarchicalModel<TreeItem> Model { get; }
@@ -100,6 +105,45 @@ namespace DataGridSample.ViewModels
         public RelayCommand CollapseAllCommand { get; }
 
         public RelayCommand RefreshRootCommand { get; }
+
+        private bool _useVimNavigation;
+
+        public bool UseVimNavigation
+        {
+            get => _useVimNavigation;
+            set
+            {
+                if (SetProperty(ref _useVimNavigation, value))
+                {
+                    UpdateGestureOverrides();
+                }
+            }
+        }
+
+        private DataGridKeyboardGestures? _keyboardGestureOverrides;
+
+        public DataGridKeyboardGestures? KeyboardGestureOverrides
+        {
+            get => _keyboardGestureOverrides;
+            set => SetProperty(ref _keyboardGestureOverrides, value);
+        }
+
+        private void UpdateGestureOverrides()
+        {
+            if (_useVimNavigation)
+            {
+                KeyboardGestureOverrides = new DataGridKeyboardGestures
+                {
+                    MoveDown = new KeyGesture(Key.J),
+                    MoveUp = new KeyGesture(Key.K),
+                    ExpandAll = new KeyGesture(Key.E)
+                };
+            }
+            else
+            {
+                KeyboardGestureOverrides = null;
+            }
+        }
 
         private TreeItem CreateRoot(string path)
         {

--- a/src/DataGridSample/ViewModels/KeyboardGestureHandlingViewModel.cs
+++ b/src/DataGridSample/ViewModels/KeyboardGestureHandlingViewModel.cs
@@ -1,0 +1,76 @@
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Input;
+using DataGridSample.Models;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class KeyboardGestureHandlingViewModel : ObservableObject
+    {
+        public KeyboardGestureHandlingViewModel()
+        {
+            People = new ObservableCollection<Person>
+            {
+                new Person { FirstName = "Ada", LastName = "Lovelace", Age = 36, IsBanned = false },
+                new Person { FirstName = "Alan", LastName = "Turing", Age = 41, IsBanned = false },
+                new Person { FirstName = "Grace", LastName = "Hopper", Age = 85, IsBanned = false },
+                new Person { FirstName = "Linus", LastName = "Torvalds", Age = 54, IsBanned = false },
+                new Person { FirstName = "Margaret", LastName = "Hamilton", Age = 86, IsBanned = false },
+                new Person { FirstName = "Tim", LastName = "Berners-Lee", Age = 68, IsBanned = false }
+            };
+
+            _lastKey = "None";
+            _useVimNavigation = false;
+            UpdateGestureOverrides();
+        }
+
+        public ObservableCollection<Person> People { get; }
+
+        private bool _useVimNavigation;
+
+        public bool UseVimNavigation
+        {
+            get => _useVimNavigation;
+            set
+            {
+                if (SetProperty(ref _useVimNavigation, value))
+                {
+                    UpdateGestureOverrides();
+                }
+            }
+        }
+
+        private DataGridKeyboardGestures? _keyboardGestureOverrides;
+
+        public DataGridKeyboardGestures? KeyboardGestureOverrides
+        {
+            get => _keyboardGestureOverrides;
+            set => SetProperty(ref _keyboardGestureOverrides, value);
+        }
+
+        private string _lastKey;
+
+        public string LastKey
+        {
+            get => _lastKey;
+            set => SetProperty(ref _lastKey, value);
+        }
+
+        private void UpdateGestureOverrides()
+        {
+            if (_useVimNavigation)
+            {
+                KeyboardGestureOverrides = new DataGridKeyboardGestures
+                {
+                    MoveDown = new KeyGesture(Key.J),
+                    MoveUp = new KeyGesture(Key.K)
+                };
+            }
+            else
+            {
+                KeyboardGestureOverrides = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Keyboard gesture override

## Summary
Built-in DataGrid keyboard handling is now driven by a `DataGridKeyboardGestures` mapping and always honors `e.Handled`, so consumers can remap or disable gestures without the old `DataGridKeyboardGestureHandling` hack.

## Goals
- Let user KeyDown handlers run first and override built-ins via `Handled`.
- Keep default navigation/editing behavior unchanged when not overridden.
- Provide a minimal, explicit API for gesture remapping.

## Non-goals
- Redefine gesture semantics (only remap).
- Add new KeyUp behaviors beyond the existing Tab adjustment.
- Change global input routing outside DataGrid.

## API
- `DataGridKeyboardGestures` (new public class)
  - Properties: `Tab`, `MoveUp`, `MoveDown`, `MoveLeft`, `MoveRight`, `MovePageUp`, `MovePageDown`,
    `MoveHome`, `MoveEnd`, `Enter`, `CancelEdit`, `BeginEdit`, `SelectAll`, `Copy`, `CopyAlternate`,
    `Delete`, `ExpandAll`.
  - `CreateDefault(KeyModifiers commandModifiers)` builds platform defaults.
- `DataGrid.KeyboardGestureOverrides` (styled property)
  - `null` uses defaults.
  - Each non-null property replaces the default for that action.
  - `KeyGesture` with `Key.None` disables that action.
- `DataGridKeyboardGestureHandling` is no longer used.

## Default gesture mapping
- Tab: `Tab`
- MoveUp: `Up`
- MoveDown: `Down`
- MoveLeft: `Left`
- MoveRight: `Right`
- MovePageUp: `PageUp`
- MovePageDown: `PageDown`
- MoveHome: `Home`
- MoveEnd: `End`
- Enter: `Enter`
- CancelEdit: `Escape`
- BeginEdit: `F2`
- SelectAll: `Cmd/Ctrl+A`
- Copy: `Cmd/Ctrl+C`
- CopyAlternate: `Cmd/Ctrl+Insert`
- Delete: `Delete`
- ExpandAll: `Multiply`

Defaults are created using `TopLevel.PlatformSettings.HotkeyConfiguration.CommandModifiers`, falling back to `Ctrl` when no top-level is available.

## Matching rules
- The mapping is resolved per event: `override ?? default`.
- `Key.None` never matches.
- Some gestures allow additional modifiers:
  - `Tab`, navigation (MoveUp/Down/Left/Right/Home/End/PageUp/PageDown), `Enter`, `CancelEdit`, `Delete`, `ExpandAll`.
  - Example: `Shift+Down` still matches the `Down` gesture.
- These require exact modifiers: `BeginEdit`, `SelectAll`, `Copy`, `CopyAlternate`.
- Compatibility: when `BeginEdit` is the default `F2` and no override is provided, `Alt+F2` still triggers edit.
- If multiple actions share a gesture, the first match in the built-in order wins:
  - Tab, MoveUp, MoveDown, MovePageDown, MovePageUp, MoveLeft, MoveRight, BeginEdit,
    BeginEdit (Alt+F2 fallback), MoveHome, MoveEnd, Enter, CancelEdit, SelectAll, Copy/CopyAlternate,
    Delete, ExpandAll.

## Keyboard event flow
- DataGrid subscribes to `InputElement.KeyDownEvent.RouteFinished` and `KeyUpEvent.RouteFinished` when attached.
- After routing completes:
  - If `e.Handled` is true, DataGrid does nothing.
  - Only bubble and direct routes are processed.
  - Only the nearest DataGrid ancestor of the event source handles the event.
- KeyDown: built-in processing runs after user handlers and sets `e.Handled` when it takes action.
- KeyUp: only the Tab adjustment runs, using the resolved Tab gesture and honoring `Handled`.

## Pointer handling
- Cell/row/row header/row group header pointer handlers exit early when `e.Handled` is true.
- This prevents built-in selection/focus changes after user pointer handling.

## Tests
- Headless tests cover:
  - `Handled` KeyDown blocking built-in navigation.
  - Overrides for each gesture (navigation, edit, selection, copy, delete, expand).
  - `Key.None` disabling a gesture.
  - Conflicting gestures resolved by first-match order.
  - Pointer handling respects `Handled` and does not change selection.

## Sample
- `KeyboardGestureHandlingPage` in DataGridSample:
  - Toggle "Use Vim navigation (J/K)" to set `KeyboardGestureOverrides`.
  - Displays the last key and whether it was handled via a `KeyDown` handler.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/125