### PR TITLE
XYFocus related fixes

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
@@ -932,6 +932,34 @@ public class DataGridInputNavigationTests
     }
 
     [AvaloniaFact]
+    public void XYFocus_NavigationModes_Inherits_From_TopLevel()
+    {
+        var (grid, _) = CreateGrid(rowCount: 3);
+        var root = TopLevel.GetTopLevel(grid);
+        Assert.NotNull(root);
+
+        XYFocus.SetNavigationModes(root!, XYFocusNavigationModes.Enabled);
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(XYFocusNavigationModes.Enabled, XYFocus.GetNavigationModes(grid));
+    }
+
+    [AvaloniaFact]
+    public void XYFocus_NavigationModes_Local_Value_Overrides_Inherited()
+    {
+        var (grid, _) = CreateGrid(rowCount: 3);
+        var root = TopLevel.GetTopLevel(grid);
+        Assert.NotNull(root);
+
+        XYFocus.SetNavigationModes(root!, XYFocusNavigationModes.Gamepad);
+        XYFocus.SetNavigationModes(grid, XYFocusNavigationModes.Enabled);
+        grid.UpdateLayout();
+
+        Assert.Equal(XYFocusNavigationModes.Enabled, XYFocus.GetNavigationModes(grid));
+    }
+
+    [AvaloniaFact]
     public void KeyDown_Respects_Handled_Flag()
     {
         var (grid, _) = CreateGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs
@@ -17,7 +17,40 @@ namespace Avalonia.Controls.DataGridTests.Input;
 public class DataGridKeyboardGestureOverrideTests
 {
     [AvaloniaFact]
-    public void KeyDown_Handler_Can_Block_BuiltIn_When_AfterHandlers()
+    public void KeyDown_Handler_Can_Block_BuiltIn_When_AfterHandlers_For_NonDirectionalKeys()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        SetDisplayedScrollingElements(grid, 1);
+
+        var invoked = false;
+        grid.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.PageDown)
+            {
+                invoked = true;
+                e.Handled = true;
+            }
+        };
+
+        var handledArgs = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.PageDown,
+            Source = grid,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        grid.RaiseEvent(handledArgs);
+        InvokeDataGridKeyDown(grid, handledArgs);
+
+        Assert.True(invoked);
+        Assert.Equal(0, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void DirectionalKeys_Run_Before_AfterHandlers()
     {
         var (grid, _) = CreateGrid();
         SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
@@ -32,7 +65,7 @@ public class DataGridKeyboardGestureOverrideTests
             }
         };
 
-        var handledArgs = new KeyEventArgs
+        var args = new KeyEventArgs
         {
             RoutedEvent = InputElement.KeyDownEvent,
             Route = InputElement.KeyDownEvent.RoutingStrategies,
@@ -41,11 +74,11 @@ public class DataGridKeyboardGestureOverrideTests
             KeyDeviceType = KeyDeviceType.Keyboard
         };
 
-        grid.RaiseEvent(handledArgs);
-        InvokeDataGridKeyDown(grid, handledArgs);
+        grid.RaiseEvent(args);
 
-        Assert.True(invoked);
-        Assert.Equal(0, grid.SelectedIndex);
+        Assert.False(invoked);
+        Assert.True(args.Handled);
+        Assert.Equal(1, grid.SelectedIndex);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -974,12 +974,32 @@ internal
             return false;
         }
 
+        private void DataGrid_KeyDownDirectional(object sender, KeyEventArgs e)
+        {
+            if (e.Handled || !IsDirectionalKey(e.Key))
+            {
+                return;
+            }
+
+            if (!IsKeyEventFromThisGrid(e))
+            {
+                return;
+            }
+
+            e.Handled = ProcessDataGridKey(e);
+        }
+
         private void DataGrid_KeyDown(object sender, KeyEventArgs e)
         {
             if (!e.Handled)
             {
                 e.Handled = ProcessDataGridKey(e);
             }
+        }
+
+        private static bool IsDirectionalKey(Key key)
+        {
+            return key is Key.Up or Key.Down or Key.Left or Key.Right;
         }
 
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -490,6 +490,9 @@ internal
         /// </summary>
         public DataGrid()
         {
+            // Handle arrow keys early so grid navigation wins over XYFocus.
+            KeyDown += DataGrid_KeyDownDirectional;
+
             //TODO: Check if override works
             GotFocus += DataGrid_GotFocus;
             LostFocus += DataGrid_LostFocus;

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -115,6 +115,9 @@
     <TabItem Header="Keyboard Overrides">
       <pages:KeyboardGestureHandlingPage />
     </TabItem>
+    <TabItem Header="XY Focus Modes">
+      <pages:XYFocusModesPage />
+    </TabItem>
     <TabItem Header="Large Variable Height">
       <local:LargeVariableHeightPage />
     </TabItem>

--- a/src/DataGridSample/Pages/XYFocusModesPage.axaml
+++ b/src/DataGridSample/Pages/XYFocusModesPage.axaml
@@ -1,0 +1,85 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.XYFocusModesPage"
+             x:DataType="viewModels:XYFocusModesViewModel">
+  <UserControl.DataContext>
+    <viewModels:XYFocusModesViewModel />
+  </UserControl.DataContext>
+
+  <Grid RowDefinitions="Auto,Auto,*" Margin="12" RowSpacing="8">
+    <StackPanel Grid.Row="0" Spacing="4">
+      <TextBlock Classes="h2">XY focus modes</TextBlock>
+      <TextBlock Text="XYFocus.NavigationModes controls which key devices use 2D directional focus navigation. Enable Keyboard to move focus with arrow keys across the layout below."
+                 TextWrapping="Wrap" />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="12">
+      <TextBlock VerticalAlignment="Center" Text="Active modes:" />
+      <CheckBox Content="Keyboard" IsChecked="{Binding KeyboardEnabled}" />
+      <CheckBox Content="Gamepad" IsChecked="{Binding GamepadEnabled}" />
+      <CheckBox Content="Remote" IsChecked="{Binding RemoteEnabled}" />
+      <TextBlock VerticalAlignment="Center" Text="{Binding ModesLabel}" />
+    </StackPanel>
+
+    <Grid Grid.Row="2"
+          ColumnDefinitions="2*,3*"
+          ColumnSpacing="12"
+          XYFocus.NavigationModes="{Binding NavigationModes}">
+      <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="4"
+              Padding="8">
+        <StackPanel Spacing="6">
+          <TextBlock Classes="h3">Directional focus playground</TextBlock>
+          <TextBlock Text="Click any button and use arrow keys. With Keyboard mode enabled, focus moves in 2D."
+                     TextWrapping="Wrap" />
+          <UniformGrid Rows="3" Columns="3" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,4,0,0">
+            <Button Content="A1" />
+            <Button Content="A2" />
+            <Button Content="A3" />
+            <Button Content="B1" />
+            <Button Content="B2" />
+            <Button Content="B3" />
+            <Button Content="C1" />
+            <Button Content="C2" />
+            <Button Content="C3" />
+          </UniformGrid>
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBox Width="140" Watermark="Focusable text" />
+            <ToggleButton Content="Toggle me" />
+            <Button Content="Action" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <Border Grid.Column="1"
+              BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="4"
+              Padding="8">
+        <StackPanel Spacing="6">
+          <TextBlock Classes="h3">DataGrid focus</TextBlock>
+          <TextBlock Text="Arrow keys still navigate selection inside the grid, even when XY focus is enabled."
+                     TextWrapping="Wrap" />
+          <DataGrid ItemsSource="{Binding Items}"
+                    AutoGenerateColumns="False"
+                    CanUserAddRows="False"
+                    CanUserDeleteRows="False"
+                    SelectionMode="Single"
+                    SelectionUnit="FullRow"
+                    IsReadOnly="True"
+                    Height="280">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="First" Binding="{Binding FirstName}" Width="2*" x:DataType="models:Person" />
+              <DataGridTextColumn Header="Last" Binding="{Binding LastName}" Width="2*" x:DataType="models:Person" />
+              <DataGridTextColumn Header="Age" Binding="{Binding Age}" Width="*" x:DataType="models:Person" />
+              <DataGridCheckBoxColumn Header="Is Banned" Binding="{Binding IsBanned}" Width="*" x:DataType="models:Person" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </StackPanel>
+      </Border>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/XYFocusModesPage.axaml.cs
+++ b/src/DataGridSample/Pages/XYFocusModesPage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    public partial class XYFocusModesPage : UserControl
+    {
+        public XYFocusModesPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DataGridSample/ViewModels/XYFocusModesViewModel.cs
+++ b/src/DataGridSample/ViewModels/XYFocusModesViewModel.cs
@@ -1,0 +1,103 @@
+using System.Collections.ObjectModel;
+using Avalonia.Input;
+using DataGridSample.Models;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class XYFocusModesViewModel : ObservableObject
+    {
+        private bool _keyboardEnabled = true;
+        private bool _gamepadEnabled;
+        private bool _remoteEnabled;
+        private XYFocusNavigationModes _navigationModes;
+
+        public XYFocusModesViewModel()
+        {
+            Items = new ObservableCollection<Person>
+            {
+                new Person { FirstName = "Ada", LastName = "Lovelace", Age = 36, IsBanned = false },
+                new Person { FirstName = "Alan", LastName = "Turing", Age = 41, IsBanned = false },
+                new Person { FirstName = "Grace", LastName = "Hopper", Age = 85, IsBanned = false },
+                new Person { FirstName = "Linus", LastName = "Torvalds", Age = 54, IsBanned = false },
+                new Person { FirstName = "Margaret", LastName = "Hamilton", Age = 86, IsBanned = false },
+                new Person { FirstName = "Tim", LastName = "Berners-Lee", Age = 68, IsBanned = false }
+            };
+
+            UpdateNavigationModes();
+        }
+
+        public ObservableCollection<Person> Items { get; }
+
+        public bool KeyboardEnabled
+        {
+            get => _keyboardEnabled;
+            set
+            {
+                if (SetProperty(ref _keyboardEnabled, value))
+                {
+                    UpdateNavigationModes();
+                }
+            }
+        }
+
+        public bool GamepadEnabled
+        {
+            get => _gamepadEnabled;
+            set
+            {
+                if (SetProperty(ref _gamepadEnabled, value))
+                {
+                    UpdateNavigationModes();
+                }
+            }
+        }
+
+        public bool RemoteEnabled
+        {
+            get => _remoteEnabled;
+            set
+            {
+                if (SetProperty(ref _remoteEnabled, value))
+                {
+                    UpdateNavigationModes();
+                }
+            }
+        }
+
+        public XYFocusNavigationModes NavigationModes
+        {
+            get => _navigationModes;
+            private set
+            {
+                if (SetProperty(ref _navigationModes, value))
+                {
+                    OnPropertyChanged(nameof(ModesLabel));
+                }
+            }
+        }
+
+        public string ModesLabel => $"Current: {NavigationModes}";
+
+        private void UpdateNavigationModes()
+        {
+            var modes = XYFocusNavigationModes.Disabled;
+            if (_keyboardEnabled)
+            {
+                modes |= XYFocusNavigationModes.Keyboard;
+            }
+
+            if (_gamepadEnabled)
+            {
+                modes |= XYFocusNavigationModes.Gamepad;
+            }
+
+            if (_remoteEnabled)
+            {
+                modes |= XYFocusNavigationModes.Remote;
+            }
+
+            NavigationModes = modes;
+        }
+    }
+}


### PR DESCRIPTION
# Keyboard Navigation and XYFocus: Arrow Key Precedence Investigation

## Summary
This document captures the investigation and resolution around a regression where keyboard arrow navigation stopped working in `DataGrid` when `XYFocus.NavigationModes="Enabled"` was set at the window level. The issue was reported against Avalonia `11.3.9-preview.11`, while `11.3.9-preview.9` behaved correctly. The fix restores preview-9 arrow key behavior by handling directional keys earlier in the `DataGrid` event pipeline so they win over XYFocus. Gesture overrides remain supported.

## Repro
- Report: https://github.com/wieslawsoltes/ProDataGrid/issues/138#issuecomment-3693983680
- Sample repo: https://github.com/YoshihiroIto/ProDataGridSample
- Key settings applied on the `Window` (in the repro):
  - `XYFocus.DownNavigationStrategy="Projection"`
  - `XYFocus.LeftNavigationStrategy="Projection"`
  - `XYFocus.NavigationModes="Enabled"`
  - `XYFocus.RightNavigationStrategy="Projection"`
  - `XYFocus.UpNavigationStrategy="Projection"`

### Expected (preview.9)
Arrow keys move the `DataGrid` selection/cell focus inside the grid.

### Observed (preview.11)
Arrow keys move focus via XYFocus instead of moving inside the `DataGrid`.

## Investigation Notes

### Event pipeline ordering
- `InputElement.KeyDownEvent` is a routed event (Bubble + Tunnel).
- Avalonia `KeyboardNavigationHandler` is attached at the `TopLevel` and handles arrow keys in its `OnKeyDown`.
  - It calls `XYFocus.TryDirectionalFocus(...)` for directional keys.
  - It sets `e.Handled = true` if focus is moved.
- `DataGrid` uses a private `DataGrid_KeyDown` method to process keyboard gestures via `ProcessDataGridKey(...)`.

### Regression trigger
The `DataGrid` handling of key events changed in the "keyboard gesture override support" work:
- Before: `DataGrid` subscribed to `KeyDown += DataGrid_KeyDown;`
  - This runs during the routed event, before the `TopLevel` handler.
  - Arrow keys were consumed by `DataGrid`, so XYFocus did not run.
- After: `DataGrid` processes keyboard input in `KeyDownEvent.RouteFinished` instead.
  - This was done to allow user KeyDown handlers to block built-in behavior.
  - Result: `KeyboardNavigationHandler` runs first and consumes arrow keys when XYFocus is enabled.

### Root cause
The regression is caused by changing DataGrid key handling from regular `KeyDown` to `RouteFinished`. This allows XYFocus (running at the window level) to handle directional keys first, marking them handled and preventing DataGrid navigation.

## Options Considered

1) **Theme override**  
   Set `input:XYFocus.NavigationModes="Gamepad,Remote"` in the DataGrid theme to block keyboard XYFocus by default.  
   - Pros: No event handling changes.  
   - Cons: Explicitly enabling keyboard XYFocus on the DataGrid still reintroduces the conflict.

2) **Avalonia base hook**  
   Add an Avalonia core interface to allow controls to intercept directional navigation before XYFocus.  
   - Pros: Clean, preserves user handler semantics and XYFocus.  
   - Cons: Requires changes in Avalonia base, not desired here.

3) **Restore preview-9 arrow key behavior** (chosen)  
   Handle arrow keys early via regular `KeyDown` and keep `RouteFinished` for non-directional keys.  
   - Pros: Arrow keys work again even with keyboard XYFocus enabled.  
   - Cons: User `KeyDown` handlers can no longer block arrow-key built-ins.

## Implemented Change

### Behavior change
- Directional keys (Up/Down/Left/Right) are processed on normal `KeyDown` before XYFocus.
- Non-directional keys continue to use `KeyDownEvent.RouteFinished` so user handlers can block built-ins.
- Gesture overrides still apply because the early handler calls `ProcessDataGridKey(...)`.
- No theme-level override is applied; `XYFocus.NavigationModes` now inherits normally from the `TopLevel` unless set locally on the grid.

### Code changes
- `src/Avalonia.Controls.DataGrid/DataGrid.cs`
  - Add `KeyDown += DataGrid_KeyDownDirectional;` in the constructor.
- `src/Avalonia.Controls.DataGrid/DataGrid.Input.cs`
  - Add `DataGrid_KeyDownDirectional` that:
    - ignores handled events
    - only handles directional keys
    - verifies the event originates from this grid
    - calls `ProcessDataGridKey(...)`
  - Add `IsDirectionalKey(...)` helper.

## Tests Updated

- `src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs`
  - Rename the "after handlers block built-in" test to scope it to non-directional keys.
  - Add a new test asserting directional keys are handled before after-handlers.
- `src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs`
  - Update XYFocus tests to reflect inheritance from the `TopLevel` and local override precedence.

## Behavior Summary (After Fix)

- **Directional keys**:
  - DataGrid handles them first (wins over XYFocus).
  - User `KeyDown` handlers do not block them.
  - Gesture overrides still work (e.g., MoveDown = J).

- **Non-directional keys**:
  - Still handled in `RouteFinished`.
  - User `KeyDown` handlers can block built-ins.

## Notes / Follow-ups

- If we want full coexistence of keyboard XYFocus and DataGrid navigation *and* keep user handler override semantics, an Avalonia base hook is needed.
- The current fix intentionally matches preview-9 behavior for directional keys while preserving newer override behavior for other keys.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/138