### PR TITLE
Add severity-aware validation

### DIFF
--- a/docfx/articles/validation-and-errors.md
+++ b/docfx/articles/validation-and-errors.md
@@ -25,6 +25,50 @@ public string Name
 }
 ```
 
+## Severity Levels
+
+Use `DataGridValidationResult` to distinguish blocking errors from non-blocking warnings and info messages. Errors prevent commit; warnings and info allow commit but keep the cell highlighted.
+
+```csharp
+using Avalonia.Controls;
+using Avalonia.Data;
+
+public int Risk
+{
+    get => _risk;
+    set
+    {
+        _risk = value;
+        OnPropertyChanged();
+
+        if (value >= 8)
+        {
+            throw new DataValidationException(
+                new DataGridValidationResult("Risk of 8+ is a warning.", DataGridValidationSeverity.Warning));
+        }
+    }
+}
+```
+
+## Style Warning and Info States
+
+Warning and info states are exposed as `:warning` and `:info` on `DataGridCell`:
+
+```xml
+<Style Selector="DataGridCell:warning">
+  <Setter Property="BorderBrush" Value="#F59E0B" />
+  <Setter Property="BorderThickness" Value="1" />
+</Style>
+
+<Style Selector="DataGridCell:info">
+  <Setter Property="BorderBrush" Value="#22C55E" />
+  <Setter Property="BorderThickness" Value="1" />
+</Style>
+
+```
+
+Built-in DataValidationErrors themes include `DataGridCellDataValidationErrorsTheme`, `DataGridCellDataValidationWarningsTheme`, and `DataGridCellDataValidationInfoTheme`. Warning/info cells surface the same inline indicator and tooltip as errors.
+
 ## Style Invalid Rows and Cells
 
 Invalid rows and cells expose the `:invalid` pseudo-class:
@@ -44,4 +88,4 @@ You can also restyle the `DataValidationErrors` theme used by cell templates via
 
 ## Sample Reference
 
-See the `Validation` page in `src/DataGridSample` for validation across every editable column type (numeric, date/time, masked text, combo boxes, toggles, hyperlinks, and more).
+See the `Validation` page in `src/DataGridSample` for validation across every editable column type (numeric, date/time, masked text, combo boxes, toggles, hyperlinks, and more) and `Validation Styling` for severity-based warnings/info.

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
@@ -245,6 +245,10 @@ public class DataGridInputNavigationTests
     public void WaitForLostFocus_Defers_KeyHandlers()
     {
         var (grid, _) = CreateGrid();
+        var firstColumn = grid.ColumnsInternal[0] as DataGridTextColumn;
+        Assert.NotNull(firstColumn);
+        firstColumn!.Binding = null;
+        grid.UpdateLayout();
         SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
         var editingElement = BeginEditAndFocus(grid);
         grid.Focusable = false;
@@ -274,6 +278,26 @@ public class DataGridInputNavigationTests
             Assert.True(handled);
             Assert.NotEmpty(lostFocusQueue);
         }
+    }
+
+    [AvaloniaFact]
+    public void WaitForLostFocus_Does_Not_Defer_For_Explicit_Binding()
+    {
+        var (grid, _) = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        var editingElement = BeginEditAndFocus(grid);
+        grid.Focusable = false;
+
+        SetFocusedObject(grid, editingElement);
+        SetExecutingLostFocusActions(grid, false);
+
+        var lostFocusQueue = GetLostFocusActions(grid);
+        lostFocusQueue.Clear();
+
+        var handled = InvokeKeyHandler(grid, "ProcessTabKey", Key.Tab, KeyModifiers.None);
+
+        Assert.True(handled);
+        Assert.Empty(lostFocusQueue);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
@@ -532,6 +532,21 @@ public class DataGridKeyboardInputTests
     }
 
     [AvaloniaFact]
+    public void F2_Starts_Edit_On_NewItemPlaceholder()
+    {
+        var (grid, items) = CreateGrid(rowCount: 2, canUserAddRows: true);
+        var slot = grid.SlotFromRowIndex(items.Count);
+        grid.UpdateSelectionAndCurrency(columnIndex: 0, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false);
+        grid.UpdateLayout();
+
+        var args = PressKey(grid, Key.F2);
+
+        Assert.True(args.Handled);
+        Assert.Equal(0, grid.EditingColumnIndex);
+        Assert.NotNull(grid.EditingRow);
+    }
+
+    [AvaloniaFact]
     public void F2_Starts_Edit_When_Alt_Pressed()
     {
         var (grid, _) = CreateGrid();
@@ -625,7 +640,8 @@ public class DataGridKeyboardInputTests
         DataGridSelectionMode selectionMode = DataGridSelectionMode.Extended,
         bool autoGenerateColumns = false,
         bool addColumns = true,
-        bool canUserDeleteRows = false)
+        bool canUserDeleteRows = false,
+        bool canUserAddRows = false)
     {
         var items = new ObservableCollection<RowItem>();
         for (var i = 0; i < rowCount; i++)
@@ -646,7 +662,7 @@ public class DataGridKeyboardInputTests
             ItemsSource = items,
             SelectionMode = selectionMode,
             SelectionUnit = selectionUnit,
-            CanUserAddRows = false,
+            CanUserAddRows = canUserAddRows,
             CanUserDeleteRows = canUserDeleteRows,
             AutoGenerateColumns = autoGenerateColumns
         };

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
@@ -353,6 +353,8 @@ public class DataGridThemeResourceCoverageTests
 
         yield return new ResourceExpectation("DataGridGridLinesVisibility", typeof(DataGridGridLinesVisibility));
         yield return new ResourceExpectation("DataGridCellDataValidationErrorsTheme", typeof(IStyle));
+        yield return new ResourceExpectation("DataGridCellDataValidationWarningsTheme", typeof(IStyle));
+        yield return new ResourceExpectation("DataGridCellDataValidationInfoTheme", typeof(IStyle));
     }
 
     private static readonly ControlThemeExpectation[] GenericControlThemeExpectations =
@@ -361,6 +363,8 @@ public class DataGridThemeResourceCoverageTests
         new("DataGridFilterButtonTheme", typeof(Button)),
         new("DataGridFilterButtonFilteredTheme", typeof(Button)),
         new("DataGridCellDataValidationErrorsTheme", typeof(DataValidationErrors)),
+        new("DataGridCellDataValidationWarningsTheme", typeof(DataValidationErrors)),
+        new("DataGridCellDataValidationInfoTheme", typeof(DataValidationErrors)),
         new("DataGridCellTextBlockTheme", typeof(TextBlock)),
         new("DataGridCellTextBoxTheme", typeof(TextBox)),
         new("DataGridCellAutoCompleteTextBlockTheme", typeof(TextBlock)),
@@ -431,6 +435,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridRowGroupHeaderHoveredBackgroundBrush",
         "DataGridRowHoveredBackgroundBrush",
         "DataGridRowInvalidBrush",
+        "DataGridRowWarningBrush",
+        "DataGridRowInfoBrush",
         "DataGridRowSelectedBackgroundBrush",
         "DataGridRowSelectedHoveredBackgroundBrush",
         "DataGridRowSelectedUnfocusedBackgroundBrush",
@@ -438,6 +444,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridCellFocusVisualPrimaryBrush",
         "DataGridCellFocusVisualSecondaryBrush",
         "DataGridCellInvalidBrush",
+        "DataGridCellWarningBrush",
+        "DataGridCellInfoBrush",
         "DataGridGridLinesBrush",
         "DataGridDetailsPresenterBackgroundBrush",
         "DataGridRowBackgroundBrush",
@@ -514,6 +522,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridRowGroupHeaderHoveredBackgroundBrush",
         "DataGridRowHoveredBackgroundBrush",
         "DataGridRowInvalidBrush",
+        "DataGridRowWarningBrush",
+        "DataGridRowInfoBrush",
         "DataGridRowDropIndicatorBrush",
         "DataGridRowSelectedBackgroundBrush",
         "DataGridRowSelectedHoveredBackgroundBrush",
@@ -522,6 +532,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridCellFocusVisualPrimaryBrush",
         "DataGridCellFocusVisualSecondaryBrush",
         "DataGridCellInvalidBrush",
+        "DataGridCellWarningBrush",
+        "DataGridCellInfoBrush",
         "DataGridGridLinesBrush",
         "DataGridDetailsPresenterBackgroundBrush",
         "DataGridSummaryRowBackgroundBrush",

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Utils/ValidationUtilTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Utils/ValidationUtilTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
+using Avalonia.Controls;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Xunit;
@@ -130,6 +131,41 @@ namespace Avalonia.Controls.DataGridTests.Utils
             var result = ValidationUtil.UnpackDataValidationException(exception);
 
             Assert.Same(exception, result);
+        }
+
+        [Fact]
+        public void GetValidationSeverity_Uses_DataGridValidationResult_Severity()
+        {
+            var warning = new DataValidationException(new DataGridValidationResult("warning", DataGridValidationSeverity.Warning));
+
+            var result = ValidationUtil.GetValidationSeverity(warning);
+
+            Assert.Equal(DataGridValidationSeverity.Warning, result);
+        }
+
+        [Fact]
+        public void GetValidationSeverity_Uses_Strongest_Severity_From_Enumerable()
+        {
+            var results = new[]
+            {
+                new DataGridValidationResult("info", DataGridValidationSeverity.Info),
+                new DataGridValidationResult("warning", DataGridValidationSeverity.Warning)
+            };
+            var exception = new DataValidationException(results);
+
+            var result = ValidationUtil.GetValidationSeverity(exception);
+
+            Assert.Equal(DataGridValidationSeverity.Warning, result);
+        }
+
+        [Fact]
+        public void GetValidationSeverity_Defaults_To_Error_For_String_Data()
+        {
+            var exception = new DataValidationException("error");
+
+            var result = ValidationUtil.GetValidationSeverity(exception);
+
+            Assert.Equal(DataGridValidationSeverity.Error, result);
         }
 
         [Fact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -10,7 +11,9 @@ using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Core.Plugins;
 using Avalonia.Headless.XUnit;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
@@ -20,6 +23,11 @@ namespace Avalonia.Controls.DataGridTests;
 
 public class DataGridValidationTests
 {
+    static DataGridValidationTests()
+    {
+        EnsureValidationPlugins();
+    }
+
     [AvaloniaFact]
     public void Invalid_edit_marks_grid_row_and_cell()
     {
@@ -39,6 +47,7 @@ public class DataGridValidationTests
             var textBox = Assert.IsType<TextBox>(cell.Content);
 
             textBox.Text = string.Empty;
+            UpdateEditingElementSource(textBox);
             Assert.False(grid.CommitEdit());
             grid.UpdateLayout();
 
@@ -47,10 +56,10 @@ public class DataGridValidationTests
             Assert.False(row.IsValid);
             Assert.True(((IPseudoClasses)cell.Classes).Contains(":invalid"));
             Assert.True(((IPseudoClasses)row.Classes).Contains(":invalid"));
-            Assert.True(DataValidationErrors.GetHasErrors(textBox));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
 
             textBox.Text = "Valid";
-            Assert.True(grid.CommitEdit());
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
             grid.UpdateLayout();
 
             Assert.True(grid.IsValid);
@@ -59,6 +68,379 @@ public class DataGridValidationTests
             Assert.False(((IPseudoClasses)cell.Classes).Contains(":invalid"));
             Assert.False(((IPseudoClasses)row.Classes).Contains(":invalid"));
             Assert.False(DataValidationErrors.GetHasErrors(textBox));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Cancel_edit_clears_validation_errors_on_cell()
+    {
+        var (grid, root, item, column) = CreateTextValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = string.Empty;
+            UpdateEditingElementSource(textBox);
+            Assert.False(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+            Assert.False(DataValidationErrors.GetHasErrors(textBox));
+
+            Assert.True(grid.CancelEdit(DataGridEditingUnit.Cell));
+            grid.UpdateLayout();
+
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+            Assert.False(DataValidationErrors.GetHasErrors(textBox));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Warning_edit_allows_commit_and_marks_cell()
+    {
+        var (grid, root, item, column) = CreateWarningValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var row = FindRow(grid, item);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.True(grid.IsValid);
+            Assert.True(cell.IsValid);
+            Assert.True(row.IsValid);
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)cell.Classes).Contains(":warning"));
+            Assert.Equal(DataGridValidationSeverity.None, row.ValidationSeverity);
+            Assert.False(((IPseudoClasses)row.Classes).Contains(":warning"));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+            Assert.False(DataValidationErrors.GetHasErrors(textBox));
+
+            var validation = cell.GetVisualDescendants().OfType<DataValidationErrors>().First();
+            Assert.True(grid.TryFindResource("DataGridCellDataValidationWarningsTheme", out var warningTheme));
+            Assert.Same(warningTheme, validation.Theme);
+
+            var errors = DataValidationErrors.GetErrors(cell)?.Cast<object>().ToList();
+            Assert.NotNull(errors);
+            Assert.Contains(errors!, error => ErrorContainsMessage(error, "Code should be at least 3"));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Info_edit_allows_commit_and_marks_cell()
+    {
+        var (grid, root, item, column) = CreateInfoValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var row = FindRow(grid, item);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = "info";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.True(grid.IsValid);
+            Assert.True(cell.IsValid);
+            Assert.True(row.IsValid);
+            Assert.Equal(DataGridValidationSeverity.Info, cell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)cell.Classes).Contains(":info"));
+            Assert.Equal(DataGridValidationSeverity.None, row.ValidationSeverity);
+            Assert.False(((IPseudoClasses)row.Classes).Contains(":info"));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+            Assert.False(DataValidationErrors.GetHasErrors(textBox));
+
+            var validation = cell.GetVisualDescendants().OfType<DataValidationErrors>().First();
+            Assert.True(grid.TryFindResource("DataGridCellDataValidationInfoTheme", out var infoTheme));
+            Assert.Same(infoTheme, validation.Theme);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Warning_validation_persists_after_selection_change()
+    {
+        var (grid, root, item, column) = CreateWarningValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            var descriptionColumn = grid.ColumnsInternal
+                .OfType<DataGridTextColumn>()
+                .First(c => c.Header?.ToString() == "Description");
+
+            Assert.True(grid.UpdateSelectionAndCurrency(descriptionColumn.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            var refreshedCell = FindCell(grid, item, column.Index);
+            var row = FindRow(grid, item);
+            Assert.Equal(DataGridValidationSeverity.Warning, refreshedCell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)refreshedCell.Classes).Contains(":warning"));
+            Assert.True(DataValidationErrors.GetHasErrors(refreshedCell));
+            Assert.Equal(DataGridValidationSeverity.None, row.ValidationSeverity);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Cancel_edit_restores_warning_state_for_exception_validation()
+    {
+        var (grid, root, item, column) = CreateWarningValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            var textBox = Assert.IsType<TextBox>(cell.Content);
+
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var editingCell = FindCell(grid, item, column.Index);
+            var editingTextBox = Assert.IsType<TextBox>(editingCell.Content);
+
+            editingTextBox.Text = "Valid";
+            UpdateEditingElementSource(editingTextBox);
+
+            Assert.True(grid.CancelEdit(DataGridEditingUnit.Cell));
+            grid.UpdateLayout();
+
+            var restoredCell = FindCell(grid, item, column.Index);
+            Assert.Equal(DataGridValidationSeverity.Warning, restoredCell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(restoredCell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Warning_edit_does_not_clear_existing_row_error()
+    {
+        var (grid, root, item, warningColumn) = CreateWarningValidationGrid();
+
+        try
+        {
+            var row = FindRow(grid, item);
+            var descriptionColumn = grid.ColumnsInternal
+                .OfType<DataGridTextColumn>()
+                .First(c => c.Header?.ToString() == "Description");
+            var errorCell = FindCell(grid, item, descriptionColumn.Index);
+
+            errorCell.IsValid = false;
+            errorCell.ValidationSeverity = DataGridValidationSeverity.Error;
+            errorCell.UpdatePseudoClasses();
+            DataValidationErrors.SetError(errorCell, new InvalidOperationException("Existing row error."));
+
+            row.IsValid = false;
+            row.ValidationSeverity = DataGridValidationSeverity.Error;
+            row.ApplyState();
+
+            Assert.False(errorCell.IsValid);
+            Assert.False(row.IsValid);
+
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(warningColumn.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var warningCell = FindCell(grid, item, warningColumn.Index);
+            var textBox = Assert.IsType<TextBox>(warningCell.Content);
+
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            grid.UpdateLayout();
+
+            Assert.False(row.IsValid);
+            Assert.Equal(DataGridValidationSeverity.Error, row.ValidationSeverity);
+            Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void INotifyDataErrorInfo_preserves_DataValidationException_severity()
+    {
+        var (grid, root, item, column) = CreateExceptionNotifyValidationGrid();
+
+        try
+        {
+            var cell = FindCell(grid, item, column.Index);
+
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void INotifyDataErrorInfo_validation_restores_on_row_recycle()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid();
+
+        try
+        {
+            var cell = FindCell(grid, item, column.Index);
+            var row = FindRow(grid, item);
+
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)cell.Classes).Contains(":warning"));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+            Assert.Equal(DataGridValidationSeverity.None, row.ValidationSeverity);
+
+            grid.NotifyRowRecycling(row);
+            Assert.Equal(DataGridValidationSeverity.None, row.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+            grid.NotifyRowPrepared(row, item);
+            grid.UpdateLayout();
+
+            var restoredCell = FindCell(grid, item, column.Index);
+            var restoredRow = FindRow(grid, item);
+
+            Assert.Equal(DataGridValidationSeverity.Warning, restoredCell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)restoredCell.Classes).Contains(":warning"));
+            Assert.True(DataValidationErrors.GetHasErrors(restoredCell));
+            Assert.Equal(DataGridValidationSeverity.None, restoredRow.ValidationSeverity);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Grid_invalid_when_offscreen_item_has_error()
+    {
+        var (grid, root, errorItem, items) = CreateOffscreenErrorValidationGrid();
+
+        try
+        {
+            var realizedRows = grid.GetVisualDescendants().OfType<DataGridRow>().ToList();
+
+            Assert.True(realizedRows.Count < items.Count);
+            Assert.DoesNotContain(realizedRows, row => ReferenceEquals(row.DataContext, errorItem));
+            Assert.False(grid.IsValid);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Cancel_row_edit_restores_template_column_validation_for_indei()
+    {
+        var (grid, root, item, boundColumn, templateColumn) = CreateNotifyTemplateValidationGrid();
+
+        try
+        {
+            var templateCell = FindCell(grid, item, templateColumn.Index);
+            templateCell.IsValid = false;
+            templateCell.ValidationSeverity = DataGridValidationSeverity.Error;
+            templateCell.UpdatePseudoClasses();
+            DataValidationErrors.SetError(templateCell, new InvalidOperationException("Template validation error."));
+
+            Assert.True(DataValidationErrors.GetHasErrors(templateCell));
+
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(boundColumn.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            Assert.True(grid.CancelEdit(DataGridEditingUnit.Row));
+            grid.UpdateLayout();
+
+            var restoredCell = FindCell(grid, item, templateColumn.Index);
+            Assert.False(restoredCell.IsValid);
+            Assert.Equal(DataGridValidationSeverity.Error, restoredCell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(restoredCell));
         }
         finally
         {
@@ -122,19 +504,23 @@ public class DataGridValidationTests
                 var editingElement = Assert.IsAssignableFrom<Control>(cell.Content);
 
                 testCase.SetValue(editingElement, false);
+                UpdateEditingElementSource(editingElement);
 
                 Assert.False(grid.CommitEdit());
                 grid.UpdateLayout();
 
                 Assert.False(cell.IsValid);
-                Assert.True(DataValidationErrors.GetHasErrors(editingElement));
+                Assert.True(DataValidationErrors.GetHasErrors(cell));
+                Assert.False(DataValidationErrors.GetHasErrors(editingElement));
 
                 testCase.SetValue(editingElement, true);
+                UpdateEditingElementSource(editingElement);
 
-                Assert.True(grid.CommitEdit());
+                Assert.True(grid.CommitEdit(), $"Column '{column.Header}' should commit after a valid edit.");
                 grid.UpdateLayout();
 
                 Assert.True(cell.IsValid);
+                Assert.False(DataValidationErrors.GetHasErrors(cell));
                 Assert.False(DataValidationErrors.GetHasErrors(editingElement));
             }
         }
@@ -248,15 +634,310 @@ public class DataGridValidationTests
         var nameColumn = new DataGridTextColumn
         {
             Header = "Name",
-            Binding = new Binding(nameof(ValidationItem.Name))
+            Binding = TwoWayBinding(nameof(ValidationItem.Name))
         };
 
         grid.ColumnsInternal.Add(nameColumn);
         root.Content = grid;
         root.Show();
+        grid.ApplyTemplate();
         grid.UpdateLayout();
 
         return (grid, root, item, nameColumn);
+    }
+
+    private static (DataGrid grid, Window root, WarningValidationItem item, DataGridTextColumn column) CreateWarningValidationGrid()
+    {
+        var item = new WarningValidationItem
+        {
+            Code = "Alpha",
+            Description = "Primary"
+        };
+
+        var items = new ObservableCollection<WarningValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var codeColumn = new DataGridTextColumn
+        {
+            Header = "Code",
+            Binding = TwoWayBinding(nameof(WarningValidationItem.Code))
+        };
+
+        grid.ColumnsInternal.Add(codeColumn);
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Description",
+            Binding = TwoWayBinding(nameof(WarningValidationItem.Description))
+        });
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, codeColumn);
+    }
+
+    private static (DataGrid grid, Window root, InfoValidationItem item, DataGridTextColumn column) CreateInfoValidationGrid()
+    {
+        var item = new InfoValidationItem
+        {
+            Status = "OK"
+        };
+
+        var items = new ObservableCollection<InfoValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var statusColumn = new DataGridTextColumn
+        {
+            Header = "Status",
+            Binding = TwoWayBinding(nameof(InfoValidationItem.Status))
+        };
+
+        grid.ColumnsInternal.Add(statusColumn);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, statusColumn);
+    }
+
+    private static (DataGrid grid, Window root, NotifyValidationItem item, DataGridTextColumn column) CreateNotifyValidationGrid()
+    {
+        var item = new NotifyValidationItem
+        {
+            Code = "X"
+        };
+
+        var items = new ObservableCollection<NotifyValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var codeColumn = new DataGridTextColumn
+        {
+            Header = "Code",
+            Binding = TwoWayBinding(nameof(NotifyValidationItem.Code))
+        };
+
+        grid.ColumnsInternal.Add(codeColumn);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, codeColumn);
+    }
+
+    private static (DataGrid grid, Window root, MixedValidationItem errorItem, IReadOnlyList<MixedValidationItem> items) CreateOffscreenErrorValidationGrid()
+    {
+        var items = new ObservableCollection<MixedValidationItem>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            var item = new MixedValidationItem();
+            if (i < 29)
+            {
+                item.ErrorValue = "Ok";
+            }
+            items.Add(item);
+        }
+
+        var errorItem = items[^1];
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 140
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false,
+            Height = 80
+        };
+
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Error",
+            Binding = TwoWayBinding(nameof(MixedValidationItem.ErrorValue))
+        });
+
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, errorItem, items);
+    }
+
+    private static (DataGrid grid, Window root, EditableNotifyValidationItem item, DataGridTextColumn boundColumn, DataGridTemplateColumn templateColumn) CreateNotifyTemplateValidationGrid()
+    {
+        var item = new EditableNotifyValidationItem
+        {
+            Code = "Valid"
+        };
+
+        var items = new ObservableCollection<EditableNotifyValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 200
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var boundColumn = new DataGridTextColumn
+        {
+            Header = "Code",
+            Binding = TwoWayBinding(nameof(EditableNotifyValidationItem.Code))
+        };
+
+        var templateColumn = new DataGridTemplateColumn
+        {
+            Header = "Template",
+            CellTemplate = new FuncDataTemplate<EditableNotifyValidationItem>((_, _) => new TextBlock { Text = "Template" })
+        };
+
+        grid.ColumnsInternal.Add(boundColumn);
+        grid.ColumnsInternal.Add(templateColumn);
+
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, boundColumn, templateColumn);
+    }
+
+    private static (DataGrid grid, Window root, MixedValidationItem item, DataGridTextColumn errorColumn, DataGridTextColumn warningColumn) CreateMixedValidationGrid()
+    {
+        var item = new MixedValidationItem
+        {
+            WarningValue = "Okay"
+        };
+
+        var items = new ObservableCollection<MixedValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var errorColumn = new DataGridTextColumn
+        {
+            Header = "Error",
+            Binding = TwoWayBinding(nameof(MixedValidationItem.ErrorValue))
+        };
+
+        var warningColumn = new DataGridTextColumn
+        {
+            Header = "Warning",
+            Binding = TwoWayBinding(nameof(MixedValidationItem.WarningValue))
+        };
+
+        grid.ColumnsInternal.Add(errorColumn);
+        grid.ColumnsInternal.Add(warningColumn);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, errorColumn, warningColumn);
+    }
+
+    private static (DataGrid grid, Window root, ExceptionNotifyValidationItem item, DataGridTextColumn column) CreateExceptionNotifyValidationGrid()
+    {
+        var item = new ExceptionNotifyValidationItem
+        {
+            Code = "X"
+        };
+
+        var items = new ObservableCollection<ExceptionNotifyValidationItem> { item };
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+
+        root.SetThemeStyles(DataGridTheme.Simple);
+
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false
+        };
+
+        var codeColumn = new DataGridTextColumn
+        {
+            Header = "Code",
+            Binding = TwoWayBinding(nameof(ExceptionNotifyValidationItem.Code))
+        };
+
+        grid.ColumnsInternal.Add(codeColumn);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        return (grid, root, item, codeColumn);
     }
 
     private static (DataGrid grid, Window root, ValidationItem item) CreateValidationGrid()
@@ -296,13 +977,13 @@ public class DataGridValidationTests
         grid.ColumnsInternal.Add(new DataGridTextColumn
         {
             Header = "Name",
-            Binding = new Binding(nameof(ValidationItem.Name))
+            Binding = TwoWayBinding(nameof(ValidationItem.Name))
         });
 
         grid.ColumnsInternal.Add(new DataGridAutoCompleteColumn
         {
             Header = "Category",
-            Binding = new Binding(nameof(ValidationItem.Category)),
+            Binding = TwoWayBinding(nameof(ValidationItem.Category)),
             ItemsSource = Categories,
             FilterMode = AutoCompleteFilterMode.Contains,
             MinimumPrefixLength = 1
@@ -313,20 +994,20 @@ public class DataGridValidationTests
             Header = "Status",
             ItemsSource = Statuses,
             IsEditable = true,
-            TextBinding = new Binding(nameof(ValidationItem.Status))
+            TextBinding = TwoWayBinding(nameof(ValidationItem.Status))
         });
 
         grid.ColumnsInternal.Add(new DataGridMaskedTextColumn
         {
             Header = "Phone",
-            Binding = new Binding(nameof(ValidationItem.Phone)),
+            Binding = TwoWayBinding(nameof(ValidationItem.Phone)),
             Mask = "(000) 000-0000"
         });
 
         grid.ColumnsInternal.Add(new DataGridNumericColumn
         {
             Header = "Price",
-            Binding = new Binding(nameof(ValidationItem.Price)),
+            Binding = TwoWayBinding(nameof(ValidationItem.Price)),
             Minimum = 0,
             Maximum = 500,
             Increment = 1
@@ -335,21 +1016,21 @@ public class DataGridValidationTests
         grid.ColumnsInternal.Add(new DataGridDatePickerColumn
         {
             Header = "Due",
-            Binding = new Binding(nameof(ValidationItem.DueDate)),
+            Binding = TwoWayBinding(nameof(ValidationItem.DueDate)),
             SelectedDateFormat = CalendarDatePickerFormat.Short
         });
 
         grid.ColumnsInternal.Add(new DataGridTimePickerColumn
         {
             Header = "Start",
-            Binding = new Binding(nameof(ValidationItem.StartTime)),
+            Binding = TwoWayBinding(nameof(ValidationItem.StartTime)),
             ClockIdentifier = "24HourClock"
         });
 
         grid.ColumnsInternal.Add(new DataGridSliderColumn
         {
             Header = "Rating",
-            Binding = new Binding(nameof(ValidationItem.Rating)),
+            Binding = TwoWayBinding(nameof(ValidationItem.Rating)),
             Minimum = 0,
             Maximum = 5,
             TickFrequency = 0.5,
@@ -359,47 +1040,158 @@ public class DataGridValidationTests
         grid.ColumnsInternal.Add(new DataGridToggleSwitchColumn
         {
             Header = "Active",
-            Binding = new Binding(nameof(ValidationItem.IsActive))
+            Binding = TwoWayBinding(nameof(ValidationItem.IsActive))
         });
 
         grid.ColumnsInternal.Add(new DataGridToggleButtonColumn
         {
             Header = "Pinned",
-            Binding = new Binding(nameof(ValidationItem.IsPinned))
+            Binding = TwoWayBinding(nameof(ValidationItem.IsPinned))
         });
 
         grid.ColumnsInternal.Add(new DataGridCheckBoxColumn
         {
             Header = "Approved",
-            Binding = new Binding(nameof(ValidationItem.IsApproved))
+            Binding = TwoWayBinding(nameof(ValidationItem.IsApproved))
         });
 
         grid.ColumnsInternal.Add(new DataGridHyperlinkColumn
         {
             Header = "Website",
-            Binding = new Binding(nameof(ValidationItem.Website)),
-            ContentBinding = new Binding(nameof(ValidationItem.Website))
+            Binding = TwoWayBinding(nameof(ValidationItem.Website)),
+            ContentBinding = TwoWayBinding(nameof(ValidationItem.Website))
         });
 
         root.Content = grid;
         root.Show();
+        grid.ApplyTemplate();
         grid.UpdateLayout();
 
         return (grid, root, item);
     }
 
-    private static DataGridCell FindCell(DataGrid grid, ValidationItem item, int columnIndex)
+    private static DataGridCell FindCell(DataGrid grid, object item, int columnIndex)
     {
         return grid.GetVisualDescendants()
             .OfType<DataGridCell>()
             .First(cell => cell.OwningColumn?.Index == columnIndex && ReferenceEquals(cell.DataContext, item));
     }
 
-    private static DataGridRow FindRow(DataGrid grid, ValidationItem item)
+    private static DataGridRow FindRow(DataGrid grid, object item)
     {
         return grid.GetVisualDescendants()
             .OfType<DataGridRow>()
             .First(row => ReferenceEquals(row.DataContext, item));
+    }
+
+    private static Binding TwoWayBinding(string path)
+    {
+        return new Binding(path)
+        {
+            Mode = BindingMode.TwoWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+        };
+    }
+
+    private static void UpdateEditingElementSource(Control editingElement)
+    {
+        switch (editingElement)
+        {
+            case MaskedTextBox masked:
+                BindingOperations.GetBindingExpressionBase(masked, MaskedTextBox.TextProperty)?.UpdateSource();
+                break;
+            case TextBox textBox:
+                BindingOperations.GetBindingExpressionBase(textBox, TextBox.TextProperty)?.UpdateSource();
+                break;
+            case AutoCompleteBox autoComplete:
+                BindingOperations.GetBindingExpressionBase(autoComplete, AutoCompleteBox.TextProperty)?.UpdateSource();
+                break;
+            case ComboBox comboBox:
+                BindingOperations.GetBindingExpressionBase(comboBox, ComboBox.TextProperty)?.UpdateSource();
+                BindingOperations.GetBindingExpressionBase(comboBox, SelectingItemsControl.SelectedItemProperty)?.UpdateSource();
+                BindingOperations.GetBindingExpressionBase(comboBox, SelectingItemsControl.SelectedValueProperty)?.UpdateSource();
+                break;
+            case NumericUpDown numeric:
+                BindingOperations.GetBindingExpressionBase(numeric, NumericUpDown.ValueProperty)?.UpdateSource();
+                break;
+            case CalendarDatePicker datePicker:
+                BindingOperations.GetBindingExpressionBase(datePicker, CalendarDatePicker.SelectedDateProperty)?.UpdateSource();
+                break;
+            case TimePicker timePicker:
+                BindingOperations.GetBindingExpressionBase(timePicker, TimePicker.SelectedTimeProperty)?.UpdateSource();
+                break;
+            case Slider slider:
+                BindingOperations.GetBindingExpressionBase(slider, Slider.ValueProperty)?.UpdateSource();
+                break;
+            case ToggleSwitch toggleSwitch:
+                BindingOperations.GetBindingExpressionBase(toggleSwitch, ToggleSwitch.IsCheckedProperty)?.UpdateSource();
+                break;
+            case ToggleButton toggleButton:
+                BindingOperations.GetBindingExpressionBase(toggleButton, ToggleButton.IsCheckedProperty)?.UpdateSource();
+                break;
+        }
+    }
+
+    private static void EnsureValidationPlugins()
+    {
+        var validators = BindingPlugins.DataValidators;
+
+        if (!validators.Any(plugin => plugin is ExceptionValidationPlugin))
+        {
+            validators.Add(new ExceptionValidationPlugin());
+        }
+
+        if (!validators.Any(plugin => plugin is IndeiValidationPlugin))
+        {
+            validators.Add(new IndeiValidationPlugin());
+        }
+    }
+
+    private static bool ErrorContainsMessage(object? error, string message)
+    {
+        if (error is null)
+        {
+            return false;
+        }
+
+        if (error is DataGridValidationResult result)
+        {
+            return result.Message.Contains(message, StringComparison.Ordinal);
+        }
+
+        if (error is DataValidationException dataValidationException)
+        {
+            return ErrorContainsMessage(dataValidationException.ErrorData, message);
+        }
+
+        if (error is AggregateException aggregateException)
+        {
+            foreach (var inner in aggregateException.InnerExceptions)
+            {
+                if (ErrorContainsMessage(inner, message))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (error is Exception exception)
+        {
+            return exception.Message.Contains(message, StringComparison.Ordinal);
+        }
+
+        if (error is IEnumerable enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                if (ErrorContainsMessage(item, message))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static DateTime NextWeekday(DateTime date)
@@ -629,6 +1421,371 @@ public class DataGridValidationTests
             {
                 throw new DataValidationException(message);
             }
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class WarningValidationItem : INotifyPropertyChanged
+    {
+        private string _code = string.Empty;
+        private string? _description;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string Code
+        {
+            get => _code;
+            set
+            {
+                if (!SetProperty(ref _code, value))
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(value) || value.Length < 3)
+                {
+                    throw new DataValidationException(new DataGridValidationResult("Code should be at least 3 characters.", DataGridValidationSeverity.Warning));
+                }
+            }
+        }
+
+        public string? Description
+        {
+            get => _description;
+            set => SetProperty(ref _description, value);
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class InfoValidationItem : INotifyPropertyChanged
+    {
+        private string _status = string.Empty;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string Status
+        {
+            get => _status;
+            set
+            {
+                if (!SetProperty(ref _status, value))
+                {
+                    return;
+                }
+
+                if (string.Equals(value, "info", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new DataValidationException(new DataGridValidationResult("Status is informational.", DataGridValidationSeverity.Info));
+                }
+            }
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class NotifyValidationItem : INotifyPropertyChanged, INotifyDataErrorInfo
+    {
+        private string _code = string.Empty;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public string Code
+        {
+            get => _code;
+            set
+            {
+                if (SetProperty(ref _code, value))
+                {
+                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Code)));
+                }
+            }
+        }
+
+        public bool HasErrors => string.IsNullOrWhiteSpace(_code) || _code.Length < 3;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName) || propertyName == nameof(Code))
+            {
+                if (string.IsNullOrWhiteSpace(_code) || _code.Length < 3)
+                {
+                    return new[]
+                    {
+                        new DataGridValidationResult("Code should be at least 3 characters.", DataGridValidationSeverity.Warning)
+                    };
+                }
+            }
+
+            return Array.Empty<object>();
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class EditableNotifyValidationItem : INotifyPropertyChanged, INotifyDataErrorInfo, IEditableObject
+    {
+        private string _code = string.Empty;
+        private string? _originalCode;
+        private bool _isEditing;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public string Code
+        {
+            get => _code;
+            set
+            {
+                if (SetProperty(ref _code, value))
+                {
+                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Code)));
+                }
+            }
+        }
+
+        public bool HasErrors => string.IsNullOrWhiteSpace(_code) || _code.Length < 3;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName) || propertyName == nameof(Code))
+            {
+                if (string.IsNullOrWhiteSpace(_code) || _code.Length < 3)
+                {
+                    return new[]
+                    {
+                        new DataGridValidationResult("Code should be at least 3 characters.", DataGridValidationSeverity.Warning)
+                    };
+                }
+            }
+
+            return Array.Empty<object>();
+        }
+
+        public void BeginEdit()
+        {
+            if (_isEditing)
+            {
+                return;
+            }
+
+            _originalCode = _code;
+            _isEditing = true;
+        }
+
+        public void CancelEdit()
+        {
+            if (!_isEditing)
+            {
+                return;
+            }
+
+            Code = _originalCode ?? string.Empty;
+            _originalCode = null;
+            _isEditing = false;
+        }
+
+        public void EndEdit()
+        {
+            _originalCode = null;
+            _isEditing = false;
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class MixedValidationItem : INotifyPropertyChanged, INotifyDataErrorInfo
+    {
+        private readonly Dictionary<string, List<object>> _errors = new();
+        private string _errorValue = string.Empty;
+        private string _warningValue = string.Empty;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public MixedValidationItem()
+        {
+            SetError(nameof(ErrorValue),
+                new DataGridValidationResult("Error value is required.", DataGridValidationSeverity.Error));
+        }
+
+        public string ErrorValue
+        {
+            get => _errorValue;
+            set
+            {
+                if (!SetProperty(ref _errorValue, value))
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    SetError(nameof(ErrorValue),
+                        new DataGridValidationResult("Error value is required.", DataGridValidationSeverity.Error));
+                }
+                else
+                {
+                    SetError(nameof(ErrorValue), null);
+                }
+            }
+        }
+
+        public string WarningValue
+        {
+            get => _warningValue;
+            set
+            {
+                if (!SetProperty(ref _warningValue, value))
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(value) || value.Length < 3)
+                {
+                    throw new DataValidationException(
+                        new DataGridValidationResult("Warning value should be at least 3 characters.", DataGridValidationSeverity.Warning));
+                }
+            }
+        }
+
+        public bool HasErrors => _errors.Count > 0;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (propertyName is { } && _errors.TryGetValue(propertyName, out var errorList))
+            {
+                return errorList;
+            }
+
+            return Array.Empty<object>();
+        }
+
+        private void SetError(string propertyName, DataGridValidationResult? error)
+        {
+            if (error == null)
+            {
+                if (_errors.Remove(propertyName))
+                {
+                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+                }
+                return;
+            }
+
+            if (_errors.TryGetValue(propertyName, out var errorList))
+            {
+                errorList.Clear();
+                errorList.Add(error);
+            }
+            else
+            {
+                _errors.Add(propertyName, new List<object> { error });
+            }
+
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+
+    private sealed class ExceptionNotifyValidationItem : INotifyPropertyChanged, INotifyDataErrorInfo
+    {
+        private string _code = string.Empty;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public string Code
+        {
+            get => _code;
+            set
+            {
+                if (SetProperty(ref _code, value))
+                {
+                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Code)));
+                }
+            }
+        }
+
+        public bool HasErrors => string.IsNullOrWhiteSpace(_code) || _code.Length < 3;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName) || propertyName == nameof(Code))
+            {
+                if (string.IsNullOrWhiteSpace(_code) || _code.Length < 3)
+                {
+                    return new[]
+                    {
+                        new DataValidationException(
+                            new DataGridValidationResult("Code should be at least 3 characters.", DataGridValidationSeverity.Warning))
+                    };
+                }
+            }
+
+            return Array.Empty<object>();
         }
 
         private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -744,7 +744,10 @@ internal
                 // Enter behaves like down arrow - it commits the potential editing and goes down one cell.
                 if (!ProcessDownKeyInternal(false, ctrl))
                 {
-                    return false;
+                    if (EditingRow == null)
+                    {
+                        return false;
+                    }
                 }
             }
             else if (WaitForLostFocus(() => ProcessEnterKey(shift, ctrl)))

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Selection.cs
@@ -167,6 +167,11 @@ namespace Avalonia.Controls
                 return false;
             }
 
+            if (IsSlotPlaceholderRow(slot))
+            {
+                return _selectedItems.ContainsSlot(slot);
+            }
+
             if (_selectionModelAdapter != null && DataConnection?.CollectionView != null)
             {
                 int rowIndex = RowIndexFromSlot(slot);
@@ -185,6 +190,15 @@ namespace Avalonia.Controls
             if (rowIndex < 0)
             {
                 return false;
+            }
+
+            if (DataConnection != null)
+            {
+                int slot = SlotFromRowIndex(rowIndex);
+                if (slot >= 0 && IsSlotPlaceholderRow(slot))
+                {
+                    return _selectedItems.ContainsSlot(slot);
+                }
             }
 
             if (_selectionModelAdapter != null)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -4,9 +4,14 @@
 
 #nullable disable
 
+using Avalonia.Collections;
+using Avalonia.Controls.Utils;
 using Avalonia.Data;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Avalonia.Controls
 {
@@ -22,29 +27,304 @@ internal
     {
 
         //TODO Validation UI
-        private void ResetValidationStatus()
+        private void ResetValidationStatus(DataGridCell editingCell = null)
         {
             // Clear the invalid status of the Cell, Row and DataGrid
             if (EditingRow != null)
             {
-                EditingRow.IsValid = true;
                 if (EditingRow.Index != -1)
                 {
-                    foreach (DataGridCell cell in EditingRow.Cells)
+                    if (editingCell != null)
                     {
-                        if (!cell.IsValid)
+                        ClearCellValidation(editingCell);
+                    }
+                    else
+                    {
+                        foreach (DataGridCell cell in EditingRow.Cells)
                         {
-                            cell.IsValid = true;
-                            cell.UpdatePseudoClasses();
+                            ClearCellValidation(cell);
                         }
                     }
-                    EditingRow.ApplyState();
+                    UpdateRowValidationStateFromCells(EditingRow);
                 }
             }
-            IsValid = true;
+            UpdateGridValidationState();
 
             _validationSubscription?.Dispose();
             _validationSubscription = null;
+        }
+
+        private static void ClearCellValidation(DataGridCell cell)
+        {
+            if (!cell.IsValid || cell.ValidationSeverity != DataGridValidationSeverity.None)
+            {
+                cell.IsValid = true;
+                cell.ValidationSeverity = DataGridValidationSeverity.None;
+                cell.UpdatePseudoClasses();
+            }
+
+            DataValidationErrors.ClearErrors(cell);
+        }
+
+        private void RestoreRowValidationState(DataGridRow row, object item, bool clearIfNoIndei = true)
+        {
+            if (row is null)
+            {
+                return;
+            }
+
+            if (item is null || ReferenceEquals(item, DataGridCollectionView.NewItemPlaceholder))
+            {
+                ClearRowValidation(row);
+                return;
+            }
+
+            if (item is not INotifyDataErrorInfo notifyDataErrorInfo)
+            {
+                if (clearIfNoIndei)
+                {
+                    ClearRowValidation(row);
+                }
+                return;
+            }
+
+            foreach (var column in ColumnsItemsInternal)
+            {
+                if (column.Index < 0 || column.Index >= row.Cells.Count)
+                {
+                    continue;
+                }
+
+                var cell = row.Cells[column.Index];
+                var bindingPath = GetColumnBindingPath(column);
+
+                if (string.IsNullOrWhiteSpace(bindingPath))
+                {
+                    continue;
+                }
+
+                var errors = notifyDataErrorInfo.GetErrors(bindingPath);
+                if (errors is null)
+                {
+                    ClearCellValidation(cell);
+                    continue;
+                }
+
+                var exceptions = CreateValidationExceptions(errors);
+                if (exceptions.Count == 0)
+                {
+                    ClearCellValidation(cell);
+                    continue;
+                }
+
+                var severity = ValidationUtil.GetValidationSeverity(exceptions);
+                cell.IsValid = severity != DataGridValidationSeverity.Error;
+                cell.ValidationSeverity = severity;
+                cell.UpdatePseudoClasses();
+
+                var errorException = exceptions.Count == 1
+                    ? exceptions[0]
+                    : new AggregateException(exceptions);
+                DataValidationErrors.SetError(cell, errorException);
+            }
+
+            UpdateRowValidationStateFromCells(row);
+            UpdateGridValidationState();
+        }
+
+        private void ClearRowValidation(DataGridRow row)
+        {
+            if (row is null)
+            {
+                return;
+            }
+
+            row.IsValid = true;
+            row.ValidationSeverity = DataGridValidationSeverity.None;
+
+            foreach (DataGridCell cell in row.Cells)
+            {
+                ClearCellValidation(cell);
+            }
+
+            row.ApplyState();
+            UpdateGridValidationState();
+        }
+
+        private static bool RowHasError(DataGridRow row)
+        {
+            foreach (DataGridCell cell in row.Cells)
+            {
+                if (cell.ValidationSeverity == DataGridValidationSeverity.Error)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void UpdateRowValidationStateFromCells(DataGridRow row)
+        {
+            if (row is null)
+            {
+                return;
+            }
+
+            var hasError = RowHasError(row);
+            row.IsValid = !hasError;
+            row.ValidationSeverity = hasError ? DataGridValidationSeverity.Error : DataGridValidationSeverity.None;
+            row.ApplyState();
+        }
+
+        private void UpdateGridValidationState()
+        {
+            var hasError = false;
+
+            if (DisplayData != null)
+            {
+                for (int slot = DisplayData.FirstScrollingSlot;
+                    slot > -1 && slot <= DisplayData.LastScrollingSlot;
+                    slot++)
+                {
+                    if (DisplayData.GetDisplayedElement(slot) is DataGridRow row &&
+                        (!row.IsValid || row.ValidationSeverity == DataGridValidationSeverity.Error))
+                    {
+                        hasError = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasError && EditingRow != null && !EditingRow.IsValid)
+            {
+                hasError = true;
+            }
+
+            if (!hasError && CollectionViewHasError())
+            {
+                hasError = true;
+            }
+
+            IsValid = !hasError;
+        }
+
+        private bool CollectionViewHasError()
+        {
+            var collectionView = DataConnection?.CollectionView;
+            if (collectionView == null)
+            {
+                return false;
+            }
+
+            foreach (var item in collectionView)
+            {
+                if (item == null || ReferenceEquals(item, DataGridCollectionView.NewItemPlaceholder))
+                {
+                    continue;
+                }
+
+                if (item is not INotifyDataErrorInfo notifyDataErrorInfo || !notifyDataErrorInfo.HasErrors)
+                {
+                    continue;
+                }
+
+                if (ItemHasError(notifyDataErrorInfo))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ItemHasError(INotifyDataErrorInfo notifyDataErrorInfo)
+        {
+            foreach (var column in ColumnsItemsInternal)
+            {
+                var bindingPath = GetColumnBindingPath(column);
+                if (string.IsNullOrWhiteSpace(bindingPath))
+                {
+                    continue;
+                }
+
+                var errors = notifyDataErrorInfo.GetErrors(bindingPath);
+                if (errors is null)
+                {
+                    continue;
+                }
+
+                var exceptions = CreateValidationExceptions(errors);
+                if (exceptions.Count == 0)
+                {
+                    continue;
+                }
+
+                if (ValidationUtil.GetValidationSeverity(exceptions) == DataGridValidationSeverity.Error)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetBindingPath(IBinding binding)
+        {
+            if (binding is Binding avaloniaBinding)
+            {
+                return avaloniaBinding.Path;
+            }
+
+            if (binding is CompiledBindingExtension compiledBinding)
+            {
+                return compiledBinding.Path?.ToString();
+            }
+
+            return null;
+        }
+
+        private static string GetColumnBindingPath(DataGridColumn column)
+        {
+            if (column is DataGridBoundColumn boundColumn)
+            {
+                return boundColumn.Binding is { } binding
+                    ? GetBindingPath(binding)
+                    : null;
+            }
+
+            if (column is DataGridComboBoxColumn comboBoxColumn)
+            {
+                return comboBoxColumn.EffectiveBinding is { } binding
+                    ? GetBindingPath(binding)
+                    : null;
+            }
+
+            return null;
+        }
+
+        private static List<Exception> CreateValidationExceptions(IEnumerable errors)
+        {
+            var exceptions = new List<Exception>();
+
+            foreach (var error in errors)
+            {
+                if (error is null)
+                {
+                    continue;
+                }
+
+                if (error is Exception exception)
+                {
+                    exceptions.Add(exception);
+                }
+                else
+                {
+                    exceptions.Add(new DataValidationException(error));
+                }
+            }
+
+            return exceptions;
         }
 
         private List<Exception> _bindingValidationErrors;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -119,7 +119,9 @@ internal
             element.DataContext = item;
             element.IsPlaceholder = ReferenceEquals(item, DataGridCollectionView.NewItemPlaceholder);
             element.IsValid = true;
+            element.ValidationSeverity = DataGridValidationSeverity.None;
             element.ClearDragDropState();
+            RestoreRowValidationState(element, item);
         }
 
         /// <summary>
@@ -145,6 +147,7 @@ internal
 
             element.IsPlaceholder = false;
             element.ClearDragDropState();
+            ClearRowValidation(element);
             element.DataContext = null;
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls
     /// Represents an individual <see cref="T:Avalonia.Controls.DataGrid" /> cell.
     /// </summary>
     [TemplatePart(DATAGRIDCELL_elementRightGridLine, typeof(Rectangle))]
-    [PseudoClasses(":selected", ":current", ":edited", ":invalid", ":focus", ":searchmatch", ":searchcurrent")]
+    [PseudoClasses(":selected", ":current", ":edited", ":invalid", ":warning", ":info", ":focus", ":searchmatch", ":searchcurrent")]
 #if !DATAGRID_INTERNAL
 public
 #else
@@ -35,11 +35,17 @@ internal
         private DataGridRow _owningRow;
 
         bool _isValid = true;
+        DataGridValidationSeverity _validationSeverity = DataGridValidationSeverity.None;
 
         public static readonly DirectProperty<DataGridCell, bool> IsValidProperty =
             AvaloniaProperty.RegisterDirect<DataGridCell, bool>(
                 nameof(IsValid),
                 o => o.IsValid);
+
+        public static readonly DirectProperty<DataGridCell, DataGridValidationSeverity> ValidationSeverityProperty =
+            AvaloniaProperty.RegisterDirect<DataGridCell, DataGridValidationSeverity>(
+                nameof(ValidationSeverity),
+                o => o.ValidationSeverity);
 
         public static readonly DirectProperty<DataGridCell, DataGridColumn> OwningColumnProperty =
             AvaloniaProperty.RegisterDirect<DataGridCell, DataGridColumn>(
@@ -69,6 +75,12 @@ internal
         {
             get { return _isValid; }
             internal set { SetAndRaise(IsValidProperty, ref _isValid, value); }
+        }
+
+        public DataGridValidationSeverity ValidationSeverity
+        {
+            get { return _validationSeverity; }
+            internal set { SetAndRaise(ValidationSeverityProperty, ref _validationSeverity, value); }
         }
 
         /// <summary>
@@ -268,7 +280,9 @@ internal
             PseudoClassesHelper.Set(PseudoClasses, ":cell-selected", cellSelected);
             PseudoClassesHelper.Set(PseudoClasses, ":current", IsCurrent);
             PseudoClassesHelper.Set(PseudoClasses, ":edited", IsEdited);
-            PseudoClassesHelper.Set(PseudoClasses, ":invalid", !IsValid);
+            PseudoClassesHelper.Set(PseudoClasses, ":invalid", ValidationSeverity == DataGridValidationSeverity.Error);
+            PseudoClassesHelper.Set(PseudoClasses, ":warning", ValidationSeverity == DataGridValidationSeverity.Warning);
+            PseudoClassesHelper.Set(PseudoClasses, ":info", ValidationSeverity == DataGridValidationSeverity.Info);
             PseudoClassesHelper.Set(PseudoClasses, ":focus", OwningGrid.IsFocused && IsCurrent);
 
             bool isSearchMatch = false;

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
@@ -190,8 +190,13 @@ namespace Avalonia.Controls
             return GenerateElement(cell, dataItem);
         }
 
+        protected virtual void RefreshEditingElement(Control editingElement)
+        {
+        }
+
         internal object PrepareCellForEditInternal(Control editingElement, RoutedEventArgs editingEventArgs)
         {
+            RefreshEditingElement(editingElement);
             var result = PrepareCellForEdit(editingElement, editingEventArgs);
             editingElement.Focus();
 

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -55,6 +55,7 @@ internal
         private FlyoutBase _filterFlyout;
         private System.Collections.IComparer _customSortComparer;
 
+
         /// <summary>
         /// Routed event raised when the column header receives a pointer press.
         /// </summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.Layout.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.Layout.cs
@@ -155,7 +155,9 @@ namespace Avalonia.Controls
                 var isSelected = isSelectedOverride ?? (Slot != -1 && OwningGrid.GetRowSelection(Slot));
                 IsSelected = isSelected;
                 PseudoClassesHelper.Set(PseudoClasses, ":editing", IsEditing);
-                PseudoClassesHelper.Set(PseudoClasses, ":invalid", !IsValid);
+                PseudoClassesHelper.Set(PseudoClasses, ":invalid", ValidationSeverity == DataGridValidationSeverity.Error);
+                PseudoClassesHelper.Set(PseudoClasses, ":warning", ValidationSeverity == DataGridValidationSeverity.Warning);
+                PseudoClassesHelper.Set(PseudoClasses, ":info", ValidationSeverity == DataGridValidationSeverity.Info);
                 UpdateCurrentPseudoClass();
                 PseudoClassesHelper.Set(PseudoClasses, ":pointerover", IsMouseOver);
                 ApplyHeaderStatus();

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Controls
     [TemplatePart(DATAGRIDROW_elementDetails,        typeof(DataGridDetailsPresenter))]
     [TemplatePart(DATAGRIDROW_elementRoot,           typeof(Panel))]
     [TemplatePart(DATAGRIDROW_elementRowHeader,      typeof(DataGridRowHeader))]
-    [PseudoClasses(":selected", ":editing", ":invalid", ":current", ":pointerover", ":dragging", ":drag-over-before", ":drag-over-after", ":drag-over-inside", ":placeholder", ":searchmatch", ":searchcurrent")]
+    [PseudoClasses(":selected", ":editing", ":invalid", ":warning", ":info", ":current", ":pointerover", ":dragging", ":drag-over-before", ":drag-over-after", ":drag-over-inside", ":placeholder", ":searchmatch", ":searchcurrent")]
 #if !DATAGRID_INTERNAL
 public
 #else
@@ -57,6 +57,7 @@ internal
         private int? _mouseOverColumnIndex;
         private DataGrid _owningGrid;
         private bool _isValid = true;
+        private DataGridValidationSeverity _validationSeverity = DataGridValidationSeverity.None;
         private bool _isPlaceholder;
         private Rectangle _bottomGridLine;
         private bool _areHandlersSuspended;
@@ -115,6 +116,11 @@ internal
                 nameof(IsValid),
                 o => o.IsValid);
 
+        public static readonly DirectProperty<DataGridRow, DataGridValidationSeverity> ValidationSeverityProperty =
+            AvaloniaProperty.RegisterDirect<DataGridRow, DataGridValidationSeverity>(
+                nameof(ValidationSeverity),
+                o => o.ValidationSeverity);
+
         /// <summary>
         /// Gets a value that indicates whether the data in a row is valid.
         /// </summary>
@@ -122,6 +128,12 @@ internal
         {
             get { return _isValid; }
             internal set { SetAndRaise(IsValidProperty, ref _isValid, value); }
+        }
+
+        public DataGridValidationSeverity ValidationSeverity
+        {
+            get { return _validationSeverity; }
+            internal set { SetAndRaise(ValidationSeverityProperty, ref _validationSeverity, value); }
         }
 
         public static readonly StyledProperty<IDataTemplate> DetailsTemplateProperty =
@@ -200,6 +212,7 @@ internal
 
             Index = -1;
             IsValid = true;
+            ValidationSeverity = DataGridValidationSeverity.None;
             Slot = -1;
             _mouseOverColumnIndex = null;
             _detailsDesiredHeight = double.NaN;

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using Avalonia.Automation;
+using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.DataGridDragDrop;
 using Avalonia.Input;
@@ -18,7 +19,7 @@ namespace Avalonia.Controls.Primitives
     /// Represents an individual <see cref="T:Avalonia.Controls.DataGrid" /> row header. 
     /// </summary>
     [TemplatePart(DATAGRIDROWHEADER_elementRootName, typeof(Control))]
-    [PseudoClasses(":invalid", ":selected", ":editing", ":current")]
+[PseudoClasses(":invalid", ":warning", ":info", ":selected", ":editing", ":current")]
 #if !DATAGRID_INTERNAL
 public
 #else
@@ -152,7 +153,9 @@ internal
             {
                 if (OwningRow != null)
                 {
-                    PseudoClassesHelper.Set(PseudoClasses, ":invalid", !OwningRow.IsValid);
+                    PseudoClassesHelper.Set(PseudoClasses, ":invalid", OwningRow.ValidationSeverity == DataGridValidationSeverity.Error);
+                    PseudoClassesHelper.Set(PseudoClasses, ":warning", OwningRow.ValidationSeverity == DataGridValidationSeverity.Warning);
+                    PseudoClassesHelper.Set(PseudoClasses, ":info", OwningRow.ValidationSeverity == DataGridValidationSeverity.Info);
                     PseudoClassesHelper.Set(PseudoClasses, ":selected", OwningRow.IsSelected);
                     PseudoClassesHelper.Set(PseudoClasses, ":editing", OwningRow.IsEditing);
 

--- a/src/Avalonia.Controls.DataGrid/DataGridValidationResult.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridValidationResult.cs
@@ -1,0 +1,49 @@
+// (c) Copyright Microsoft Corporation.
+// This source is subject to the Microsoft Public License (Ms-PL).
+// Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
+// All other rights reserved.
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Defines the severity of a validation result.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridValidationSeverity
+    {
+        None = 0,
+        Info = 1,
+        Warning = 2,
+        Error = 3
+    }
+
+    /// <summary>
+    /// Describes a validation message with a severity level.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridValidationResult
+    {
+        public DataGridValidationResult(string message, DataGridValidationSeverity severity = DataGridValidationSeverity.Error)
+        {
+            Message = message;
+            Severity = severity;
+        }
+
+        public string Message { get; }
+
+        public DataGridValidationSeverity Severity { get; }
+
+        public override string ToString()
+        {
+            return Message;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -19,6 +19,8 @@
           <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
           <SolidColorBrush x:Key="DataGridRowHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
           <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+          <SolidColorBrush x:Key="DataGridRowWarningBrush" Color="#F59E0B" />
+          <SolidColorBrush x:Key="DataGridRowInfoBrush" Color="#22C55E" />
           <SolidColorBrush x:Key="DataGridRowDropIndicatorBrush" Color="{DynamicResource SystemAccentColor}" />
           <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
           <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
@@ -27,6 +29,8 @@
           <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
           <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
           <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+          <SolidColorBrush x:Key="DataGridCellWarningBrush" Color="#F59E0B" />
+          <SolidColorBrush x:Key="DataGridCellInfoBrush" Color="#22C55E" />
           <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
           <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush" Color="{DynamicResource SystemChromeMediumLowColor}" />
           <SolidColorBrush x:Key="DataGridSummaryRowBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />
@@ -54,6 +58,8 @@
           <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
           <SolidColorBrush x:Key="DataGridRowHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
           <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+          <SolidColorBrush x:Key="DataGridRowWarningBrush" Color="#F59E0B" />
+          <SolidColorBrush x:Key="DataGridRowInfoBrush" Color="#22C55E" />
           <SolidColorBrush x:Key="DataGridRowDropIndicatorBrush" Color="{DynamicResource SystemAccentColor}" />
           <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
           <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
@@ -62,6 +68,8 @@
           <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
           <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
           <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+          <SolidColorBrush x:Key="DataGridCellWarningBrush" Color="#F59E0B" />
+          <SolidColorBrush x:Key="DataGridCellInfoBrush" Color="#22C55E" />
           <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
           <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush" Color="{DynamicResource SystemChromeMediumLowColor}" />
           <SolidColorBrush x:Key="DataGridSummaryRowBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -158,6 +158,8 @@
                               IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
               <ContentPresenter Name="PART_ContentPresenter"
                                 Padding="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -189,6 +191,112 @@
                     Height="14"
                     Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2"
                     Stroke="{DynamicResource DataGridCellInvalidBrush}"
+                    StrokeThickness="2" />
+            </Panel>
+          </DataTemplate>
+        </Setter>
+      </ControlTheme>
+
+      <!-- DataGridCellDataValidationWarningsTheme -->
+      <ControlTheme x:Key="DataGridCellDataValidationWarningsTheme"
+                    TargetType="DataValidationErrors">
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Setter Property="Template">
+          <ControlTemplate TargetType="DataValidationErrors">
+            <DockPanel LastChildFill="True">
+              <ContentControl Content="{Binding (DataValidationErrors.Errors)}"
+                              ContentTemplate="{TemplateBinding ErrorTemplate}"
+                              DataContext="{TemplateBinding Owner}"
+                              DockPanel.Dock="Right"
+                              IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                CornerRadius="{TemplateBinding CornerRadius}" />
+            </DockPanel>
+          </ControlTemplate>
+        </Setter>
+        <Setter Property="ErrorTemplate">
+          <DataTemplate>
+            <Panel Name="PART_InlineErrorTemplatePanel"
+                   Background="Transparent">
+              <Panel.Styles>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel">
+                  <Setter Property="Margin" Value="8,0" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip">
+                  <Setter Property="BorderBrush" Value="{DynamicResource DataGridCellWarningBrush}" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip TextBlock">
+                  <Setter Property="TextWrapping" Value="Wrap" />
+                </Style>
+              </Panel.Styles>
+              <ToolTip.Tip>
+                <ItemsControl ItemsSource="{Binding}" />
+              </ToolTip.Tip>
+              <Path Width="14"
+                    Height="14"
+                    Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2"
+                    Stroke="{DynamicResource DataGridCellWarningBrush}"
+                    StrokeThickness="2" />
+            </Panel>
+          </DataTemplate>
+        </Setter>
+      </ControlTheme>
+
+      <!-- DataGridCellDataValidationInfoTheme -->
+      <ControlTheme x:Key="DataGridCellDataValidationInfoTheme"
+                    TargetType="DataValidationErrors">
+        <Setter Property="CornerRadius" Value="{DynamicResource DataGridCellCornerRadius}" />
+        <Setter Property="Template">
+          <ControlTemplate TargetType="DataValidationErrors">
+            <DockPanel LastChildFill="True">
+              <ContentControl Content="{Binding (DataValidationErrors.Errors)}"
+                              ContentTemplate="{TemplateBinding ErrorTemplate}"
+                              DataContext="{TemplateBinding Owner}"
+                              DockPanel.Dock="Right"
+                              IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                CornerRadius="{TemplateBinding CornerRadius}" />
+            </DockPanel>
+          </ControlTemplate>
+        </Setter>
+        <Setter Property="ErrorTemplate">
+          <DataTemplate>
+            <Panel Name="PART_InlineErrorTemplatePanel"
+                   Background="Transparent">
+              <Panel.Styles>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel">
+                  <Setter Property="Margin" Value="8,0" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip">
+                  <Setter Property="BorderBrush" Value="{DynamicResource DataGridCellInfoBrush}" />
+                </Style>
+                <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip TextBlock">
+                  <Setter Property="TextWrapping" Value="Wrap" />
+                </Style>
+              </Panel.Styles>
+              <ToolTip.Tip>
+                <ItemsControl ItemsSource="{Binding}" />
+              </ToolTip.Tip>
+              <Path Width="14"
+                    Height="14"
+                    Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2"
+                    Stroke="{DynamicResource DataGridCellInfoBrush}"
                     StrokeThickness="2" />
             </Panel>
           </DataTemplate>
@@ -531,12 +639,14 @@
                              StrokeThickness="1" />
                 </Grid>
 
-                <ContentPresenter Grid.Column="0" Margin="{TemplateBinding Padding}"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Foreground="{TemplateBinding Foreground}" />
+                <DataValidationErrors Grid.Column="0"
+                                      Name="PART_CellValidationErrors"
+                                      Padding="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}" />
 
                 <Rectangle Grid.Column="0" x:Name="InvalidVisualElement"
                            IsVisible="False"
@@ -571,6 +681,14 @@
         </Style>
         <Style Selector="^:invalid /template/ Rectangle#InvalidVisualElement">
           <Setter Property="IsVisible" Value="True" />
+        </Style>
+        <Style Selector="^:warning /template/ Rectangle#InvalidVisualElement">
+          <Setter Property="IsVisible" Value="True" />
+          <Setter Property="Stroke" Value="{DynamicResource DataGridCellWarningBrush}" />
+        </Style>
+        <Style Selector="^:info /template/ Rectangle#InvalidVisualElement">
+          <Setter Property="IsVisible" Value="True" />
+          <Setter Property="Stroke" Value="{DynamicResource DataGridCellInfoBrush}" />
         </Style>
       </ControlTheme>
 
@@ -823,6 +941,24 @@
         <Style Selector="^:invalid">
           <Style Selector="^ /template/ Rectangle#InvalidVisualElement">
             <Setter Property="Opacity" Value="0.4" />
+          </Style>
+          <Style Selector="^ /template/ Rectangle#BackgroundRectangle">
+            <Setter Property="Opacity" Value="0" />
+          </Style>
+        </Style>
+        <Style Selector="^:warning">
+          <Style Selector="^ /template/ Rectangle#InvalidVisualElement">
+            <Setter Property="Opacity" Value="0.35" />
+            <Setter Property="Fill" Value="{DynamicResource DataGridRowWarningBrush}" />
+          </Style>
+          <Style Selector="^ /template/ Rectangle#BackgroundRectangle">
+            <Setter Property="Opacity" Value="0" />
+          </Style>
+        </Style>
+        <Style Selector="^:info">
+          <Style Selector="^ /template/ Rectangle#InvalidVisualElement">
+            <Setter Property="Opacity" Value="0.35" />
+            <Setter Property="Fill" Value="{DynamicResource DataGridRowInfoBrush}" />
           </Style>
           <Style Selector="^ /template/ Rectangle#BackgroundRectangle">
             <Setter Property="Opacity" Value="0" />
@@ -1165,6 +1301,12 @@
 
   <Style Selector="DataGridCell DataValidationErrors">
     <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationErrorsTheme}" />
+  </Style>
+  <Style Selector="DataGridCell:warning DataValidationErrors">
+    <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationWarningsTheme}" />
+  </Style>
+  <Style Selector="DataGridCell:info DataValidationErrors">
+    <Setter Property="Theme" Value="{DynamicResource DataGridCellDataValidationInfoTheme}" />
   </Style>
 
   <!-- Drag and Drop Styles -->

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -18,6 +18,8 @@
       <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush" Color="{DynamicResource ThemeControlHighColor}" />
       <SolidColorBrush x:Key="DataGridRowHoveredBackgroundBrush" Color="{DynamicResource ThemeControlHighColor}" />
       <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource ErrorColor}" />
+      <SolidColorBrush x:Key="DataGridRowWarningBrush" Color="#F59E0B" />
+      <SolidColorBrush x:Key="DataGridRowInfoBrush" Color="#22C55E" />
       <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource ThemeAccentColor2}" />
       <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource ThemeAccentColor2}" />
       <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="{DynamicResource ThemeAccentColor2}" />
@@ -25,6 +27,8 @@
       <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource ThemeBorderHighColor}" />
       <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource ThemeBorderMidColor}" />
       <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource ErrorColor}" />
+      <SolidColorBrush x:Key="DataGridCellWarningBrush" Color="#F59E0B" />
+      <SolidColorBrush x:Key="DataGridCellInfoBrush" Color="#22C55E" />
       <SolidColorBrush x:Key="DataGridGridLinesBrush" Color="{DynamicResource ThemeBorderHighColor}" />
       <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush" Color="{DynamicResource ThemeControlMidColor}" />
       <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="Transparent" />

--- a/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+
+namespace Avalonia.Controls.Utils
+{
+    internal static class BindingCloneHelper
+    {
+        public static bool TryCreateExplicitBinding(IBinding binding, out IBinding explicitBinding)
+        {
+            switch (binding)
+            {
+                case Binding avaloniaBinding:
+                    explicitBinding = CloneBinding(avaloniaBinding);
+                    return true;
+                case CompiledBindingExtension compiledBinding:
+                    explicitBinding = CloneBinding(compiledBinding);
+                    return true;
+                default:
+                    explicitBinding = binding;
+                    return false;
+            }
+        }
+
+        private static Binding CloneBinding(Binding source)
+        {
+            return new Binding
+            {
+                Path = source.Path,
+                ElementName = source.ElementName,
+                RelativeSource = source.RelativeSource,
+                Source = source.Source,
+                TypeResolver = source.TypeResolver,
+                Delay = source.Delay,
+                Converter = source.Converter,
+                ConverterCulture = source.ConverterCulture,
+                ConverterParameter = source.ConverterParameter,
+                FallbackValue = source.FallbackValue,
+                TargetNullValue = source.TargetNullValue,
+                Mode = source.Mode,
+                Priority = source.Priority,
+                StringFormat = source.StringFormat,
+                DefaultAnchor = source.DefaultAnchor,
+                NameScope = source.NameScope,
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
+        }
+
+        private static CompiledBindingExtension CloneBinding(CompiledBindingExtension source)
+        {
+            return new CompiledBindingExtension
+            {
+                Path = source.Path,
+                Delay = source.Delay,
+                Converter = source.Converter,
+                ConverterCulture = source.ConverterCulture,
+                ConverterParameter = source.ConverterParameter,
+                FallbackValue = source.FallbackValue,
+                TargetNullValue = source.TargetNullValue,
+                Mode = source.Mode,
+                Priority = source.Priority,
+                StringFormat = source.StringFormat,
+                Source = source.Source,
+                DataType = source.DataType,
+                DefaultAnchor = source.DefaultAnchor,
+                NameScope = source.NameScope,
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
@@ -1,8 +1,11 @@
 ﻿#nullable disable
 
+using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.PropertyStore;
 using Avalonia.Reactive;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Avalonia.Controls.Utils
@@ -25,33 +28,65 @@ internal
         private readonly LightweightSubject<bool> _changedSubject = new();
         private readonly List<Exception> _validationErrors = new List<Exception>();
         private readonly SubjectWrapper _inner;
+        private readonly IValueEntry _valueEntry;
+        private readonly Func<object> _getTargetValue;
+        private DataGridValidationSeverity _validationSeverity = DataGridValidationSeverity.None;
 
-        public bool IsValid => _validationErrors.Count <= 0;
+        public bool IsValid => _validationSeverity != DataGridValidationSeverity.Error;
         public IEnumerable<Exception> ValidationErrors => _validationErrors;
         public IObservable<bool> ValidationChanged => _changedSubject;
         public IAvaloniaSubject<object> InternalSubject => _inner;
 
-        public CellEditBinding(IAvaloniaSubject<object> bindingSourceSubject)
+        public CellEditBinding(IAvaloniaSubject<object> bindingSourceSubject, IValueEntry valueEntry = null, Func<object> getTargetValue = null)
         {
             _inner = new SubjectWrapper(bindingSourceSubject, this);
+            _valueEntry = valueEntry;
+            _getTargetValue = getTargetValue;
         }
 
         private void AlterValidationErrors(Action<List<Exception>> action)
         {
-            var wasValid = IsValid;
-            action(_validationErrors);
-            var isValid = IsValid;
+            var hadErrors = _validationErrors.Count > 0;
 
-            if (!isValid || !wasValid)
+            action(_validationErrors);
+            _validationSeverity = _validationErrors.Count == 0
+                ? DataGridValidationSeverity.None
+                : ValidationUtil.GetValidationSeverity(_validationErrors);
+            var hasErrors = _validationErrors.Count > 0;
+
+            if (hadErrors || hasErrors)
             {
-                _changedSubject.OnNext(isValid);
+                _changedSubject.OnNext(IsValid);
             }
         }
 
         public bool CommitEdit()
         {
-            _inner.CommitEdit();
+            _inner.CommitEdit(_getTargetValue);
+            UpdateValidationErrorsFromEntry();
             return IsValid;
+        }
+
+        private void UpdateValidationErrorsFromEntry()
+        {
+            if (_valueEntry == null)
+            {
+                return;
+            }
+
+            _valueEntry.GetDataValidationState(out var state, out var error);
+            if ((state & BindingValueType.HasError) != 0 && error != null)
+            {
+                AlterValidationErrors(errors =>
+                {
+                    errors.Clear();
+                    errors.AddRange(ValidationUtil.UnpackException(error));
+                });
+            }
+            else
+            {
+                AlterValidationErrors(errors => errors.Clear());
+            }
         }
 
         class SubjectWrapper : LightweightObservableBase<object>, IAvaloniaSubject<object>, IDisposable
@@ -75,7 +110,18 @@ internal
                 {
                     _settingSourceValue = true;
 
-                    _sourceSubject.OnNext(value);
+                    try
+                    {
+                        _sourceSubject.OnNext(value);
+                    }
+                    catch (Exception ex)
+                    {
+                        _editBinding.AlterValidationErrors(errors =>
+                        {
+                            errors.Clear();
+                            errors.AddRange(ValidationUtil.UnpackException(ex));
+                        });
+                    }
 
                     _settingSourceValue = false;
                 }
@@ -87,6 +133,11 @@ internal
 
             private void OnValidationError(BindingNotification notification)
             {
+                if (notification.HasValue && IsDataValidationException(notification.Error))
+                {
+                    SetControlValue(notification.Value);
+                }
+
                 if (notification.Error != null)
                 {
                     _editBinding.AlterValidationErrors(errors =>
@@ -97,6 +148,27 @@ internal
                             errors.AddRange(unpackedErrors);
                     });
                 }
+            }
+
+            private static bool IsDataValidationException(Exception exception)
+            {
+                if (exception is DataValidationException)
+                {
+                    return true;
+                }
+
+                if (exception is AggregateException aggregate)
+                {
+                    foreach (var inner in aggregate.InnerExceptions)
+                    {
+                        if (inner is DataValidationException)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
             }
             private void OnControlValueUpdated(object value)
             {
@@ -157,10 +229,174 @@ internal
                 _subscription?.Dispose();
                 _subscription = null;
             }
-            public void CommitEdit()
+            public void CommitEdit(Func<object> getValue)
             {
                 if (_isControlValueSet)
+                {
                     SetSourceValue(_controlValue);
+                }
+                else if (getValue != null)
+                {
+                    SetSourceValue(getValue());
+                }
+            }
+        }
+    }
+
+    internal class ExplicitCellEditBinding : ICellEditBinding
+    {
+        private readonly AvaloniaObject _target;
+        private readonly AvaloniaProperty _property;
+        private readonly LightweightSubject<bool> _changedSubject = new();
+        private readonly List<Exception> _validationErrors = new List<Exception>();
+        private DataGridValidationSeverity _validationSeverity = DataGridValidationSeverity.None;
+
+        public ExplicitCellEditBinding(AvaloniaObject target, AvaloniaProperty property)
+        {
+            _target = target;
+            _property = property;
+        }
+
+        public bool IsValid => _validationSeverity != DataGridValidationSeverity.Error;
+        public IEnumerable<Exception> ValidationErrors => _validationErrors;
+        public IObservable<bool> ValidationChanged => _changedSubject;
+
+        public bool CommitEdit()
+        {
+            Exception commitError = null;
+            var expression = BindingOperations.GetBindingExpressionBase(_target, _property);
+            if (expression != null)
+            {
+                try
+                {
+                    expression.UpdateSource();
+                }
+                catch (Exception ex)
+                {
+                    commitError = ex;
+                }
+            }
+
+            if (commitError != null)
+            {
+                UpdateValidationErrorsFromException(commitError);
+            }
+            else
+            {
+                UpdateValidationErrorsFromTarget(expression);
+
+                if (!IsValid && expression is IValueEntry valueEntry && TryGetSourceValue(valueEntry, out var sourceValue))
+                {
+                    var targetValue = _target.GetValue(_property);
+                    if (Equals(targetValue, sourceValue))
+                    {
+                        expression?.UpdateTarget();
+                        UpdateValidationErrorsFromTarget(expression);
+                    }
+                }
+            }
+
+            return IsValid;
+        }
+
+        private void UpdateValidationErrorsFromException(Exception error)
+        {
+            AlterValidationErrors(errors =>
+            {
+                errors.Clear();
+                errors.AddRange(ValidationUtil.UnpackException(error));
+            });
+        }
+
+        private void UpdateValidationErrorsFromTarget(BindingExpressionBase expression)
+        {
+            var valueEntry = expression as IValueEntry;
+            if (valueEntry != null)
+            {
+                valueEntry.GetDataValidationState(out var state, out var error);
+                if ((state & BindingValueType.HasError) != 0 && error != null)
+                {
+                    AlterValidationErrors(list =>
+                    {
+                        list.Clear();
+                        list.AddRange(ValidationUtil.UnpackException(error));
+                    });
+                }
+                else
+                {
+                    AlterValidationErrors(list => list.Clear());
+                }
+
+                return;
+            }
+
+            if (_target is not Control control)
+            {
+                AlterValidationErrors(list => list.Clear());
+                return;
+            }
+
+            var errors = DataValidationErrors.GetErrors(control);
+            AlterValidationErrors(list =>
+            {
+                list.Clear();
+                if (errors == null)
+                {
+                    return;
+                }
+
+                foreach (var error in errors)
+                {
+                    if (error == null)
+                    {
+                        continue;
+                    }
+
+                    if (error is Exception exception)
+                    {
+                        list.AddRange(ValidationUtil.UnpackException(exception));
+                    }
+                    else
+                    {
+                        list.Add(new DataValidationException(error));
+                    }
+                }
+            });
+        }
+
+        private void AlterValidationErrors(Action<List<Exception>> action)
+        {
+            var hadErrors = _validationErrors.Count > 0;
+
+            action(_validationErrors);
+            _validationSeverity = _validationErrors.Count == 0
+                ? DataGridValidationSeverity.None
+                : ValidationUtil.GetValidationSeverity(_validationErrors);
+            var hasErrors = _validationErrors.Count > 0;
+
+            if (hadErrors || hasErrors)
+            {
+                _changedSubject.OnNext(IsValid);
+            }
+        }
+
+        private static bool TryGetSourceValue(IValueEntry valueEntry, out object sourceValue)
+        {
+            sourceValue = null;
+
+            try
+            {
+                if (!valueEntry.HasValue())
+                {
+                    return false;
+                }
+
+                sourceValue = valueEntry.GetValue();
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
     }

--- a/src/DataGridSample/Converters/ValidationSeverityBrushConverter.cs
+++ b/src/DataGridSample/Converters/ValidationSeverityBrushConverter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace DataGridSample.Converters
+{
+    public class ValidationSeverityBrushConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo? culture)
+        {
+            if (value is DataGridValidationSeverity severity)
+            {
+                var resourceKey = severity switch
+                {
+                    DataGridValidationSeverity.Error => "DataGridCellInvalidBrush",
+                    DataGridValidationSeverity.Warning => "DataGridCellWarningBrush",
+                    DataGridValidationSeverity.Info => "DataGridCellInfoBrush",
+                    _ => null
+                };
+
+                if (resourceKey != null && Application.Current?.TryFindResource(resourceKey, out var resource) == true)
+                {
+                    return resource;
+                }
+            }
+
+            return Brushes.Transparent;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo? culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -185,6 +185,9 @@
     <TabItem Header="Validation">
       <pages:ValidationColumnsPage />
     </TabItem>
+    <TabItem Header="Validation Styling">
+      <pages:ValidationStylingPage />
+    </TabItem>
     <TabItem Header="DataTable">
       <local:DataTablePage />
     </TabItem>

--- a/src/DataGridSample/Pages/ValidationStylingPage.axaml
+++ b/src/DataGridSample/Pages/ValidationStylingPage.axaml
@@ -1,0 +1,83 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:DataGridSample.Converters"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.ValidationStylingPage"
+             x:Name="Root"
+             x:DataType="viewModels:ValidationStylingViewModel">
+  <UserControl.DataContext>
+    <viewModels:ValidationStylingViewModel />
+  </UserControl.DataContext>
+
+  <UserControl.Resources>
+    <converters:ValidationSeverityBrushConverter x:Key="ValidationSeverityBrushConverter" />
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="12" Margin="12">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2">Validation Styling</TextBlock>
+      <TextBlock Text="Severity-aware validation keeps errors blocking and warnings/info non-blocking while still highlighting the cell."
+                 TextWrapping="Wrap" />
+      <TextBlock Text="Try clearing Title (error), setting Risk to 8+, or Health below 50."
+                 TextWrapping="Wrap"
+                 Foreground="Gray"
+                 FontStyle="Italic" />
+    </StackPanel>
+
+    <ItemsControl Grid.Row="1"
+                  ItemsSource="{Binding Legend}">
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <StackPanel Orientation="Horizontal"
+                      Spacing="16" />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate x:DataType="viewModels:ValidationLegendItem">
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Border Width="12"
+                    Height="12"
+                    CornerRadius="2"
+                    Background="{Binding Severity, Converter={StaticResource ValidationSeverityBrushConverter}}" />
+            <StackPanel>
+              <TextBlock Text="{Binding Label}" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding Description}" FontSize="11" Foreground="Gray" />
+            </StackPanel>
+          </StackPanel>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <DataGrid Grid.Row="2"
+              ItemsSource="{Binding Items}"
+              AutoGenerateColumns="False"
+              IsReadOnly="False"
+              CanUserAddRows="False"
+              CanUserDeleteRows="False"
+              CanUserResizeColumns="True"
+              HeadersVisibility="All"
+              GridLinesVisibility="All"
+              RowHeight="36">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Title"
+                            Binding="{Binding Title}"
+                            Width="220"
+                            x:DataType="viewModels:ValidationStylingItem" />
+        <DataGridNumericColumn Header="Risk"
+                               Binding="{Binding Risk}"
+                               Minimum="0"
+                               Maximum="10"
+                               Increment="1"
+                               Width="140"
+                               x:DataType="viewModels:ValidationStylingItem" />
+        <DataGridNumericColumn Header="Health"
+                               Binding="{Binding Health}"
+                               Minimum="0"
+                               Maximum="100"
+                               Increment="5"
+                               Width="160"
+                               x:DataType="viewModels:ValidationStylingItem" />
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/ValidationStylingPage.axaml.cs
+++ b/src/DataGridSample/Pages/ValidationStylingPage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    public partial class ValidationStylingPage : UserControl
+    {
+        public ValidationStylingPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DataGridSample/Program.cs
+++ b/src/DataGridSample/Program.cs
@@ -41,6 +41,8 @@ public static class Program
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(RoutedEventsViewModel.SampleItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(RoutedEventsViewModel.HierarchicalItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(ValidationSampleItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(ValidationStylingItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(ValidationLegendItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalRowDragDropViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSampleViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalUndoRedoViewModel.TreeItem))]

--- a/src/DataGridSample/ViewModels/ValidationStylingViewModel.cs
+++ b/src/DataGridSample/ViewModels/ValidationStylingViewModel.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Avalonia.Controls;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class ValidationStylingViewModel : ObservableObject
+    {
+        public ValidationStylingViewModel()
+        {
+            Legend = new ReadOnlyCollection<ValidationLegendItem>(new[]
+            {
+                new ValidationLegendItem("Error", DataGridValidationSeverity.Error, "Blocks commit."),
+                new ValidationLegendItem("Warning", DataGridValidationSeverity.Warning, "Allows commit and keeps the cell highlighted."),
+                new ValidationLegendItem("Info", DataGridValidationSeverity.Info, "Allows commit and keeps the cell highlighted.")
+            });
+
+            Items = new ObservableCollection<ValidationStylingItem>
+            {
+                new ValidationStylingItem { Title = "Launch plan", Risk = 5m, Health = 72m },
+                new ValidationStylingItem { Title = "Security audit", Risk = 6m, Health = 68m },
+                new ValidationStylingItem { Title = "Docs refresh", Risk = 4m, Health = 80m }
+            };
+        }
+
+        public ObservableCollection<ValidationStylingItem> Items { get; }
+
+        public IReadOnlyList<ValidationLegendItem> Legend { get; }
+    }
+
+    public sealed class ValidationLegendItem
+    {
+        public ValidationLegendItem(string label, DataGridValidationSeverity severity, string description)
+        {
+            Label = label;
+            Severity = severity;
+            Description = description;
+        }
+
+        public string Label { get; }
+
+        public DataGridValidationSeverity Severity { get; }
+
+        public string Description { get; }
+    }
+
+    public class ValidationStylingItem : ObservableObject, INotifyDataErrorInfo
+    {
+        private string _title = string.Empty;
+        private decimal? _risk;
+        private decimal? _health;
+        private readonly Dictionary<string, List<DataGridValidationResult>> _errors = new();
+
+        public string Title
+        {
+            get => _title;
+            set
+            {
+                if (!SetProperty(ref _title, value))
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    SetError(nameof(Title),
+                        new DataGridValidationResult("Title is required.", DataGridValidationSeverity.Error));
+                }
+                else
+                {
+                    SetError(nameof(Title), null);
+                }
+            }
+        }
+
+        public decimal? Risk
+        {
+            get => _risk;
+            set
+            {
+                if (!SetProperty(ref _risk, value))
+                {
+                    return;
+                }
+
+                if (!value.HasValue)
+                {
+                    SetError(nameof(Risk),
+                        new DataGridValidationResult("Risk is required.", DataGridValidationSeverity.Error));
+                }
+                else if (value.Value >= 8m)
+                {
+                    SetError(nameof(Risk),
+                        new DataGridValidationResult("Risk of 8+ is a warning.", DataGridValidationSeverity.Warning));
+                }
+                else
+                {
+                    SetError(nameof(Risk), null);
+                }
+            }
+        }
+
+        public decimal? Health
+        {
+            get => _health;
+            set
+            {
+                if (!SetProperty(ref _health, value))
+                {
+                    return;
+                }
+
+                if (!value.HasValue)
+                {
+                    SetError(nameof(Health),
+                        new DataGridValidationResult("Health is required.", DataGridValidationSeverity.Error));
+                }
+                else if (value.Value < 50m)
+                {
+                    SetError(nameof(Health),
+                        new DataGridValidationResult("Health under 50 is informational.", DataGridValidationSeverity.Info));
+                }
+                else
+                {
+                    SetError(nameof(Health), null);
+                }
+            }
+        }
+
+        public bool HasErrors => _errors.Count > 0;
+
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (propertyName is { } && _errors.TryGetValue(propertyName, out var errorList))
+            {
+                return errorList;
+            }
+
+            return Array.Empty<object>();
+        }
+
+        private void SetError(string propertyName, DataGridValidationResult? error)
+        {
+            if (error == null)
+            {
+                if (_errors.Remove(propertyName))
+                {
+                    OnErrorsChanged(propertyName);
+                }
+                return;
+            }
+
+            if (_errors.TryGetValue(propertyName, out var errorList))
+            {
+                errorList.Clear();
+                errorList.Add(error);
+            }
+            else
+            {
+                _errors.Add(propertyName, new List<DataGridValidationResult> { error });
+            }
+
+            OnErrorsChanged(propertyName);
+        }
+
+        private void OnErrorsChanged(string propertyName)
+        {
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary

## Overview
- Add severity-aware validation with `DataGridValidationSeverity` and `DataGridValidationResult` so warnings/info are non-blocking while errors still block commits.
- Rework DataGrid validation state so cell-level severity drives row/grid validity, preserves INDEI error severity, and keeps grid invalid even when error rows are off-screen.
- Tighten edit/validation lifecycle to restore prior cell/row state on cancel, keep template-column validation intact, and avoid duplicate tooltip icons during editing.
- Fix selection checks for the new-item placeholder so editing can be initiated when selection models don't include the placeholder row.
- Expand built-in themes, samples, and docs to showcase severity styling and tooltips.

## Implementation Details
- Core validation
  - Introduced severity-aware result type (`DataGridValidationResult`) and extended `ValidationUtil` to derive severity from `DataValidationException` payloads and result collections.
  - Updated `DataGrid.Validation` to compute row severity from cells, preserve INDEI exceptions (including warning/info), and scan the collection view for error severity to keep `IsValid` accurate regardless of virtualization.
  - Avoid clearing cell validation for columns with no binding path so template/manual validation persists across recycling or edit cancel.
- Editing/commit flow
  - Added row and cell validation snapshots and restore paths for cancel scenarios, including template columns and non-INDEI cells.
  - Cleared validation errors from editing elements on failed commit and attach errors to the cell instead to prevent duplicate tooltip icons.
  - Added binding-clone helper to enforce explicit update source triggers for edit bindings (bound and combo columns) to keep commit semantics consistent.
  - Commit edits on Enter even when move-down navigation fails (for example, at the last row with a new-item placeholder).
  - Treat placeholder row selection as coming from the grid selection cache to allow F2/click edit to start on add-new rows.
- Styling/theming
  - Added warning/info brushes and `DataValidationErrors` themes for warning/info states across Generic/Simple/Fluent.
  - Exposed `:warning` and `:info` pseudo-classes for cells/rows/row headers to allow consistent severity styling.
  - Kept inline error indicator and tooltip behavior consistent for error/warning/info at the cell level.
- Sample + docs
  - Added a new “Validation Styling” sample page with severity legend, numeric inputs, and resizing enabled.
  - Added `ValidationSeverityBrushConverter` for sample legend visuals and trimming annotations for new sample models.
  - Updated `validation-and-errors.md` with severity guidance, styling hooks, and sample references.

## Tests
- Added/expanded unit/headless coverage:
  - `DataGridValidationTests` for severity behavior, restore flows, off-screen INDEI errors, and template-column restore.
  - `ValidationUtilTests` for severity extraction.
  - Theme resource coverage and column editing headless tests for validation resources and edit paths.
  - `DataGridInputNavigationTests` and `DataGridColumnEditingHeadlessTests` for explicit edit-binding behavior and deferred source updates until commit.
  - `DataGridKeyboardInputTests` to verify F2 starts editing on the add-new placeholder row.
- Ran:
  - `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DataGridValidationTests" -m:1 -v:minimal -clp:ErrorsOnly`
  - `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DataGridAllCellsEditingHeadlessTests.Edit_Multiple_Rows_With_F2_And_Enter" -m:1 -v:minimal -clp:ErrorsOnly -p:UsedAvaloniaProducts=`
  - `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DataGridInputNavigationTests.WaitForLostFocus|FullyQualifiedName~DataGridColumnEditingHeadlessTests.TextColumn_Edit_Does_Not_Update_Source_Until_Commit|FullyQualifiedName~DataGridColumnEditingHeadlessTests.ComboBoxColumn_Edit_Does_Not_Update_Source_Until_Commit" -m:1 -v:minimal -clp:ErrorsOnly -p:UsedAvaloniaProducts=`
  - `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DataGridKeyboardInputTests.F2_Starts_Edit_On_NewItemPlaceholder" -m:1 -v:minimal -clp:ErrorsOnly -p:UsedAvaloniaProducts=`

## Behavior Notes
- Errors block commit and set the grid invalid; warnings/info allow commit and keep the grid valid while still highlighting the cell and showing tooltip content.
- Validation tooltips are now sourced from the cell only, avoiding the duplicate editor tooltip while editing.

## Screenshots

<img width="2224" height="1680" alt="image" src="https://github.com/user-attachments/assets/8ef8a218-7465-4646-bd71-8d80262d6202" />

<img width="2224" height="1680" alt="image" src="https://github.com/user-attachments/assets/7dfbc0a2-3a50-4303-8ec7-e88e55307604" />


Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/158