### PR TITLE
SelectionModel item-based SelectRange

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Selection/SelectionModelItemSelectionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Selection/SelectionModelItemSelectionTests.cs
@@ -155,6 +155,80 @@ public class SelectionModelItemSelectionTests
         Assert.Equal("B", selection.SelectedItems[0]);
     }
 
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_Uses_Source_Index()
+    {
+        var items = new List<string> { "A", "B", "C", "D" };
+        var selection = new SelectionModel<string> { Source = items, SingleSelect = false };
+
+        selection.SelectRange(new[] { "B", "D" });
+
+        Assert.Equal(2, selection.SelectedIndexes.Count);
+        Assert.Contains(1, selection.SelectedIndexes);
+        Assert.Contains(3, selection.SelectedIndexes);
+    }
+
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_Resolves_Hierarchical_Nodes()
+    {
+        var root = new NodeItem("root");
+        var childA = new NodeItem("childA");
+        var childB = new NodeItem("childB");
+        root.Children.Add(childA);
+        root.Children.Add(childB);
+
+        var model = CreateModel(root);
+        var selection = new SelectionModel<object> { Source = model.Flattened, SingleSelect = false };
+
+        selection.SelectRange(new object[] { childA, childB });
+
+        Assert.Equal(2, selection.SelectedIndexes.Count);
+        Assert.Contains(1, selection.SelectedIndexes);
+        Assert.Contains(2, selection.SelectedIndexes);
+    }
+
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_Throws_When_Not_Found()
+    {
+        var items = new List<string> { "A", "B" };
+        var selection = new SelectionModel<string> { Source = items, SingleSelect = false };
+
+        var exception = Assert.Throws<ArgumentException>(() => selection.SelectRange(new[] { "A", "C" }));
+        Assert.Contains("Item not found", exception.Message);
+    }
+
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_With_Null_Source_Throws_For_MultiSelect()
+    {
+        var selection = new SelectionModel<string> { SingleSelect = false };
+
+        Assert.Throws<InvalidOperationException>(() => selection.SelectRange(new[] { "A", "B" }));
+    }
+
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_With_Null_Source_Allows_Single_Item()
+    {
+        var selection = new SelectionModel<string> { SingleSelect = false };
+
+        selection.SelectRange(new[] { "A" });
+
+        Assert.Equal("A", selection.SelectedItem);
+        Assert.Single(selection.SelectedItems);
+        Assert.Equal("A", selection.SelectedItems[0]);
+    }
+
+    [Fact]
+    public void SelectionModel_SelectRange_By_Items_With_Null_Source_Sets_SelectedItem_When_SingleSelect()
+    {
+        var selection = new SelectionModel<string> { SingleSelect = true };
+
+        selection.SelectRange(new[] { "A", "B" });
+
+        Assert.Equal("B", selection.SelectedItem);
+        Assert.Single(selection.SelectedItems);
+        Assert.Equal("B", selection.SelectedItems[0]);
+    }
+
     [AvaloniaFact]
     public void DataGrid_Selection_Select_By_Item_Selects_Hierarchical_Item()
     {

--- a/src/Avalonia.Controls.DataGrid/Selection/SelectionModelItemExtensions.cs
+++ b/src/Avalonia.Controls.DataGrid/Selection/SelectionModelItemExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Avalonia.Controls.DataGridHierarchical;
 
 namespace Avalonia.Controls.Selection
@@ -88,6 +89,72 @@ namespace Avalonia.Controls.Selection
             else
             {
                 model.SelectRange(endIndex, startIndex);
+            }
+        }
+
+        public static void SelectRange(this ISelectionModel model, IEnumerable items)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            var list = items as IList;
+            if (list == null)
+            {
+                var materialized = new List<object>();
+                foreach (var item in items)
+                {
+                    materialized.Add(item);
+                }
+                list = materialized;
+            }
+
+            if (list.Count == 0)
+            {
+                return;
+            }
+
+            if (model.Source == null)
+            {
+                if (model.SingleSelect || list.Count == 1)
+                {
+                    model.SelectedItem = list[list.Count - 1];
+                    return;
+                }
+
+                throw new InvalidOperationException("Selection model source is not set.");
+            }
+
+            var indexes = new List<int>(list.Count);
+            for (var i = 0; i < list.Count; i++)
+            {
+                var index = ResolveIndex(model.Source, list[i]);
+                if (index < 0)
+                {
+                    throw new ArgumentException("Item not found in selection model source.", nameof(items));
+                }
+
+                indexes.Add(index);
+            }
+
+            if (model.SingleSelect)
+            {
+                model.SelectedIndex = indexes[indexes.Count - 1];
+                return;
+            }
+
+            using (model.BatchUpdate())
+            {
+                for (var i = 0; i < indexes.Count; i++)
+                {
+                    model.Select(indexes[i]);
+                }
             }
         }
 

--- a/src/DataGridSample/Pages/SelectionModelItemSelectionPage.axaml
+++ b/src/DataGridSample/Pages/SelectionModelItemSelectionPage.axaml
@@ -29,7 +29,7 @@
       <TextBlock Classes="h2"
                  Text="SelectionModel Select by Item" />
       <TextBlock TextWrapping="Wrap"
-                 Text="Use SelectionModel.Select(item) to choose rows by the view-model object even when the selection source is hierarchical nodes." />
+                 Text="Use SelectionModel.Select(item), SelectRange(item, item), and SelectRange(items) to choose rows by the view-model object even when the selection source is hierarchical nodes." />
     </StackPanel>
 
     <WrapPanel Grid.Row="1"
@@ -42,6 +42,12 @@
               Margin="0 0 8 8" />
       <Button Content="Select first two siblings"
               Command="{Binding SelectSiblingPairCommand}"
+              Margin="0 0 8 8" />
+      <Button Content="Select range (first child to deep item)"
+              Command="{Binding SelectRangeCommand}"
+              Margin="0 0 8 8" />
+      <Button Content="Select specific items (list)"
+              Command="{Binding SelectItemsCommand}"
               Margin="0 0 8 8" />
       <Button Content="Clear selection"
               Command="{Binding ClearSelectionCommand}"

--- a/src/DataGridSample/ViewModels/SelectionModelItemSelectionViewModel.cs
+++ b/src/DataGridSample/ViewModels/SelectionModelItemSelectionViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.Selection;
@@ -56,6 +57,8 @@ namespace DataGridSample.ViewModels
             SelectRootCommand = new RelayCommand(_ => SelectItem(Roots.Count > 0 ? Roots[0] : null));
             SelectDeepItemCommand = new RelayCommand(_ => SelectItem(_deepItem));
             SelectSiblingPairCommand = new RelayCommand(_ => SelectSiblings());
+            SelectRangeCommand = new RelayCommand(_ => SelectRange());
+            SelectItemsCommand = new RelayCommand(_ => SelectItems());
             ClearSelectionCommand = new RelayCommand(_ => SelectionModel.Clear());
         }
 
@@ -70,6 +73,10 @@ namespace DataGridSample.ViewModels
         public RelayCommand SelectDeepItemCommand { get; }
 
         public RelayCommand SelectSiblingPairCommand { get; }
+
+        public RelayCommand SelectRangeCommand { get; }
+
+        public RelayCommand SelectItemsCommand { get; }
 
         public RelayCommand ClearSelectionCommand { get; }
 
@@ -106,6 +113,60 @@ namespace DataGridSample.ViewModels
                 {
                     SelectionModel.Select(siblings[i]);
                 }
+            }
+        }
+
+        private void SelectRange()
+        {
+            if (SelectionModel.Source == null || Roots.Count == 0 || _deepItem == null)
+            {
+                return;
+            }
+
+            var start = Roots[0].Children.Count > 0 ? Roots[0].Children[0] : Roots[0];
+            using (SelectionModel.BatchUpdate())
+            {
+                SelectionModel.Clear();
+                SelectionModel.SelectRange(start, _deepItem);
+            }
+        }
+
+        private void SelectItems()
+        {
+            if (SelectionModel.Source == null || Roots.Count == 0)
+            {
+                return;
+            }
+
+            var items = new List<TreeItem>
+            {
+                Roots[0]
+            };
+
+            if (Roots[0].Children.Count > 0)
+            {
+                items.Add(Roots[0].Children[0]);
+            }
+
+            if (_deepItem != null)
+            {
+                items.Add(_deepItem);
+            }
+
+            if (Roots.Count > 1)
+            {
+                items.Add(Roots[Roots.Count - 1]);
+            }
+
+            if (items.Count == 0)
+            {
+                return;
+            }
+
+            using (SelectionModel.BatchUpdate())
+            {
+                SelectionModel.Clear();
+                SelectionModel.SelectRange(items);
             }
         }
 


### PR DESCRIPTION
# SelectionModel item-based SelectRange

## What changed
- Added item-based SelectRange overloads to `ISelectionModel` extensions:
  - `SelectRange(item, item)` resolves each item against `SelectionModel.Source`, normalizes reversed ranges, and applies `SelectRange(start, end)`.
  - `SelectRange(IEnumerable items)` materializes the list (if needed), resolves each item to an index, and selects all indices in a batch update.
- Both overloads support hierarchical node items by matching `IHierarchicalNodeItem.Item` and handle single-select scenarios by setting the final selected item/index.
- Both overloads throw when items are not found in the source and when multi-select is requested without a `Source`.

## Samples
- Extended the SelectionModel item selection sample to demonstrate:
  - Range selection between two items.
  - Selecting a specific list of items in one call.
  - Updated UI text to mention both overloads and added buttons/commands for each scenario.

## Tests
- Added unit tests for:
  - Range selection by two items (flat + hierarchical sources).
  - Range selection by item list (flat + hierarchical sources).
  - Missing item behavior.
  - Null source behavior for single-select and multi-select cases.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/156