### PR TITLE
Add column header auto-fit on double-click

### DIFF
--- a/docfx/articles/columns-and-editing.md
+++ b/docfx/articles/columns-and-editing.md
@@ -52,8 +52,10 @@ Widths accept pixel values (`"80"`), `Auto` (content-based), `*` or weighted sta
 
 - Widths: pixel, `Auto`, and star sizing (`*`, `2*`).
 - Constraints: `MinWidth`/`MaxWidth` per column.
-- Interaction: `CanUserResizeColumns` and `CanUserReorderColumns` at the grid level; `CanUserResize`, `CanUserReorder`, and `CanUserSort` per column.
+- Interaction: `CanUserResizeColumns`, `CanUserResizeColumnsOnDoubleClick`, and `CanUserReorderColumns` at the grid level; `CanUserResize`, `CanUserReorder`, and `CanUserSort` per column.
 - Frozen columns: `FrozenColumnCount` and `FrozenColumnCountRight` pin columns on the left/right.
+
+Double-click the column header resize handle to fit the column to visible content when `CanUserResizeColumnsOnDoubleClick` is enabled.
 
 ```xml
 <DataGrid FrozenColumnCount="1"

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnHeaderAutoFitTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnHeaderAutoFitTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridTests;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Columns;
+
+public class DataGridColumnHeaderAutoFitTests
+{
+    [AvaloniaFact]
+    public void Double_Click_On_Resize_Handle_Auto_Fits_Column()
+    {
+        var (grid, root, column) = CreateGrid(canAutoFit: true);
+        try
+        {
+            var header = GetHeaderForColumn(grid, column);
+            var initialWidth = column.ActualWidth;
+
+            RaiseDoubleClickOnResizeHandle(header);
+            grid.UpdateLayout();
+
+            Assert.True(column.ActualWidth > initialWidth + 0.5);
+            Assert.True(column.ActualWidth >= 180);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Double_Click_On_Resize_Handle_Is_Ignored_When_Disabled()
+    {
+        var (grid, root, column) = CreateGrid(canAutoFit: false);
+        try
+        {
+            var header = GetHeaderForColumn(grid, column);
+            var initialWidth = column.ActualWidth;
+
+            RaiseDoubleClickOnResizeHandle(header);
+            grid.UpdateLayout();
+
+            Assert.InRange(Math.Abs(column.ActualWidth - initialWidth), 0, 0.5);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    private static (DataGrid grid, Window root, DataGridColumn column) CreateGrid(bool canAutoFit)
+    {
+        var items = new ObservableCollection<Item>
+        {
+            new("Alpha"),
+            new("Beta")
+        };
+
+        var root = new Window
+        {
+            Width = 400,
+            Height = 200
+        };
+
+        root.SetThemeStyles();
+
+        var column = new DataGridTemplateColumn
+        {
+            Header = "Name",
+            Width = new DataGridLength(40),
+            CellTemplate = new FuncDataTemplate<Item>((_, _) => new Border { Width = 180, Height = 20 })
+        };
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            CanUserResizeColumns = true,
+            CanUserResizeColumnsOnDoubleClick = canAutoFit,
+            ItemsSource = items
+        };
+
+        grid.ColumnsInternal.Add(column);
+
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        return (grid, root, column);
+    }
+
+    private static DataGridColumnHeader GetHeaderForColumn(DataGrid grid, DataGridColumn column)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridColumnHeader>()
+            .First(h => ReferenceEquals(h.OwningColumn, column));
+    }
+
+    private static void RaiseDoubleClickOnResizeHandle(DataGridColumnHeader header)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var properties = new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed);
+        var x = Math.Max(1, header.Bounds.Width - 2);
+        var point = new Point(x, header.Bounds.Height / 2);
+        var args = new PointerPressedEventArgs(header, pointer, header, point, 0, properties, KeyModifiers.None, 2);
+        header.RaiseEvent(args);
+    }
+
+    private sealed class Item
+    {
+        public Item(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -63,6 +63,21 @@ internal
         }
 
         /// <summary>
+        /// Identifies the CanUserResizeColumnsOnDoubleClick dependency property.
+        /// </summary>
+        public static readonly StyledProperty<bool> CanUserResizeColumnsOnDoubleClickProperty =
+            AvaloniaProperty.Register<DataGrid, bool>(nameof(CanUserResizeColumnsOnDoubleClick), true);
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether a column can be auto-fit by double-clicking its resize handle.
+        /// </summary>
+        public bool CanUserResizeColumnsOnDoubleClick
+        {
+            get { return GetValue(CanUserResizeColumnsOnDoubleClickProperty); }
+            set { SetValue(CanUserResizeColumnsOnDoubleClickProperty, value); }
+        }
+
+        /// <summary>
         /// Identifies the CanUserSortColumns dependency property.
         /// </summary>
         public static readonly StyledProperty<bool> CanUserSortColumnsProperty =


### PR DESCRIPTION
- Add `CanUserResizeColumnsOnDoubleClick` to control auto-fit behavior on header double-click.
- Implement auto-fit sizing on the column header resize handle by measuring visible header/cell content.
- Add headless unit tests and document the new interaction in the columns/editing article.
