### PR TITLE
Initialized row-group layout caches

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionGroupingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionGroupingTests.cs
@@ -77,6 +77,59 @@ public class DataGridSelectionGroupingTests
         Assert.Single(grid.SelectedItems);
     }
 
+    [AvaloniaFact]
+    public void Setting_Grouped_ItemsSource_When_Attached_Does_Not_Throw()
+    {
+        var items = new ObservableCollection<Item>
+        {
+            new() { Group = "A", Name = "One" },
+            new() { Group = "A", Name = "Two" },
+            new() { Group = "B", Name = "Three" },
+        };
+
+        dynamic view = CreateGroupedView(items, nameof(Item.Group));
+        var root = new Window
+        {
+            Width = 300,
+            Height = 200,
+        };
+
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            Selection = new SelectionModel<Item>(),
+            SelectionMode = DataGridSelectionMode.Single,
+            AutoScrollToSelectedItem = true,
+        };
+
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Group",
+            Binding = new Binding(nameof(Item.Group))
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(Item.Name))
+        });
+
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        try
+        {
+            var exception = Record.Exception(() => grid.ItemsSource = (System.Collections.IEnumerable)view);
+            Assert.Null(exception);
+            grid.UpdateLayout();
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
     private static dynamic CreateGroupedView(IEnumerable<Item> items, string? groupPath)
     {
         var assembly = typeof(DataGrid).Assembly;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
@@ -342,6 +342,7 @@ namespace Avalonia.Controls
             }
             SlotCount = DataConnection.Count + RowGroupHeadersTable.IndexCount + RowGroupFootersTable.IndexCount;
             VisibleSlotCount = SlotCount;
+            RefreshRowGroupHeaders();
         }
 
         private void SyncRowGroupInfoSlots()


### PR DESCRIPTION
# Issue 134 Summary

## Problem
- Updating to 11.3.9-preview.10 introduced a NullReferenceException when a DataGrid with grouping applied selection/scroll updates during ItemsSource changes.

## Root Cause
- Group header layout caches (`_rowGroupHeightsByLevel` and `RowGroupSublevelIndents`) were not initialized before row generation. When the grid tried to measure a grouped slot, `InsertDisplayedElement` accessed these arrays and hit a null dereference.

## Fix
- Initialize row group header state immediately after populating group headers by calling `RefreshRowGroupHeaders()` from `PopulateRowGroupHeadersTable()`.

## Tests
- Added a headless unit test that attaches a DataGrid, then assigns a grouped ItemsSource and asserts no exception is thrown.

## Files Changed
- `src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs`
- `src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionGroupingTests.cs`

Fixes: https://github.com/wieslawsoltes/ProDataGrid/issues/134
