### PR TITLE
Theme and styling updates

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
@@ -172,11 +172,35 @@ public class DataGridThemeResourceCoverageTests
     {
         AddResourceIfAvailable(resources, baseTheme, typeof(TextBox), variant);
         AddResourceIfAvailable(resources, baseTheme, typeof(ComboBox), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(AutoCompleteBox), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(MaskedTextBox), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(NumericUpDown), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(CalendarDatePicker), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(TimePicker), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(Slider), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(ToggleSwitch), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(ToggleButton), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(CheckBox), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(ProgressBar), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(Button), variant);
         AddResourceIfAvailable(resources, baseTheme, typeof(HyperlinkButton), variant);
+        AddResourceIfAvailable(resources, baseTheme, typeof(DataValidationErrors), variant);
 
         EnsureControlTheme(resources, typeof(TextBox));
         EnsureControlTheme(resources, typeof(ComboBox));
+        EnsureControlTheme(resources, typeof(AutoCompleteBox));
+        EnsureControlTheme(resources, typeof(MaskedTextBox));
+        EnsureControlTheme(resources, typeof(NumericUpDown));
+        EnsureControlTheme(resources, typeof(CalendarDatePicker));
+        EnsureControlTheme(resources, typeof(TimePicker));
+        EnsureControlTheme(resources, typeof(Slider));
+        EnsureControlTheme(resources, typeof(ToggleSwitch));
+        EnsureControlTheme(resources, typeof(ToggleButton));
+        EnsureControlTheme(resources, typeof(CheckBox));
+        EnsureControlTheme(resources, typeof(ProgressBar));
+        EnsureControlTheme(resources, typeof(Button));
         EnsureControlTheme(resources, typeof(HyperlinkButton));
+        EnsureControlTheme(resources, typeof(DataValidationErrors));
 
         if (includeHighlightBrush)
         {
@@ -336,10 +360,28 @@ public class DataGridThemeResourceCoverageTests
         new("DataGridFilterFlyoutPresenterTheme", typeof(FlyoutPresenter)),
         new("DataGridFilterButtonTheme", typeof(Button)),
         new("DataGridFilterButtonFilteredTheme", typeof(Button)),
+        new("DataGridCellDataValidationErrorsTheme", typeof(DataValidationErrors)),
         new("DataGridCellTextBlockTheme", typeof(TextBlock)),
         new("DataGridCellTextBoxTheme", typeof(TextBox)),
+        new("DataGridCellAutoCompleteTextBlockTheme", typeof(TextBlock)),
+        new("DataGridCellAutoCompleteBoxTheme", typeof(AutoCompleteBox)),
         new("DataGridCellComboBoxTheme", typeof(ComboBox)),
         new("DataGridCellComboBoxDisplayTheme", typeof(ComboBox)),
+        new("DataGridCellMaskedTextBlockTheme", typeof(TextBlock)),
+        new("DataGridCellMaskedTextBoxTheme", typeof(MaskedTextBox)),
+        new("DataGridCellNumericTextBlockTheme", typeof(TextBlock)),
+        new("DataGridCellNumericUpDownTheme", typeof(NumericUpDown)),
+        new("DataGridCellDateTextBlockTheme", typeof(TextBlock)),
+        new("DataGridCellDatePickerTheme", typeof(CalendarDatePicker)),
+        new("DataGridCellTimeTextBlockTheme", typeof(TextBlock)),
+        new("DataGridCellTimePickerTheme", typeof(TimePicker)),
+        new("DataGridCellSliderTheme", typeof(Slider)),
+        new("DataGridCellSliderDisplayTheme", typeof(Slider)),
+        new("DataGridCellToggleSwitchTheme", typeof(ToggleSwitch)),
+        new("DataGridCellToggleButtonTheme", typeof(ToggleButton)),
+        new("DataGridCellCheckBoxTheme", typeof(CheckBox)),
+        new("DataGridCellProgressBarTheme", typeof(ProgressBar)),
+        new("DataGridCellButtonTheme", typeof(Button)),
         new("DataGridCellHyperlinkButtonTheme", typeof(HyperlinkButton)),
         new("DataGridHierarchicalExpanderTheme", typeof(ToggleButton)),
         new(typeof(DataGridHierarchicalPresenter), typeof(DataGridHierarchicalPresenter)),
@@ -455,7 +497,8 @@ public class DataGridThemeResourceCoverageTests
 
     private static readonly string[] SimpleCornerRadiusKeys =
     {
-        "DataGridFilterFlyoutCornerRadius"
+        "DataGridFilterFlyoutCornerRadius",
+        "DataGridCellCornerRadius"
     };
 
     private static readonly string[] FluentThemeBrushKeys =
@@ -552,7 +595,8 @@ public class DataGridThemeResourceCoverageTests
 
     private static readonly string[] FluentCornerRadiusKeys =
     {
-        "DataGridFilterFlyoutCornerRadius"
+        "DataGridFilterFlyoutCornerRadius",
+        "DataGridCellCornerRadius"
     };
 }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -1,0 +1,646 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests;
+
+public class DataGridValidationTests
+{
+    [AvaloniaFact]
+    public void Invalid_edit_marks_grid_row_and_cell()
+    {
+        var (grid, root, item, column) = CreateTextValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var row = FindRow(grid, item);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = string.Empty;
+            Assert.False(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.False(grid.IsValid);
+            Assert.False(cell.IsValid);
+            Assert.False(row.IsValid);
+            Assert.True(((IPseudoClasses)cell.Classes).Contains(":invalid"));
+            Assert.True(((IPseudoClasses)row.Classes).Contains(":invalid"));
+            Assert.True(DataValidationErrors.GetHasErrors(textBox));
+
+            textBox.Text = "Valid";
+            Assert.True(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.True(grid.IsValid);
+            Assert.True(cell.IsValid);
+            Assert.True(row.IsValid);
+            Assert.False(((IPseudoClasses)cell.Classes).Contains(":invalid"));
+            Assert.False(((IPseudoClasses)row.Classes).Contains(":invalid"));
+            Assert.False(DataValidationErrors.GetHasErrors(textBox));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DataValidationErrors_theme_uses_grid_corner_radius()
+    {
+        var (grid, root, item, column) = CreateTextValidationGrid(DataGridTheme.Fluent);
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+            var validation = textBox.GetVisualDescendants().OfType<DataValidationErrors>().First();
+
+            Assert.True(grid.TryFindResource("DataGridCellDataValidationErrorsTheme", out var themeResource));
+            Assert.Same(themeResource, validation.Theme);
+
+            Assert.True(grid.TryFindResource("DataGridCellCornerRadius", out var cornerResource));
+            Assert.Equal((CornerRadius)cornerResource!, validation.CornerRadius);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Editable_columns_report_validation_errors()
+    {
+        var (grid, root, item) = CreateValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+
+            foreach (var column in grid.ColumnsInternal)
+            {
+                if (!ColumnValidationCases.TryGetValue(column.Header?.ToString() ?? string.Empty, out var testCase))
+                {
+                    continue;
+                }
+
+                Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+                grid.UpdateLayout();
+
+                Assert.True(grid.BeginEdit());
+                grid.UpdateLayout();
+
+                var cell = FindCell(grid, item, column.Index);
+                var editingElement = Assert.IsAssignableFrom<Control>(cell.Content);
+
+                testCase.SetValue(editingElement, false);
+
+                Assert.False(grid.CommitEdit());
+                grid.UpdateLayout();
+
+                Assert.False(cell.IsValid);
+                Assert.True(DataValidationErrors.GetHasErrors(editingElement));
+
+                testCase.SetValue(editingElement, true);
+
+                Assert.True(grid.CommitEdit());
+                grid.UpdateLayout();
+
+                Assert.True(cell.IsValid);
+                Assert.False(DataValidationErrors.GetHasErrors(editingElement));
+            }
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    private static readonly IReadOnlyList<string> Categories = new[] { "Hardware", "Software", "Services" };
+    private static readonly IReadOnlyList<string> Statuses = new[] { "Draft", "Active", "Closed" };
+
+    private static readonly Dictionary<string, ColumnValidationCase> ColumnValidationCases = new()
+    {
+        ["Name"] = new ColumnValidationCase((control, valid) =>
+        {
+            var textBox = (TextBox)control;
+            textBox.Text = valid ? "Gamma" : string.Empty;
+        }),
+        ["Category"] = new ColumnValidationCase((control, valid) =>
+        {
+            var autoComplete = (AutoCompleteBox)control;
+            autoComplete.Text = valid ? Categories[0] : "Invalid";
+        }),
+        ["Status"] = new ColumnValidationCase((control, valid) =>
+        {
+            var comboBox = (ComboBox)control;
+            comboBox.Text = valid ? Statuses[1] : "Bogus";
+        }),
+        ["Phone"] = new ColumnValidationCase((control, valid) =>
+        {
+            var masked = (MaskedTextBox)control;
+            masked.Text = valid ? "(555) 010-1000" : string.Empty;
+        }),
+        ["Price"] = new ColumnValidationCase((control, valid) =>
+        {
+            var numeric = (NumericUpDown)control;
+            numeric.Value = valid ? 25m : 12m;
+        }),
+        ["Due"] = new ColumnValidationCase((control, valid) =>
+        {
+            var picker = (CalendarDatePicker)control;
+            picker.SelectedDate = valid ? NextWeekday(DateTime.Today.AddDays(1)) : DateTime.Today.AddDays(-1);
+        }),
+        ["Start"] = new ColumnValidationCase((control, valid) =>
+        {
+            var picker = (TimePicker)control;
+            picker.SelectedTime = valid ? new TimeSpan(10, 0, 0) : new TimeSpan(7, 0, 0);
+        }),
+        ["Rating"] = new ColumnValidationCase((control, valid) =>
+        {
+            var slider = (Slider)control;
+            slider.Value = valid ? 3.0 : 0.5;
+        }),
+        ["Active"] = new ColumnValidationCase((control, valid) =>
+        {
+            var toggle = (ToggleSwitch)control;
+            toggle.IsChecked = valid;
+        }),
+        ["Pinned"] = new ColumnValidationCase((control, valid) =>
+        {
+            var toggle = (ToggleButton)control;
+            toggle.IsChecked = valid;
+        }),
+        ["Approved"] = new ColumnValidationCase((control, valid) =>
+        {
+            var checkBox = (CheckBox)control;
+            checkBox.IsChecked = valid;
+        }),
+        ["Website"] = new ColumnValidationCase((control, valid) =>
+        {
+            var textBox = (TextBox)control;
+            textBox.Text = valid ? "https://example.com" : "not-a-url";
+        })
+    };
+
+    private static (DataGrid grid, Window root, ValidationItem item, DataGridTextColumn column) CreateTextValidationGrid(DataGridTheme theme = DataGridTheme.Simple)
+    {
+        var item = new ValidationItem(Categories, Statuses)
+        {
+            Name = "Alpha",
+            Category = Categories[0],
+            Status = Statuses[0],
+            Phone = "(555) 010-1000",
+            Price = 25m,
+            DueDate = NextWeekday(DateTime.Today.AddDays(1)),
+            StartTime = new TimeSpan(10, 0, 0),
+            Rating = 3.0,
+            IsActive = true,
+            IsPinned = true,
+            IsApproved = true,
+            Website = "https://example.com"
+        };
+
+        var items = new ObservableCollection<ValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 800,
+            Height = 400
+        };
+
+        root.SetThemeStyles(theme);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var nameColumn = new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(ValidationItem.Name))
+        };
+
+        grid.ColumnsInternal.Add(nameColumn);
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        return (grid, root, item, nameColumn);
+    }
+
+    private static (DataGrid grid, Window root, ValidationItem item) CreateValidationGrid()
+    {
+        var item = new ValidationItem(Categories, Statuses)
+        {
+            Name = "Alpha",
+            Category = Categories[0],
+            Status = Statuses[1],
+            Phone = "(555) 010-1000",
+            Price = 25m,
+            DueDate = NextWeekday(DateTime.Today.AddDays(1)),
+            StartTime = new TimeSpan(10, 0, 0),
+            Rating = 3.0,
+            IsActive = true,
+            IsPinned = true,
+            IsApproved = true,
+            Website = "https://example.com"
+        };
+
+        var items = new ObservableCollection<ValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 1200,
+            Height = 400
+        };
+
+        root.SetThemeStyles(DataGridTheme.Fluent);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(ValidationItem.Name))
+        });
+
+        grid.ColumnsInternal.Add(new DataGridAutoCompleteColumn
+        {
+            Header = "Category",
+            Binding = new Binding(nameof(ValidationItem.Category)),
+            ItemsSource = Categories,
+            FilterMode = AutoCompleteFilterMode.Contains,
+            MinimumPrefixLength = 1
+        });
+
+        grid.ColumnsInternal.Add(new DataGridComboBoxColumn
+        {
+            Header = "Status",
+            ItemsSource = Statuses,
+            IsEditable = true,
+            TextBinding = new Binding(nameof(ValidationItem.Status))
+        });
+
+        grid.ColumnsInternal.Add(new DataGridMaskedTextColumn
+        {
+            Header = "Phone",
+            Binding = new Binding(nameof(ValidationItem.Phone)),
+            Mask = "(000) 000-0000"
+        });
+
+        grid.ColumnsInternal.Add(new DataGridNumericColumn
+        {
+            Header = "Price",
+            Binding = new Binding(nameof(ValidationItem.Price)),
+            Minimum = 0,
+            Maximum = 500,
+            Increment = 1
+        });
+
+        grid.ColumnsInternal.Add(new DataGridDatePickerColumn
+        {
+            Header = "Due",
+            Binding = new Binding(nameof(ValidationItem.DueDate)),
+            SelectedDateFormat = CalendarDatePickerFormat.Short
+        });
+
+        grid.ColumnsInternal.Add(new DataGridTimePickerColumn
+        {
+            Header = "Start",
+            Binding = new Binding(nameof(ValidationItem.StartTime)),
+            ClockIdentifier = "24HourClock"
+        });
+
+        grid.ColumnsInternal.Add(new DataGridSliderColumn
+        {
+            Header = "Rating",
+            Binding = new Binding(nameof(ValidationItem.Rating)),
+            Minimum = 0,
+            Maximum = 5,
+            TickFrequency = 0.5,
+            IsSnapToTickEnabled = true
+        });
+
+        grid.ColumnsInternal.Add(new DataGridToggleSwitchColumn
+        {
+            Header = "Active",
+            Binding = new Binding(nameof(ValidationItem.IsActive))
+        });
+
+        grid.ColumnsInternal.Add(new DataGridToggleButtonColumn
+        {
+            Header = "Pinned",
+            Binding = new Binding(nameof(ValidationItem.IsPinned))
+        });
+
+        grid.ColumnsInternal.Add(new DataGridCheckBoxColumn
+        {
+            Header = "Approved",
+            Binding = new Binding(nameof(ValidationItem.IsApproved))
+        });
+
+        grid.ColumnsInternal.Add(new DataGridHyperlinkColumn
+        {
+            Header = "Website",
+            Binding = new Binding(nameof(ValidationItem.Website)),
+            ContentBinding = new Binding(nameof(ValidationItem.Website))
+        });
+
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        return (grid, root, item);
+    }
+
+    private static DataGridCell FindCell(DataGrid grid, ValidationItem item, int columnIndex)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridCell>()
+            .First(cell => cell.OwningColumn?.Index == columnIndex && ReferenceEquals(cell.DataContext, item));
+    }
+
+    private static DataGridRow FindRow(DataGrid grid, ValidationItem item)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .First(row => ReferenceEquals(row.DataContext, item));
+    }
+
+    private static DateTime NextWeekday(DateTime date)
+    {
+        while (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
+        {
+            date = date.AddDays(1);
+        }
+
+        return date;
+    }
+
+    private sealed record ColumnValidationCase(Action<Control, bool> SetValue);
+
+    private sealed class ValidationItem : INotifyPropertyChanged
+    {
+        private readonly HashSet<string> _categories;
+        private readonly HashSet<string> _statuses;
+        private string _name = string.Empty;
+        private string? _category;
+        private string? _status;
+        private string? _phone;
+        private decimal _price;
+        private DateTime? _dueDate;
+        private TimeSpan? _startTime;
+        private double _rating;
+        private bool _isActive;
+        private bool _isPinned;
+        private bool _isApproved;
+        private string? _website;
+
+        public ValidationItem(IEnumerable<string> categories, IEnumerable<string> statuses)
+        {
+            _categories = new HashSet<string>(categories);
+            _statuses = new HashSet<string>(statuses);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                RequireText(value, "Name is required.");
+                SetProperty(ref _name, value);
+            }
+        }
+
+        public string? Category
+        {
+            get => _category;
+            set
+            {
+                RequireChoice(value, _categories, "Category must match the suggestions list.");
+                SetProperty(ref _category, value);
+            }
+        }
+
+        public string? Status
+        {
+            get => _status;
+            set
+            {
+                RequireChoice(value, _statuses, "Status must be one of the defined options.");
+                SetProperty(ref _status, value);
+            }
+        }
+
+        public string? Phone
+        {
+            get => _phone;
+            set
+            {
+                RequireText(value, "Phone is required.");
+                if (value!.Count(char.IsDigit) != 10)
+                {
+                    throw new DataValidationException("Phone must include 10 digits.");
+                }
+
+                SetProperty(ref _phone, value);
+            }
+        }
+
+        public decimal Price
+        {
+            get => _price;
+            set
+            {
+                if (value < 10m || value % 5m != 0)
+                {
+                    throw new DataValidationException("Price must be at least 10 and in increments of 5.");
+                }
+
+                SetProperty(ref _price, value);
+            }
+        }
+
+        public DateTime? DueDate
+        {
+            get => _dueDate;
+            set
+            {
+                RequireValue(value, "Due date is required.");
+                var date = value!.Value.Date;
+                if (date < DateTime.Today)
+                {
+                    throw new DataValidationException("Due date must be today or later.");
+                }
+
+                if (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
+                {
+                    throw new DataValidationException("Due date cannot fall on a weekend.");
+                }
+
+                SetProperty(ref _dueDate, value);
+            }
+        }
+
+        public TimeSpan? StartTime
+        {
+            get => _startTime;
+            set
+            {
+                RequireValue(value, "Start time is required.");
+                var time = value!.Value;
+                if (time < new TimeSpan(9, 0, 0) || time > new TimeSpan(17, 0, 0))
+                {
+                    throw new DataValidationException("Start time must be between 09:00 and 17:00.");
+                }
+
+                SetProperty(ref _startTime, value);
+            }
+        }
+
+        public double Rating
+        {
+            get => _rating;
+            set
+            {
+                if (value < 1.0 || value > 4.5)
+                {
+                    throw new DataValidationException("Rating must be between 1.0 and 4.5.");
+                }
+
+                SetProperty(ref _rating, value);
+            }
+        }
+
+        public bool IsActive
+        {
+            get => _isActive;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Active must stay enabled.");
+                }
+
+                SetProperty(ref _isActive, value);
+            }
+        }
+
+        public bool IsPinned
+        {
+            get => _isPinned;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Pinned must stay enabled.");
+                }
+
+                SetProperty(ref _isPinned, value);
+            }
+        }
+
+        public bool IsApproved
+        {
+            get => _isApproved;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Approval is required.");
+                }
+
+                SetProperty(ref _isApproved, value);
+            }
+        }
+
+        public string? Website
+        {
+            get => _website;
+            set
+            {
+                RequireText(value, "Website is required.");
+                if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                {
+                    throw new DataValidationException("Website must be a valid http/https URL.");
+                }
+
+                SetProperty(ref _website, value);
+            }
+        }
+
+        private static void RequireValue<T>(T? value, string message) where T : struct
+        {
+            if (!value.HasValue)
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private static void RequireText(string? value, string message)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private static void RequireChoice(string? value, HashSet<string> allowed, string message)
+        {
+            if (string.IsNullOrWhiteSpace(value) || !allowed.Contains(value))
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -396,6 +396,11 @@ namespace Avalonia.Controls
                     }
                     else
                     {
+                        if (IsValid)
+                        {
+                            IsValid = false;
+                        }
+
                         if (editingRow != null)
                         {
                             if (editingCell.IsValid)

--- a/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
@@ -77,12 +77,27 @@ namespace Avalonia.Controls
             ItemsControl.ItemTemplateProperty.AddOwner<DataGridComboBoxColumn>();
 
         /// <summary>
+        /// Defines the <see cref="ComboBox.IsEditable"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> IsEditableProperty =
+            ComboBox.IsEditableProperty.AddOwner<DataGridComboBoxColumn>();
+
+        /// <summary>
         /// Gets or sets the template used to display each item in the combo box.
         /// </summary>
         public IDataTemplate ItemTemplate
         {
             get => GetValue(ItemTemplateProperty);
             set => SetValue(ItemTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the generated combo box allows free-form text entry.
+        /// </summary>
+        public bool IsEditable
+        {
+            get => GetValue(IsEditableProperty);
+            set => SetValue(IsEditableProperty, value);
         }
 
         /// <summary>
@@ -408,6 +423,7 @@ namespace Avalonia.Controls
 
             if (change.Property == ItemsSourceProperty ||
                 change.Property == ItemTemplateProperty ||
+                change.Property == IsEditableProperty ||
                 change.Property == HorizontalContentAlignmentProperty ||
                 change.Property == VerticalContentAlignmentProperty ||
                 change.Property == DisplayMemberPathProperty ||
@@ -439,6 +455,7 @@ namespace Avalonia.Controls
         {
             DataGridHelper.SyncColumnProperty(this, comboBox, ItemsSourceProperty);
             DataGridHelper.SyncColumnProperty(this, comboBox, ItemTemplateProperty);
+            DataGridHelper.SyncColumnProperty(this, comboBox, IsEditableProperty);
             DataGridHelper.SyncColumnProperty(this, comboBox, HorizontalContentAlignmentProperty);
             DataGridHelper.SyncColumnProperty(this, comboBox, VerticalContentAlignmentProperty);
             comboBox.DisplayMemberBinding = CreateDisplayMemberBinding();

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -135,7 +135,7 @@
       <SolidColorBrush x:Key="DataGridBorderBrush" Color="Transparent" />
       <SolidColorBrush x:Key="DataGridDropLocationIndicatorBackground" Color="{DynamicResource SystemAccentColor}" />
       <StaticResource x:Key="DataGridDropLocationIndicatorBrush" ResourceKey="DataGridDropLocationIndicatorBackground" />
-      <StaticResource x:Key="DataGridCellDataValidationErrorsTheme" ResourceKey="TooltipDataValidationErrors" />
+
     </ResourceDictionary>
   </Styles.Resources>
 </Styles>

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -14,6 +14,9 @@
       <StreamGeometry x:Key="DataGridRowGroupHeaderIconOpenedPath">M10 4.895 L10 4.895 M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z M10 16.595 L10 16.595</StreamGeometry>
       <StreamGeometry x:Key="DataGridDragGripIconPath">M4 3 a1 1 0 1 1 0.001 0 M8 3 a1 1 0 1 1 0.001 0 M4 7 a1 1 0 1 1 0.001 0 M8 7 a1 1 0 1 1 0.001 0 M4 11 a1 1 0 1 1 0.001 0 M8 11 a1 1 0 1 1 0.001 0</StreamGeometry>
 
+      <!-- Cell corner radius -->
+      <CornerRadius x:Key="DataGridCellCornerRadius">0</CornerRadius>
+
       <!-- Flyout presenter theme for filter popups -->
       <ControlTheme x:Key="DataGridFilterFlyoutPresenterTheme" TargetType="FlyoutPresenter">
         <Setter Property="Padding" Value="{DynamicResource DataGridFilterFlyoutPadding}" />
@@ -141,6 +144,57 @@
         </Style>
       </ControlTheme>
 
+      <!-- DataGridCellDataValidationErrorsTheme -->
+      <ControlTheme x:Key="DataGridCellDataValidationErrorsTheme"
+                    TargetType="DataValidationErrors">
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Setter Property="Template">
+          <ControlTemplate TargetType="DataValidationErrors">
+            <DockPanel LastChildFill="True">
+              <ContentControl Content="{Binding (DataValidationErrors.Errors)}"
+                              ContentTemplate="{TemplateBinding ErrorTemplate}"
+                              DataContext="{TemplateBinding Owner}"
+                              DockPanel.Dock="Right"
+                              IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                CornerRadius="{TemplateBinding CornerRadius}" />
+            </DockPanel>
+          </ControlTemplate>
+        </Setter>
+        <Setter Property="ErrorTemplate">
+          <DataTemplate>
+            <Panel Name="PART_InlineErrorTemplatePanel"
+                   Background="Transparent">
+              <Panel.Styles>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel">
+                  <Setter Property="Margin" Value="8,0" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip">
+                  <Setter Property="BorderBrush" Value="{DynamicResource DataGridCellInvalidBrush}" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip TextBlock">
+                  <Setter Property="TextWrapping" Value="Wrap" />
+                </Style>
+              </Panel.Styles>
+              <ToolTip.Tip>
+                <ItemsControl ItemsSource="{Binding}" />
+              </ToolTip.Tip>
+              <Path Width="14"
+                    Height="14"
+                    Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2"
+                    Stroke="{DynamicResource DataGridCellInvalidBrush}"
+                    StrokeThickness="2" />
+            </Panel>
+          </DataTemplate>
+        </Setter>
+      </ControlTheme>
+
       <!-- DataGridCellTextBlockTheme -->
       <ControlTheme x:Key="DataGridCellTextBlockTheme" TargetType="TextBlock">
         <Setter Property="Margin" Value="{DynamicResource DataGridCellTextBlockMargin}" />
@@ -153,8 +207,25 @@
                     BasedOn="{StaticResource {x:Type TextBox}}">
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
         <Style Selector="^ /template/ DataValidationErrors">
           <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellAutoCompleteTextBlockTheme -->
+      <ControlTheme x:Key="DataGridCellAutoCompleteTextBlockTheme"
+                    TargetType="TextBlock"
+                    BasedOn="{StaticResource DataGridCellTextBlockTheme}" />
+
+      <!-- DataGridCellAutoCompleteBoxTheme -->
+      <ControlTheme x:Key="DataGridCellAutoCompleteBoxTheme"
+                    TargetType="AutoCompleteBox"
+                    BasedOn="{StaticResource {x:Type AutoCompleteBox}}">
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ TextBox#PART_TextBox">
+          <Setter Property="Theme" Value="{StaticResource DataGridCellTextBoxTheme}" />
         </Style>
       </ControlTheme>
 
@@ -167,6 +238,10 @@
         <Setter Property="Padding" Value="{DynamicResource DataGridCellComboBoxPadding}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
       </ControlTheme>
 
       <!-- DataGridCellComboBoxDisplayTheme -->
@@ -178,8 +253,139 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="IsHitTestVisible" Value="False" />
+      </ControlTheme>
+
+      <!-- DataGridCellMaskedTextBlockTheme -->
+      <ControlTheme x:Key="DataGridCellMaskedTextBlockTheme"
+                    TargetType="TextBlock"
+                    BasedOn="{StaticResource DataGridCellTextBlockTheme}" />
+
+      <!-- DataGridCellMaskedTextBoxTheme -->
+      <ControlTheme x:Key="DataGridCellMaskedTextBoxTheme"
+                    TargetType="MaskedTextBox"
+                    BasedOn="{StaticResource {x:Type MaskedTextBox}}">
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellNumericTextBlockTheme -->
+      <ControlTheme x:Key="DataGridCellNumericTextBlockTheme"
+                    TargetType="TextBlock"
+                    BasedOn="{StaticResource DataGridCellTextBlockTheme}" />
+
+      <!-- DataGridCellNumericUpDownTheme -->
+      <ControlTheme x:Key="DataGridCellNumericUpDownTheme"
+                    TargetType="NumericUpDown"
+                    BasedOn="{StaticResource {x:Type NumericUpDown}}">
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellDateTextBlockTheme -->
+      <ControlTheme x:Key="DataGridCellDateTextBlockTheme"
+                    TargetType="TextBlock"
+                    BasedOn="{StaticResource DataGridCellTextBlockTheme}" />
+
+      <!-- DataGridCellDatePickerTheme -->
+      <ControlTheme x:Key="DataGridCellDatePickerTheme"
+                    TargetType="CalendarDatePicker"
+                    BasedOn="{StaticResource {x:Type CalendarDatePicker}}">
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellTimeTextBlockTheme -->
+      <ControlTheme x:Key="DataGridCellTimeTextBlockTheme"
+                    TargetType="TextBlock"
+                    BasedOn="{StaticResource DataGridCellTextBlockTheme}" />
+
+      <!-- DataGridCellTimePickerTheme -->
+      <ControlTheme x:Key="DataGridCellTimePickerTheme"
+                    TargetType="TimePicker"
+                    BasedOn="{StaticResource {x:Type TimePicker}}">
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellSliderTheme -->
+      <ControlTheme x:Key="DataGridCellSliderTheme"
+                    TargetType="Slider"
+                    BasedOn="{StaticResource {x:Type Slider}}">
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Style Selector="^ /template/ DataValidationErrors">
+          <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+        </Style>
+      </ControlTheme>
+
+      <!-- DataGridCellSliderDisplayTheme -->
+      <ControlTheme x:Key="DataGridCellSliderDisplayTheme"
+                    TargetType="Slider"
+                    BasedOn="{StaticResource {x:Type Slider}}">
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+      </ControlTheme>
+
+      <!-- DataGridCellToggleSwitchTheme -->
+      <ControlTheme x:Key="DataGridCellToggleSwitchTheme"
+                    TargetType="ToggleSwitch"
+                    BasedOn="{StaticResource {x:Type ToggleSwitch}}">
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+      </ControlTheme>
+
+      <!-- DataGridCellToggleButtonTheme -->
+      <ControlTheme x:Key="DataGridCellToggleButtonTheme"
+                    TargetType="ToggleButton"
+                    BasedOn="{StaticResource {x:Type ToggleButton}}">
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+      </ControlTheme>
+
+      <!-- DataGridCellCheckBoxTheme -->
+      <ControlTheme x:Key="DataGridCellCheckBoxTheme"
+                    TargetType="CheckBox"
+                    BasedOn="{StaticResource {x:Type CheckBox}}">
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+      </ControlTheme>
+
+      <!-- DataGridCellProgressBarTheme -->
+      <ControlTheme x:Key="DataGridCellProgressBarTheme"
+                    TargetType="ProgressBar"
+                    BasedOn="{StaticResource {x:Type ProgressBar}}">
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+      </ControlTheme>
+
+      <!-- DataGridCellButtonTheme -->
+      <ControlTheme x:Key="DataGridCellButtonTheme"
+                    TargetType="Button"
+                    BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
       </ControlTheme>
 
       <!-- DataGridCellHyperlinkButtonTheme -->
@@ -956,6 +1162,10 @@
       </ControlTheme>
     </ResourceDictionary>
   </Styles.Resources>
+
+  <Style Selector="DataGridCell DataValidationErrors">
+    <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+  </Style>
 
   <!-- Drag and Drop Styles -->
   <Style Selector="DataGrid:row-drag-enabled:row-drag-handle-visible DataGridRowHeader">

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -137,6 +137,9 @@
     <TabItem Header="Column Types">
       <pages:ColumnTypesPage />
     </TabItem>
+    <TabItem Header="Validation">
+      <pages:ValidationColumnsPage />
+    </TabItem>
     <TabItem Header="DataTable">
       <local:DataTablePage />
     </TabItem>

--- a/src/DataGridSample/Pages/ValidationColumnsPage.axaml
+++ b/src/DataGridSample/Pages/ValidationColumnsPage.axaml
@@ -1,0 +1,143 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.ValidationColumnsPage"
+             x:Name="Root"
+             x:DataType="viewModels:ValidationColumnsViewModel">
+  <UserControl.DataContext>
+    <viewModels:ValidationColumnsViewModel />
+  </UserControl.DataContext>
+
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="12" Margin="12">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2">Validation</TextBlock>
+      <TextBlock Text="Every editable column type below is wired for data validation. Try clearing required fields, typing unknown options, or picking out-of-policy values to see inline errors and cell/row invalid states."
+                 TextWrapping="Wrap" />
+      <TextBlock Text="Tips: set Price to 12, pick a weekend date, move Rating below 1.0, or toggle any required switch off."
+                 TextWrapping="Wrap" Foreground="Gray" FontStyle="Italic" />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1"
+                Orientation="Horizontal"
+                Spacing="8">
+      <TextBlock Text="Fix uses the button column to reset a row to valid defaults. Image and Progress columns are read-only." />
+    </StackPanel>
+
+    <DataGrid Grid.Row="2"
+              ItemsSource="{Binding Items}"
+              AutoGenerateColumns="False"
+              IsReadOnly="False"
+              CanUserAddRows="False"
+              CanUserDeleteRows="False"
+              HeadersVisibility="All"
+              GridLinesVisibility="All"
+              RowHeight="40">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Name"
+                            Binding="{Binding Name}"
+                            Width="140"
+                            x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridAutoCompleteColumn Header="Category"
+                                    Binding="{Binding Category}"
+                                    ItemsSource="{Binding #Root.((viewModels:ValidationColumnsViewModel)DataContext).Categories}"
+                                    FilterMode="Contains"
+                                    MinimumPrefixLength="1"
+                                    Watermark="Pick..."
+                                    Width="140"
+                                    x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridComboBoxColumn Header="Status"
+                                ItemsSource="{Binding #Root.((viewModels:ValidationColumnsViewModel)DataContext).Statuses}"
+                                IsEditable="True"
+                                TextBinding="{Binding Status}"
+                                Width="120"
+                                x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridMaskedTextColumn Header="Phone"
+                                  Binding="{Binding Phone}"
+                                  Mask="(000) 000-0000"
+                                  Width="140"
+                                  x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridNumericColumn Header="Price"
+                               Binding="{Binding Price}"
+                               FormatString="C2"
+                               Minimum="0"
+                               Maximum="500"
+                               Increment="1"
+                               Width="110"
+                               x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridDatePickerColumn Header="Due"
+                                  Binding="{Binding DueDate}"
+                                  SelectedDateFormat="Short"
+                                  Width="120"
+                                  x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridTimePickerColumn Header="Start"
+                                  Binding="{Binding StartTime}"
+                                  ClockIdentifier="24HourClock"
+                                  MinuteIncrement="15"
+                                  Width="100"
+                                  x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridSliderColumn Header="Rating"
+                              Binding="{Binding Rating}"
+                              Minimum="0"
+                              Maximum="5"
+                              TickFrequency="0.5"
+                              IsSnapToTickEnabled="True"
+                              Width="140"
+                              x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridToggleSwitchColumn Header="Active"
+                                    Binding="{Binding IsActive}"
+                                    OnContent="Yes"
+                                    OffContent="No"
+                                    Width="90"
+                                    x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridToggleButtonColumn Header="Pinned"
+                                    Binding="{Binding IsPinned}"
+                                    Content="Pin"
+                                    Width="80"
+                                    x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridCheckBoxColumn Header="Approved"
+                                Binding="{Binding IsApproved}"
+                                Width="90"
+                                x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridHyperlinkColumn Header="Website"
+                                 Binding="{Binding Website}"
+                                 ContentBinding="{Binding Website}"
+                                 Width="180"
+                                 x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridImageColumn Header="Icon"
+                             Binding="{Binding Thumbnail}"
+                             ImageWidth="24"
+                             ImageHeight="24"
+                             Width="70"
+                             x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridProgressBarColumn Header="Progress"
+                                   Binding="{Binding Progress}"
+                                   Minimum="0"
+                                   Maximum="100"
+                                   ShowProgressText="True"
+                                   ProgressTextFormat="{}{0:0}%"
+                                   Width="120"
+                                   x:DataType="viewModels:ValidationSampleItem" />
+
+        <DataGridButtonColumn Header="Fix"
+                              Content="Fix"
+                              Command="{Binding #Root.((viewModels:ValidationColumnsViewModel)DataContext).FixRowCommand}"
+                              CommandParameter="{Binding}"
+                              Width="70"
+                              x:DataType="viewModels:ValidationSampleItem" />
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/ValidationColumnsPage.axaml.cs
+++ b/src/DataGridSample/Pages/ValidationColumnsPage.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DataGridSample.Pages
+{
+    public partial class ValidationColumnsPage : UserControl
+    {
+        public ValidationColumnsPage()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/DataGridSample/Program.cs
+++ b/src/DataGridSample/Program.cs
@@ -35,6 +35,7 @@ public static class Program
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(FilteringModelSampleViewModel.Order))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(RoutedEventsViewModel.SampleItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(RoutedEventsViewModel.HierarchicalItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(ValidationSampleItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalRowDragDropViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSampleViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSelectionViewModel.TreeItem))]

--- a/src/DataGridSample/ViewModels/ValidationColumnsViewModel.cs
+++ b/src/DataGridSample/ViewModels/ValidationColumnsViewModel.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Data;
+using Avalonia.Media;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class ValidationColumnsViewModel : ObservableObject
+    {
+        private static readonly string[] DefaultCategories =
+        {
+            "Hardware",
+            "Software",
+            "Services",
+            "Support",
+            "Other"
+        };
+
+        private static readonly string[] DefaultStatuses =
+        {
+            "Draft",
+            "Active",
+            "On Hold",
+            "Closed"
+        };
+
+        public ValidationColumnsViewModel()
+        {
+            Categories = new ReadOnlyCollection<string>(DefaultCategories);
+            Statuses = new ReadOnlyCollection<string>(DefaultStatuses);
+
+            Items = new ObservableCollection<ValidationSampleItem>
+            {
+                new ValidationSampleItem(Categories, Statuses)
+                {
+                    Name = "Alpha",
+                    Category = "Hardware",
+                    Status = "Active",
+                    Phone = "(555) 010-1001",
+                    Price = 25m,
+                    DueDate = NextWeekday(DateTime.Today.AddDays(2)),
+                    StartTime = new TimeSpan(9, 0, 0),
+                    Rating = 3.5,
+                    IsActive = true,
+                    IsPinned = true,
+                    IsApproved = true,
+                    Website = "https://example.com",
+                    Progress = 65
+                },
+                new ValidationSampleItem(Categories, Statuses)
+                {
+                    Name = "Beta",
+                    Category = "Software",
+                    Status = "Draft",
+                    Phone = "(555) 010-1002",
+                    Price = 30m,
+                    DueDate = NextWeekday(DateTime.Today.AddDays(5)),
+                    StartTime = new TimeSpan(10, 0, 0),
+                    Rating = 2.5,
+                    IsActive = true,
+                    IsPinned = true,
+                    IsApproved = true,
+                    Website = "https://avaloniaui.net",
+                    Progress = 40
+                }
+            };
+
+            FixRowCommand = new RelayCommand(FixRow, CanFixRow);
+        }
+
+        public ObservableCollection<ValidationSampleItem> Items { get; }
+
+        public IReadOnlyList<string> Categories { get; }
+
+        public IReadOnlyList<string> Statuses { get; }
+
+        public RelayCommand FixRowCommand { get; }
+
+        private static bool CanFixRow(object? parameter)
+        {
+            return parameter is ValidationSampleItem;
+        }
+
+        private void FixRow(object? parameter)
+        {
+            if (parameter is ValidationSampleItem item)
+            {
+                item.ResetToDefaults();
+            }
+        }
+
+        private static DateTime NextWeekday(DateTime date)
+        {
+            while (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
+            {
+                date = date.AddDays(1);
+            }
+
+            return date;
+        }
+    }
+
+    public class ValidationSampleItem : ObservableObject
+    {
+        private readonly HashSet<string> _categories;
+        private readonly HashSet<string> _statuses;
+        private string _name = string.Empty;
+        private string? _category;
+        private string? _status;
+        private string? _phone;
+        private decimal _price;
+        private DateTime? _dueDate;
+        private TimeSpan? _startTime;
+        private double _rating;
+        private bool _isActive;
+        private bool _isPinned;
+        private bool _isApproved;
+        private string? _website;
+        private double _progress;
+        private IImage? _thumbnail;
+
+        public ValidationSampleItem(IReadOnlyCollection<string> categories, IReadOnlyCollection<string> statuses)
+        {
+            _categories = new HashSet<string>(categories);
+            _statuses = new HashSet<string>(statuses);
+        }
+
+        public void ResetToDefaults()
+        {
+            Name = "Item";
+            Category = _categories.FirstOrDefault() ?? "Hardware";
+            Status = _statuses.FirstOrDefault() ?? "Draft";
+            Phone = "(555) 010-0000";
+            Price = 25m;
+            DueDate = NextWeekday(DateTime.Today.AddDays(1));
+            StartTime = new TimeSpan(9, 0, 0);
+            Rating = 3.0;
+            IsActive = true;
+            IsPinned = true;
+            IsApproved = true;
+            Website = "https://example.com";
+            Progress = 50;
+            Thumbnail = null;
+        }
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                RequireText(value, "Name is required.");
+                SetProperty(ref _name, value);
+            }
+        }
+
+        public string? Category
+        {
+            get => _category;
+            set
+            {
+                RequireChoice(value, _categories, "Category must match the suggestions list.");
+                SetProperty(ref _category, value);
+            }
+        }
+
+        public string? Status
+        {
+            get => _status;
+            set
+            {
+                RequireChoice(value, _statuses, "Status must be one of the defined options.");
+                SetProperty(ref _status, value);
+            }
+        }
+
+        public string? Phone
+        {
+            get => _phone;
+            set
+            {
+                RequireText(value, "Phone is required.");
+                if (value!.Count(char.IsDigit) != 10)
+                {
+                    throw new DataValidationException("Phone must include 10 digits.");
+                }
+
+                SetProperty(ref _phone, value);
+            }
+        }
+
+        public decimal Price
+        {
+            get => _price;
+            set
+            {
+                if (value < 10m || value % 5m != 0)
+                {
+                    throw new DataValidationException("Price must be at least 10 and in increments of 5.");
+                }
+
+                SetProperty(ref _price, value);
+            }
+        }
+
+        public DateTime? DueDate
+        {
+            get => _dueDate;
+            set
+            {
+                RequireValue(value, "Due date is required.");
+                var date = value!.Value.Date;
+                if (date < DateTime.Today)
+                {
+                    throw new DataValidationException("Due date must be today or later.");
+                }
+
+                if (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
+                {
+                    throw new DataValidationException("Due date cannot fall on a weekend.");
+                }
+
+                SetProperty(ref _dueDate, value);
+            }
+        }
+
+        public TimeSpan? StartTime
+        {
+            get => _startTime;
+            set
+            {
+                RequireValue(value, "Start time is required.");
+                var time = value!.Value;
+                if (time < new TimeSpan(9, 0, 0) || time > new TimeSpan(17, 0, 0))
+                {
+                    throw new DataValidationException("Start time must be between 09:00 and 17:00.");
+                }
+
+                SetProperty(ref _startTime, value);
+            }
+        }
+
+        public double Rating
+        {
+            get => _rating;
+            set
+            {
+                if (value < 1.0 || value > 4.5)
+                {
+                    throw new DataValidationException("Rating must be between 1.0 and 4.5.");
+                }
+
+                SetProperty(ref _rating, value);
+            }
+        }
+
+        public bool IsActive
+        {
+            get => _isActive;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Active must stay enabled.");
+                }
+
+                SetProperty(ref _isActive, value);
+            }
+        }
+
+        public bool IsPinned
+        {
+            get => _isPinned;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Pinned must stay enabled.");
+                }
+
+                SetProperty(ref _isPinned, value);
+            }
+        }
+
+        public bool IsApproved
+        {
+            get => _isApproved;
+            set
+            {
+                if (!value)
+                {
+                    throw new DataValidationException("Approval is required.");
+                }
+
+                SetProperty(ref _isApproved, value);
+            }
+        }
+
+        public string? Website
+        {
+            get => _website;
+            set
+            {
+                RequireText(value, "Website is required.");
+                if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                {
+                    throw new DataValidationException("Website must be a valid http/https URL.");
+                }
+
+                SetProperty(ref _website, value);
+            }
+        }
+
+        public double Progress
+        {
+            get => _progress;
+            set => SetProperty(ref _progress, value);
+        }
+
+        public IImage? Thumbnail
+        {
+            get => _thumbnail;
+            set => SetProperty(ref _thumbnail, value);
+        }
+
+        private static void RequireValue<T>(T? value, string message) where T : struct
+        {
+            if (!value.HasValue)
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private static void RequireText(string? value, string message)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private static void RequireChoice(string? value, HashSet<string> allowed, string message)
+        {
+            if (string.IsNullOrWhiteSpace(value) || !allowed.Contains(value))
+            {
+                throw new DataValidationException(message);
+            }
+        }
+
+        private static DateTime NextWeekday(DateTime date)
+        {
+            while (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
+            {
+                date = date.AddDays(1);
+            }
+
+            return date;
+        }
+    }
+}


### PR DESCRIPTION
# Validation and theming changes summary

## Overview
This document summarizes the validation, theming, sample, and test changes added to the DataGrid.

## Validation behavior
- The DataGrid now sets `IsValid = false` when validation fails, so the grid, row, and cell reflect invalid states consistently.
- Validation state is verified across editable cell types and clears correctly after committing valid values.

## Theme and styling updates
- Added `DataGridCellCornerRadius` resource (default `0`) in the generic theme and use it across cell editor themes.
- Added a DataGrid-specific validation theme, `DataGridCellDataValidationErrorsTheme`, in `Generic.xaml`. It mirrors the tooltip-style layout from Avalonia Fluent, but uses DataGrid resources:
  - Icon and tooltip border use `DataGridCellInvalidBrush` (theme-specific: Fluent uses `SystemErrorTextColor`, Simple uses `ErrorColor`).
  - Corner radius uses `DataGridCellCornerRadius`.
- Applied the validation theme to cell editors via:
  - Per-control template styles (`TextBox`, `ComboBox`, `MaskedTextBox`, `NumericUpDown`, `CalendarDatePicker`, `TimePicker`, `Slider`).
  - A DataGrid-scoped style (`DataGridCell DataValidationErrors`) to ensure nested `DataValidationErrors` receive the DataGrid theme.
- Added/expanded DataGrid cell control themes to cover all editor and display controls and align them with DataGrid styling, including:
  - `TextBox`, `AutoCompleteBox`, `ComboBox`, `MaskedTextBox`, `NumericUpDown`, `CalendarDatePicker`, `TimePicker`, `Slider`, `ToggleSwitch`, `ToggleButton`, `CheckBox`, `ProgressBar`, `Button`, `HyperlinkButton`, and display `TextBlock` themes.
- Fluent and Simple themes now reuse the generic DataGrid validation theme; no Fluent-only override is needed.

## Column/editor support
- Added `IsEditable` to `DataGridComboBoxColumn` and synced it to generated combo boxes.
- Ensured validation support covers all editable column types and their corresponding editors.

## Sample updates
- Added a new validation showcase page:
  - `src/DataGridSample/Pages/ValidationColumnsPage.axaml`
  - `src/DataGridSample/Pages/ValidationColumnsPage.axaml.cs`
  - `src/DataGridSample/ViewModels/ValidationColumnsViewModel.cs`
- The page includes all major column types, shows invalid states, and provides a "Fix" button to reset values.
- Wired the page into the sample app UI and ensured trimming-safe access to the validation sample item via `Program.cs`.

## Tests and coverage
- Added `DataGridValidationTests` to cover:
  - Grid/row/cell invalid state handling.
  - Validation errors for each editable column type.
  - Validation theme corner radius in Fluent.
- Updated theme resource coverage expectations to include new DataGrid cell themes and resources.

## Build configuration
- Set `ProduceReferenceAssembly` to `false` in `Avalonia.Controls.DataGrid.csproj` to avoid XAML resource resolution issues in the sample app.

## Key files
- `src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs`
- `src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs`
- `src/Avalonia.Controls.DataGrid/Themes/Generic.xaml`
- `src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml`
- `src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs`
- `src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs`
- `src/DataGridSample/Pages/ValidationColumnsPage.axaml`
- `src/DataGridSample/ViewModels/ValidationColumnsViewModel.cs`
- `src/DataGridSample/MainWindow.axaml`
- `src/DataGridSample/Program.cs`

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/109