### PR TITLE
Fix Hierarchical stale Indentation

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalColumnTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalColumnTests.cs
@@ -4,8 +4,10 @@
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Input;
 using Avalonia.Headless.XUnit;
@@ -29,6 +31,28 @@ public class DataGridHierarchicalColumnTests
         presenter.Indent = 10;
 
         Assert.Equal(new Thickness(20, 0, 0, 0), presenter.Padding);
+    }
+
+    [AvaloniaFact]
+    public void Presenter_Reapplies_Padding_On_DataContext_Change()
+    {
+        var presenter = new DataGridHierarchicalPresenter
+        {
+            Indent = 8
+        };
+
+        presenter.Bind(DataGridHierarchicalPresenter.LevelProperty, new Binding(nameof(HierarchicalNode.Level)));
+
+        var nodeA = new HierarchicalNode(new object(), level: 1);
+        var nodeB = new HierarchicalNode(new object(), level: 1);
+
+        presenter.DataContext = nodeA;
+        Assert.Equal(new Thickness(8, 0, 0, 0), presenter.Padding);
+
+        presenter.Padding = new Thickness(123, 0, 0, 0);
+        presenter.DataContext = nodeB;
+
+        Assert.Equal(new Thickness(8, 0, 0, 0), presenter.Padding);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -1550,6 +1550,43 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
     }
 
     [Fact]
+    public void Reparenting_Keeps_Node_Levels_Consistent()
+    {
+        var root1 = new Item("Root1");
+        var root2 = new Item("Root2");
+        var child = new Item("Child");
+        var grandchild = new Item("Grandchild");
+        child.Children.Add(grandchild);
+        root1.Children.Add(child);
+
+        var items = new ObservableCollection<Item> { root1, root2 };
+
+        var model = CreateModel();
+        model.SetRoots(items);
+        model.ExpandAll();
+
+        Assert.Equal(1, model.FindNode(child)!.Level);
+        Assert.Equal(2, model.FindNode(grandchild)!.Level);
+
+        for (var i = 0; i < 3; i++)
+        {
+            root1.Children.Remove(child);
+            root2.Children.Add(child);
+            model.ExpandAll();
+
+            Assert.Equal(1, model.FindNode(child)!.Level);
+            Assert.Equal(2, model.FindNode(grandchild)!.Level);
+
+            root2.Children.Remove(child);
+            root1.Children.Add(child);
+            model.ExpandAll();
+
+            Assert.Equal(1, model.FindNode(child)!.Level);
+            Assert.Equal(2, model.FindNode(grandchild)!.Level);
+        }
+    }
+
+    [Fact]
     public void SetRoots_TypedModel_WorksCorrectly()
     {
         var items = new ObservableCollection<Item>

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalPresenter.cs
@@ -95,7 +95,9 @@ namespace Avalonia.Controls
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == LevelProperty || change.Property == IndentProperty)
+            if (change.Property == LevelProperty ||
+                change.Property == IndentProperty ||
+                change.Property == StyledElement.DataContextProperty)
             {
                 UpdateIndentPadding();
             }

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -173,6 +173,9 @@
     <TabItem Header="Hierarchical Model">
       <pages:HierarchicalSamplePage />
     </TabItem>
+    <TabItem Header="Hierarchical Undo/Redo">
+      <pages:HierarchicalUndoRedoPage />
+    </TabItem>
     <TabItem Header="Hierarchical Expanded State">
       <pages:HierarchicalExpandedStatePage />
     </TabItem>

--- a/src/DataGridSample/Pages/HierarchicalUndoRedoPage.axaml
+++ b/src/DataGridSample/Pages/HierarchicalUndoRedoPage.axaml
@@ -1,0 +1,133 @@
+<!--
+  Copyright (c) Wiesław Šoltés. All rights reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for details.
+-->
+<UserControl
+    x:Class="DataGridSample.Pages.HierarchicalUndoRedoPage"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+    xmlns:hier="clr-namespace:Avalonia.Controls.DataGridHierarchical;assembly=Avalonia.Controls.DataGrid"
+    x:DataType="viewModels:HierarchicalUndoRedoViewModel"
+    d:DesignHeight="720"
+    d:DesignWidth="1100"
+    mc:Ignorable="d">
+
+  <UserControl.DataContext>
+    <viewModels:HierarchicalUndoRedoViewModel />
+  </UserControl.DataContext>
+
+  <Grid Margin="12"
+        RowDefinitions="Auto,Auto,Auto,*"
+        RowSpacing="8">
+    <StackPanel Spacing="4">
+      <TextBlock Text="Hierarchical undo/redo reparenting"
+                 FontWeight="Bold"
+                 FontSize="18" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Move an item between groups and use undo/redo to replay the reparenting. This exercises hierarchical row recycling after reparenting (issue #115)." />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1"
+                Orientation="Horizontal"
+                Spacing="8">
+      <TextBlock Text="Destination:"
+                 VerticalAlignment="Center" />
+      <ComboBox Width="180"
+                ItemsSource="{Binding Roots}"
+                SelectedItem="{Binding DestinationParent}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="viewModels:HierarchicalUndoRedoViewModel+TreeItem">
+            <TextBlock Text="{Binding Name}" />
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+      <Button Content="Move selected"
+              Command="{Binding MoveSelectedCommand}" />
+      <Button Content="Undo"
+              Command="{Binding UndoCommand}" />
+      <Button Content="Redo"
+              Command="{Binding RedoCommand}" />
+      <Button Content="Expand all"
+              Command="{Binding ExpandAllCommand}" />
+      <Button Content="Collapse all"
+              Command="{Binding CollapseAllCommand}" />
+      <Button Content="Reset"
+              Command="{Binding ResetCommand}" />
+    </StackPanel>
+
+    <Grid Grid.Row="2"
+          ColumnDefinitions="Auto,*"
+          ColumnSpacing="16">
+      <StackPanel Orientation="Horizontal"
+                  Spacing="12"
+                  VerticalAlignment="Center">
+        <TextBlock Text="{Binding SelectedLabel}"
+                   FontWeight="SemiBold" />
+        <TextBlock Text="{Binding UndoCount, StringFormat=Undo: {0}}" />
+        <TextBlock Text="{Binding RedoCount, StringFormat=Redo: {0}}" />
+      </StackPanel>
+      <TextBlock Grid.Column="1"
+                 Text="{Binding Status}"
+                 TextWrapping="Wrap" />
+    </Grid>
+
+    <DataGrid Grid.Row="3"
+              AutoGenerateColumns="False"
+              HierarchicalModel="{Binding Model}"
+              HierarchicalRowsEnabled="True"
+              SelectionMode="Single"
+              SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+              HeadersVisibility="Column"
+              GridLinesVisibility="Horizontal"
+              x:DataType="viewModels:HierarchicalUndoRedoViewModel">
+      <DataGrid.Columns>
+        <DataGridHierarchicalColumn Header="Name"
+                                    Width="2*"
+                                    x:CompileBindings="False"
+                                    Binding="{Binding Item}">
+          <DataGridHierarchicalColumn.CellTemplate>
+            <DataTemplate x:DataType="viewModels:HierarchicalUndoRedoViewModel+TreeItem">
+              <TextBlock Text="{Binding Name}" />
+            </DataTemplate>
+          </DataGridHierarchicalColumn.CellTemplate>
+        </DataGridHierarchicalColumn>
+
+        <DataGridTemplateColumn Header="Parent"
+                                Width="180"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock x:DataType="viewModels:HierarchicalUndoRedoViewModel+TreeItem"
+                         DataContext="{Binding Item}"
+                         Text="{Binding ParentName}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+
+        <DataGridTemplateColumn Header="Level"
+                                Width="80">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock Text="{Binding Level}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+
+        <DataGridTemplateColumn Header="Children"
+                                Width="90"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock x:DataType="viewModels:HierarchicalUndoRedoViewModel+TreeItem"
+                         DataContext="{Binding Item}"
+                         Text="{Binding Children.Count}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/HierarchicalUndoRedoPage.axaml.cs
+++ b/src/DataGridSample/Pages/HierarchicalUndoRedoPage.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    public partial class HierarchicalUndoRedoPage : UserControl
+    {
+        public HierarchicalUndoRedoPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DataGridSample/Program.cs
+++ b/src/DataGridSample/Program.cs
@@ -38,6 +38,7 @@ public static class Program
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(ValidationSampleItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalRowDragDropViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSampleViewModel.TreeItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalUndoRedoViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSelectionViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalPathSelectionViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DocumentProperty))]

--- a/src/DataGridSample/ViewModels/HierarchicalUndoRedoViewModel.cs
+++ b/src/DataGridSample/ViewModels/HierarchicalUndoRedoViewModel.cs
@@ -1,0 +1,382 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Avalonia.Controls.DataGridHierarchical;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class HierarchicalUndoRedoViewModel : ObservableObject
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+        public sealed class TreeItem : ObservableObject
+        {
+            private TreeItem? _parent;
+
+            public TreeItem(int id, string name, TreeItem? parent = null)
+            {
+                Id = id;
+                Name = name;
+                _parent = parent;
+                Children = new ObservableCollection<TreeItem>();
+            }
+
+            public int Id { get; }
+
+            public string Name { get; }
+
+            public TreeItem? Parent
+            {
+                get => _parent;
+                set
+                {
+                    if (SetProperty(ref _parent, value))
+                    {
+                        OnPropertyChanged(nameof(ParentName));
+                    }
+                }
+            }
+
+            public string ParentName => Parent?.Name ?? "Root";
+
+            public ObservableCollection<TreeItem> Children { get; }
+        }
+
+        private sealed class ReparentAction
+        {
+            public ReparentAction(TreeItem item, TreeItem? oldParent, int oldIndex, TreeItem? newParent, int newIndex)
+            {
+                Item = item;
+                OldParent = oldParent;
+                OldIndex = oldIndex;
+                NewParent = newParent;
+                NewIndex = newIndex;
+            }
+
+            public TreeItem Item { get; }
+            public TreeItem? OldParent { get; }
+            public int OldIndex { get; }
+            public TreeItem? NewParent { get; }
+            public int NewIndex { get; }
+        }
+
+        private readonly Stack<ReparentAction> _undoStack = new();
+        private readonly Stack<ReparentAction> _redoStack = new();
+        private TreeItem? _selectedItem;
+        private TreeItem? _destinationParent;
+        private string _selectedLabel = "Selected: None";
+        private string _status = "Select an item and move it between groups.";
+        private int _undoCount;
+        private int _redoCount;
+
+        public HierarchicalUndoRedoViewModel()
+        {
+            Roots = BuildSample();
+
+            var options = new HierarchicalOptions<TreeItem>
+            {
+                ChildrenSelector = item => item.Children,
+                IsLeafSelector = item => item.Children.Count == 0,
+                AutoExpandRoot = true,
+                MaxAutoExpandDepth = 1
+            };
+
+            Model = new HierarchicalModel<TreeItem>(options);
+            Model.SetRoots(Roots);
+
+            MoveSelectedCommand = new RelayCommand(_ => MoveSelected(), _ => CanMoveSelected());
+            UndoCommand = new RelayCommand(_ => Undo(), _ => _undoStack.Count > 0);
+            RedoCommand = new RelayCommand(_ => Redo(), _ => _redoStack.Count > 0);
+            ExpandAllCommand = new RelayCommand(_ => Model.ExpandAll());
+            CollapseAllCommand = new RelayCommand(_ => Model.CollapseAll());
+            ResetCommand = new RelayCommand(_ => ResetSample());
+
+            DestinationParent = Roots.FirstOrDefault();
+        }
+
+        public ObservableCollection<TreeItem> Roots { get; }
+
+        public HierarchicalModel<TreeItem> Model { get; }
+
+        public RelayCommand MoveSelectedCommand { get; }
+
+        public RelayCommand UndoCommand { get; }
+
+        public RelayCommand RedoCommand { get; }
+
+        public RelayCommand ExpandAllCommand { get; }
+
+        public RelayCommand CollapseAllCommand { get; }
+
+        public RelayCommand ResetCommand { get; }
+
+        public TreeItem? SelectedItem
+        {
+            get => _selectedItem;
+            set
+            {
+                if (SetProperty(ref _selectedItem, value))
+                {
+                    SelectedLabel = value == null ? "Selected: None" : $"Selected: {value.Name} (#{value.Id})";
+                    UpdateCommandStates();
+                }
+            }
+        }
+
+        public TreeItem? DestinationParent
+        {
+            get => _destinationParent;
+            set
+            {
+                if (SetProperty(ref _destinationParent, value))
+                {
+                    UpdateCommandStates();
+                }
+            }
+        }
+
+        public string SelectedLabel
+        {
+            get => _selectedLabel;
+            private set => SetProperty(ref _selectedLabel, value);
+        }
+
+        public string Status
+        {
+            get => _status;
+            private set => SetProperty(ref _status, value);
+        }
+
+        public int UndoCount
+        {
+            get => _undoCount;
+            private set => SetProperty(ref _undoCount, value);
+        }
+
+        public int RedoCount
+        {
+            get => _redoCount;
+            private set => SetProperty(ref _redoCount, value);
+        }
+
+        private bool CanMoveSelected()
+        {
+            if (SelectedItem == null || DestinationParent == null)
+            {
+                return false;
+            }
+
+            if (SelectedItem.Parent == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(SelectedItem.Parent, DestinationParent))
+            {
+                return false;
+            }
+
+            return !IsDescendant(DestinationParent, SelectedItem);
+        }
+
+        private void MoveSelected()
+        {
+            var selectedItem = SelectedItem;
+            var destinationParent = DestinationParent;
+            if (selectedItem == null || destinationParent == null)
+            {
+                Status = "Select an item and destination parent.";
+                return;
+            }
+
+            if (selectedItem.Parent == null)
+            {
+                Status = "Root items are fixed in this sample.";
+                return;
+            }
+
+            if (ReferenceEquals(selectedItem.Parent, destinationParent))
+            {
+                Status = $"'{selectedItem.Name}' is already under '{destinationParent.Name}'.";
+                return;
+            }
+
+            if (IsDescendant(destinationParent, selectedItem))
+            {
+                Status = "Cannot move an item into its own subtree.";
+                return;
+            }
+
+            var sourceParent = selectedItem.Parent;
+            var sourceCollection = GetCollection(sourceParent);
+            var sourceIndex = sourceCollection.IndexOf(selectedItem);
+            if (sourceIndex < 0)
+            {
+                Status = "Could not locate the selected item.";
+                return;
+            }
+
+            var destinationCollection = GetCollection(destinationParent);
+            var destinationIndex = destinationCollection.Count;
+
+            var action = new ReparentAction(selectedItem, sourceParent, sourceIndex, destinationParent, destinationIndex);
+
+            ApplyMove(action.Item, action.OldParent, action.OldIndex, action.NewParent, action.NewIndex);
+            _undoStack.Push(action);
+            _redoStack.Clear();
+
+            UpdateHistoryCounts();
+            Status = $"Moved '{selectedItem.Name}' to '{destinationParent.Name}'.";
+        }
+
+        private void Undo()
+        {
+            if (_undoStack.Count == 0)
+            {
+                return;
+            }
+
+            var action = _undoStack.Pop();
+            ApplyMove(action.Item, action.NewParent, action.NewIndex, action.OldParent, action.OldIndex);
+            _redoStack.Push(action);
+
+            SelectedItem = action.Item;
+            UpdateHistoryCounts();
+            Status = $"Undo: moved '{action.Item.Name}' back to '{action.OldParent?.Name ?? "Root"}'.";
+        }
+
+        private void Redo()
+        {
+            if (_redoStack.Count == 0)
+            {
+                return;
+            }
+
+            var action = _redoStack.Pop();
+            ApplyMove(action.Item, action.OldParent, action.OldIndex, action.NewParent, action.NewIndex);
+            _undoStack.Push(action);
+
+            SelectedItem = action.Item;
+            UpdateHistoryCounts();
+            Status = $"Redo: moved '{action.Item.Name}' to '{action.NewParent?.Name ?? "Root"}'.";
+        }
+
+        private void ResetSample()
+        {
+            Roots.Clear();
+            foreach (var root in BuildSample())
+            {
+                Roots.Add(root);
+            }
+
+            Model.SetRoots(Roots);
+            DestinationParent = Roots.FirstOrDefault();
+            SelectedItem = null;
+
+            _undoStack.Clear();
+            _redoStack.Clear();
+            UpdateHistoryCounts();
+            Status = "Sample data reset.";
+        }
+
+        private void ApplyMove(TreeItem item, TreeItem? fromParent, int fromIndex, TreeItem? toParent, int toIndex)
+        {
+            var sourceCollection = GetCollection(fromParent);
+            if (fromIndex < 0 || fromIndex >= sourceCollection.Count || !ReferenceEquals(sourceCollection[fromIndex], item))
+            {
+                fromIndex = sourceCollection.IndexOf(item);
+            }
+
+            if (fromIndex >= 0)
+            {
+                sourceCollection.RemoveAt(fromIndex);
+            }
+
+            var destinationCollection = GetCollection(toParent);
+            if (toIndex < 0 || toIndex > destinationCollection.Count)
+            {
+                toIndex = destinationCollection.Count;
+            }
+
+            destinationCollection.Insert(toIndex, item);
+            item.Parent = toParent;
+        }
+
+        private ObservableCollection<TreeItem> GetCollection(TreeItem? parent)
+        {
+            return parent?.Children ?? Roots;
+        }
+
+        private void UpdateHistoryCounts()
+        {
+            UndoCount = _undoStack.Count;
+            RedoCount = _redoStack.Count;
+            UpdateCommandStates();
+        }
+
+        private void UpdateCommandStates()
+        {
+            MoveSelectedCommand.RaiseCanExecuteChanged();
+            UndoCommand.RaiseCanExecuteChanged();
+            RedoCommand.RaiseCanExecuteChanged();
+        }
+
+        private static bool IsDescendant(TreeItem node, TreeItem potentialAncestor)
+        {
+            var current = node.Parent;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, potentialAncestor))
+                {
+                    return true;
+                }
+
+                current = current.Parent;
+            }
+
+            return false;
+        }
+
+        private static ObservableCollection<TreeItem> BuildSample()
+        {
+            var id = 1;
+
+            var backlog = new TreeItem(id++, "Backlog");
+            var inProgress = new TreeItem(id++, "In Progress");
+            var done = new TreeItem(id++, "Done");
+
+            var planning = AddChild(backlog, ref id, "Planning");
+            AddChild(planning, ref id, "Specs");
+            AddChild(planning, ref id, "Estimates");
+
+            var feature = AddChild(backlog, ref id, "Feature X");
+            AddChild(feature, ref id, "Design");
+            AddChild(feature, ref id, "Implementation");
+
+            AddChild(inProgress, ref id, "Bugfix Sprint");
+            var qa = AddChild(inProgress, ref id, "QA");
+            AddChild(qa, ref id, "Regression");
+
+            AddChild(done, ref id, "Release Notes");
+            AddChild(done, ref id, "Telemetry Review");
+
+            return new ObservableCollection<TreeItem>
+            {
+                backlog,
+                inProgress,
+                done
+            };
+        }
+
+        private static TreeItem AddChild(TreeItem parent, ref int id, string name)
+        {
+            var child = new TreeItem(id++, name, parent);
+            parent.Children.Add(child);
+            return child;
+        }
+    }
+}


### PR DESCRIPTION
# Issue 115 - Hierarchical reparenting undo/redo

## Summary
- Indentation could become stale after undo/redo reparenting because recycled row presenters did not recompute padding when their data context changed.
- The fix forces the hierarchical presenter to refresh its indent padding whenever the data context updates.

## Fix
- `DataGridHierarchicalPresenter` now recalculates padding on data context changes in addition to level/indent changes.

## Tests
- `DataGridHierarchicalColumnTests.Presenter_Reapplies_Padding_On_DataContext_Change` (headless UI test).
- `HierarchicalModelTests.Reparenting_Keeps_Node_Levels_Consistent` (unit test for level stability after reparenting).

## Sample
- Added a "Hierarchical Undo/Redo" sample page in `DataGridSample` with move/undo/redo controls to exercise reparenting and verify indentation stays correct.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/115