### PR TITLE
Fix Keyboard Navigation Scroll

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
@@ -619,6 +619,8 @@ internal
 
             SetVerticalOffset(_verticalOffset);
 
+            SyncLogicalScrollableOffset();
+
             InvalidateMeasure();
             InvalidateRowsMeasure(false /*invalidateIndividualRows*/);
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
@@ -108,7 +108,10 @@ internal
                         break;
                 }
 
-                if (CurrentSlot != slot || (CurrentColumnIndex != columnIndex && columnIndex != -1))
+                bool currentCellChanged = CurrentSlot != slot || (CurrentColumnIndex != columnIndex && columnIndex != -1);
+                int scrollColumnIndex = columnIndex;
+
+                if (currentCellChanged)
                 {
                     if (columnIndex == -1)
                     {
@@ -130,15 +133,37 @@ internal
                         if (!SetCurrentCellCore(
                                 columnIndex, slot,
                                 commitEdit: true,
-                                endRowEdit: SlotFromRowIndex(SelectedIndex) != slot)
-                            || (scrollIntoView &&
-                                !ScrollSlotIntoView(
-                                    columnIndex, slot,
-                                    forCurrentCellChange: true,
-                                    forceHorizontalScroll: false)))
+                                endRowEdit: SlotFromRowIndex(SelectedIndex) != slot))
                         {
                             return;
                         }
+                    }
+
+                    scrollColumnIndex = columnIndex;
+                }
+
+                if (scrollIntoView)
+                {
+                    if (scrollColumnIndex == -1)
+                    {
+                        scrollColumnIndex = CurrentColumnIndex;
+                        if (scrollColumnIndex == -1)
+                        {
+                            DataGridColumn firstVisibleColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
+                            if (firstVisibleColumn != null)
+                            {
+                                scrollColumnIndex = firstVisibleColumn.Index;
+                            }
+                        }
+                    }
+
+                    if (scrollColumnIndex != -1 &&
+                        !ScrollSlotIntoView(
+                            scrollColumnIndex, slot,
+                            forCurrentCellChange: currentCellChanged,
+                            forceHorizontalScroll: false))
+                    {
+                        return;
                     }
                 }
                 _successfullyUpdatedSelection = true;


### PR DESCRIPTION
# Keyboard Navigation Scroll Summary

Fixed keyboard navigation by ensuring `scrollIntoView` actually scrolls even when `AutoScrollToSelectedItem` is off, and added a regression test for logical scrolling.

- `src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs`: moved the scroll-into-view call outside the current-cell-change guard and resolve a usable column index so arrow key navigation always attempts to scroll when requested.
- `src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs`: sync logical scroll offsets after vertical offset updates to keep the ScrollViewer aligned.
- `src/Avalonia.Controls.DataGrid.UnitTests/DataGridScrollingTests.cs`: added `Keyboard_Navigation_Scrolls_When_AutoScroll_Disabled` with a small key-press helper.

Tests run:
- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "Keyboard_Navigation_Scrolls_When_AutoScroll_Disabled"`

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/140
