### PR TITLE
Fix grouping indentation refresh for recycled headers

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridProgrammaticGroupingIndentationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridProgrammaticGroupingIndentationTests.cs
@@ -1,0 +1,441 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests;
+
+public class DataGridProgrammaticGroupingIndentationTests
+{
+    [AvaloniaFact]
+    public void ProgrammaticGrouping_Recalculates_Indentation_Across_Grouping_Changes()
+    {
+        var items = new List<Item>
+        {
+            new("Prices", "Identification", "Base price", "es-ES"),
+            new("Prices", "Encoding", "Currency", "en-US"),
+            new("Metadata", "Identification", "Name", "en-US"),
+            new("Metadata", "Encoding", "Language", "es-ES"),
+        };
+
+        var view = new DataGridCollectionView(items);
+
+        var root = new Window
+        {
+            Width = 600,
+            Height = 400,
+        };
+
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            ItemsSource = view,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+        };
+
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Category",
+            Binding = new Binding(nameof(Item.Category)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Group",
+            Binding = new Binding(nameof(Item.Group)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Locale",
+            Binding = new Binding(nameof(Item.Locale)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(Item.Name)),
+        });
+
+        root.Content = grid;
+        root.Show();
+        PumpLayout(grid);
+
+        try
+        {
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+            });
+            PumpLayout(grid);
+
+            var level1Header = GetHeaderForLevel(grid, 1);
+
+            Assert.NotNull(grid.RowGroupSublevelIndents);
+            var expectedIndent = grid.RowGroupSublevelIndents![0];
+            Assert.Equal(expectedIndent, GetIndentSpacerWidth(level1Header), precision: 3);
+            Assert.True(grid.ColumnsInternal.RowGroupSpacerColumn.IsRepresented);
+            Assert.Equal(grid.RowGroupSublevelIndents[^1], grid.ColumnsInternal.RowGroupSpacerColumn.Width.Value, precision: 3);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            PumpLayout(grid);
+
+            var topLevelHeader = GetHeaderForLevel(grid, 0);
+            Assert.Equal(0d, GetIndentSpacerWidth(topLevelHeader), precision: 3);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                var locale = new DataGridPathGroupDescription(nameof(Item.Locale));
+                locale.GroupKeys.Add("es-ES");
+                locale.GroupKeys.Add("en-US");
+                locale.GroupKeys.Add("(none)");
+
+                groups.Add(locale);
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            PumpLayout(grid);
+
+            var localeHeader = GetHeaderForLevel(grid, 1);
+
+            Assert.NotNull(grid.RowGroupSublevelIndents);
+            expectedIndent = grid.RowGroupSublevelIndents![0];
+            Assert.Equal(expectedIndent, GetIndentSpacerWidth(localeHeader), precision: 3);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            PumpLayout(grid);
+
+            var reorderedHeader = GetHeaderForLevel(grid, 1);
+
+            Assert.NotNull(grid.RowGroupSublevelIndents);
+            expectedIndent = grid.RowGroupSublevelIndents![0];
+            Assert.Equal(expectedIndent, GetIndentSpacerWidth(reorderedHeader), precision: 3);
+
+            view.GroupDescriptions.Clear();
+            view.Refresh();
+            PumpLayout(grid);
+
+            Assert.True(grid.RowGroupHeadersTable.IsEmpty);
+            Assert.False(grid.ColumnsInternal.RowGroupSpacerColumn.IsRepresented);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ProgrammaticGrouping_Indentation_Is_Correct_For_All_Visible_Headers_Across_Mutations()
+    {
+        var items = new ObservableCollection<Item>(new[]
+        {
+            new Item("Prices", "Identification", "Base price", "es-ES"),
+            new Item("Prices", "Identification", "Wholesale", "en-US"),
+            new Item("Prices", "Encoding", "Currency", "es-ES"),
+            new Item("Prices", "Encoding", "Currency", "en-US"),
+            new Item("Metadata", "Identification", "Name", "es-ES"),
+            new Item("Metadata", "Identification", "Name", "en-US"),
+            new Item("Metadata", "Encoding", "Language", "es-ES"),
+            new Item("Metadata", "Encoding", "Language", "en-US"),
+        });
+
+        var view = new DataGridCollectionView(items);
+        var (root, grid) = CreateGrid(view, width: 600, height: 320);
+
+        try
+        {
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+                groups.Insert(1, new DataGridPathGroupDescription(nameof(Item.Group)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                var locale = new DataGridPathGroupDescription(nameof(Item.Locale));
+                locale.GroupKeys.Add("es-ES");
+                locale.GroupKeys.Add("en-US");
+                locale.GroupKeys.Add("(none)");
+
+                groups.Add(locale);
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            SetGroupDescriptions(view, groups =>
+            {
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+                groups.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+            });
+            items.Insert(0, new Item("Prices", "Identification", "Generated", "en-US"));
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            view.GroupDescriptions.Clear();
+            view.Refresh();
+            PumpLayout(grid);
+            Assert.Empty(GetGroupHeaders(grid).Where(header => header.IsVisible));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ProgrammaticGrouping_Reapplies_Indentation_After_Recycling_GroupHeaders()
+    {
+        var items = new ObservableCollection<Item>();
+        var categories = new[] { "A", "B", "C", "D" };
+        var groups = new[] { "One", "Two", "Three" };
+        var locales = new[] { "es-ES", "en-US" };
+
+        for (var i = 0; i < 60; i++)
+        {
+            items.Add(new Item(
+                categories[i % categories.Length],
+                groups[i % groups.Length],
+                $"Name {i}",
+                locales[i % locales.Length]));
+        }
+
+        var view = new DataGridCollectionView(items);
+        var (root, grid) = CreateGrid(view, width: 500, height: 200);
+
+        try
+        {
+            SetGroupDescriptions(view, groupDescriptions =>
+            {
+                groupDescriptions.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+                groupDescriptions.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            AssertGroupHeaderIndentation(grid);
+
+            var lastHeaderSlot = grid.RowGroupHeadersTable.GetIndexes().Last();
+            ScrollSlotIntoView(grid, lastHeaderSlot);
+
+            SetGroupDescriptions(view, groupDescriptions =>
+            {
+                groupDescriptions.Add(new DataGridPathGroupDescription(nameof(Item.Group)));
+                groupDescriptions.Add(new DataGridPathGroupDescription(nameof(Item.Category)));
+            });
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+
+            ScrollSlotIntoView(grid, 0);
+            AssertGroupHeaderIndentation(grid);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    private static void SetGroupDescriptions(
+        DataGridCollectionView view,
+        System.Action<AvaloniaList<DataGridGroupDescription>> configure)
+    {
+        var groups = view.GroupDescriptions;
+        groups.Clear();
+        configure(groups);
+        view.Refresh();
+    }
+
+    private static (Window root, DataGrid grid) CreateGrid(DataGridCollectionView view, double width, double height)
+    {
+        var root = new Window
+        {
+            Width = width,
+            Height = height,
+        };
+
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            ItemsSource = view,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+        };
+
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Category",
+            Binding = new Binding(nameof(Item.Category)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Group",
+            Binding = new Binding(nameof(Item.Group)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Locale",
+            Binding = new Binding(nameof(Item.Locale)),
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(Item.Name)),
+        });
+
+        root.Content = grid;
+        root.Show();
+        PumpLayout(grid);
+
+        return (root, grid);
+    }
+
+    private static IReadOnlyList<DataGridRowGroupHeader> GetGroupHeaders(DataGrid grid)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridRowGroupHeader>()
+            .Where(header => !header.IsRecycled)
+            .ToList();
+    }
+
+    private static IReadOnlyList<DataGridRowGroupInfo> GetRowGroupInfos(DataGrid grid)
+    {
+        return grid.RowGroupHeadersTable.GetIndexes()
+            .Select(slot => grid.RowGroupHeadersTable.GetValueAt(slot))
+            .Where(info => info != null)
+            .ToList();
+    }
+
+    private static DataGridRowGroupHeader GetHeaderForLevel(DataGrid grid, int level)
+    {
+        var info = GetRowGroupInfos(grid).First(group => group.Level == level);
+        return GetHeaderForGroupInfo(grid, info);
+    }
+
+    private static DataGridRowGroupHeader GetHeaderForGroupInfo(DataGrid grid, DataGridRowGroupInfo info)
+    {
+        var columnIndex = grid.ColumnsInternal.FirstVisibleNonFillerColumn?.Index ?? 0;
+        if (grid.ColumnDefinitions.Count > 0)
+        {
+            grid.ScrollSlotIntoView(columnIndex, info.Slot, forCurrentCellChange: false, forceHorizontalScroll: false);
+        }
+
+        PumpLayout(grid);
+
+        if (grid.DisplayData.GetDisplayedElement(info.Slot) is DataGridRowGroupHeader header)
+        {
+            return header;
+        }
+
+        throw new InvalidOperationException("Group header was not realized.");
+    }
+
+    private static void AssertGroupHeaderIndentation(DataGrid grid)
+    {
+        var rowGroupInfos = GetRowGroupInfos(grid);
+        Assert.NotEmpty(rowGroupInfos);
+
+        var hasSubGroups = rowGroupInfos.Any(info => info.Level > 0);
+        var indents = grid.RowGroupSublevelIndents ?? System.Array.Empty<double>();
+
+        if (hasSubGroups)
+        {
+            Assert.NotNull(grid.RowGroupSublevelIndents);
+        }
+
+        foreach (var info in rowGroupInfos)
+        {
+            var header = GetHeaderForGroupInfo(grid, info);
+            var level = info.Level;
+            var expected = level <= 0 || indents.Length == 0
+                ? 0
+                : indents[System.Math.Min(level - 1, indents.Length - 1)];
+
+            Assert.Equal(expected, GetIndentSpacerWidth(header), precision: 3);
+        }
+    }
+
+    private static void ScrollSlotIntoView(DataGrid grid, int slot)
+    {
+        if (grid.ColumnDefinitions.Count > 0)
+        {
+            var columnIndex = grid.ColumnsInternal.FirstVisibleNonFillerColumn?.Index ?? 0;
+            grid.ScrollSlotIntoView(columnIndex, slot, forCurrentCellChange: false, forceHorizontalScroll: false);
+        }
+
+        PumpLayout(grid);
+    }
+
+    private static double GetIndentSpacerWidth(DataGridRowGroupHeader header)
+    {
+        var spacer = header.GetVisualDescendants()
+            .OfType<Rectangle>()
+            .FirstOrDefault(rect => rect.Name == "PART_IndentSpacer");
+
+        Assert.NotNull(spacer);
+        return spacer!.Width;
+    }
+
+    private static void PumpLayout(Control control)
+    {
+        Dispatcher.UIThread.RunJobs();
+        if (control.GetVisualRoot() is Window window)
+        {
+            window.ApplyTemplate();
+            window.UpdateLayout();
+        }
+        control.ApplyTemplate();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private sealed record Item(string Category, string Group, string Name, string Locale);
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalIndentationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalIndentationTests.cs
@@ -1,0 +1,377 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Hierarchical;
+
+public class DataGridHierarchicalIndentationTests
+{
+    [AvaloniaFact]
+    public void HierarchicalIndentation_Updates_After_Reparent()
+    {
+        var rootA = new Node("Root A");
+        var rootB = new Node("Root B");
+        var child = new Node("Child");
+        rootA.Children.Add(child);
+
+        var roots = new ObservableCollection<Node> { rootA, rootB };
+
+        var model = new HierarchicalModel<Node>(new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            AutoExpandRoot = true,
+            MaxAutoExpandDepth = 2
+        });
+        model.SetRoots(roots);
+        model.ExpandAll();
+
+        const double indent = 24;
+        var (root, grid) = CreateGrid(model, indent);
+
+        try
+        {
+            var initialRow = FindRowForItem(grid, child);
+            var initialPresenter = FindPresenter(initialRow);
+            Assert.Equal(new Thickness(indent, 0, 0, 0), initialPresenter.Padding);
+
+            rootA.Children.Remove(child);
+            roots.Add(child);
+            Dispatcher.UIThread.RunJobs();
+            grid.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            var movedRow = FindRowForItem(grid, child);
+            var movedPresenter = FindPresenter(movedRow);
+            Assert.Equal(new Thickness(0, 0, 0, 0), movedPresenter.Padding);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HierarchicalIndentation_Updates_After_Subtree_Reparent_Undo_Redo()
+    {
+        var rootA = new Node("Root A");
+        var rootB = new Node("Root B");
+        var parent = new Node("Parent");
+        var child = new Node("Child");
+        parent.Children.Add(child);
+        rootA.Children.Add(parent);
+
+        var roots = new ObservableCollection<Node> { rootA, rootB };
+
+        var model = new HierarchicalModel<Node>(new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            AutoExpandRoot = true,
+            MaxAutoExpandDepth = 2
+        });
+        model.SetRoots(roots);
+        model.ExpandAll();
+
+        const double indent = 24;
+        var (root, grid) = CreateGrid(model, indent);
+
+        try
+        {
+            PumpLayout(grid);
+            AssertIndentation(grid, parent, indent, level: 1);
+            AssertIndentation(grid, child, indent, level: 2);
+
+            rootA.Children.Remove(parent);
+            roots.Add(parent);
+            model.ExpandAll();
+            PumpLayout(grid);
+
+            AssertIndentation(grid, parent, indent, level: 0);
+            AssertIndentation(grid, child, indent, level: 1);
+
+            roots.Remove(parent);
+            rootA.Children.Add(parent);
+            model.ExpandAll();
+            PumpLayout(grid);
+
+            AssertIndentation(grid, parent, indent, level: 1);
+            AssertIndentation(grid, child, indent, level: 2);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HierarchicalIndentation_Updates_After_Resetting_Roots()
+    {
+        var rootA = new Node("Root A");
+        var childA = new Node("Child A");
+        rootA.Children.Add(childA);
+
+        var roots = new ObservableCollection<Node> { rootA };
+
+        var model = new HierarchicalModel<Node>(new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            AutoExpandRoot = true,
+            MaxAutoExpandDepth = 1
+        });
+        model.SetRoots(roots);
+        model.ExpandAll();
+
+        const double indent = 24;
+        var (root, grid) = CreateGrid(model, indent);
+
+        try
+        {
+            PumpLayout(grid);
+            AssertIndentation(grid, childA, indent, level: 1);
+
+            var rootB = new Node("Root B");
+            var childB = new Node("Child B");
+            rootB.Children.Add(childB);
+
+            var newRoots = new ObservableCollection<Node> { rootB };
+            model.SetRoots(newRoots);
+            model.ExpandAll();
+            PumpLayout(grid);
+
+            AssertIndentation(grid, childB, indent, level: 1);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HierarchicalIndentation_Updates_After_Roots_Reset_Via_Collection_Change()
+    {
+        var rootA = new Node("Root A");
+        var childA = new Node("Child A");
+        rootA.Children.Add(childA);
+
+        var rootB = new Node("Root B");
+        var childB = new Node("Child B");
+        rootB.Children.Add(childB);
+
+        var roots = new ObservableCollection<Node> { rootA };
+
+        var model = new HierarchicalModel<Node>(new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            AutoExpandRoot = true,
+            MaxAutoExpandDepth = 1
+        });
+        model.SetRoots(roots);
+        model.ExpandAll();
+
+        const double indent = 24;
+        var (root, grid) = CreateGrid(model, indent);
+
+        try
+        {
+            PumpLayout(grid);
+            AssertIndentation(grid, childA, indent, level: 1);
+
+            roots.Clear();
+            roots.Add(rootB);
+            model.ExpandAll();
+            PumpLayout(grid);
+
+            Assert.Null(model.FindNode(childA));
+            Assert.NotNull(model.FindNode(childB));
+            AssertIndentation(grid, childB, indent, level: 1);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HierarchicalIndentation_Updates_After_Child_Collection_Reset()
+    {
+        var rootNode = new Node("Root");
+        var childA = new Node("Child A");
+        var childB = new Node("Child B");
+        rootNode.Children.Add(childA);
+
+        var roots = new ObservableCollection<Node> { rootNode };
+
+        var model = new HierarchicalModel<Node>(new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            AutoExpandRoot = true,
+            MaxAutoExpandDepth = 1
+        });
+        model.SetRoots(roots);
+        model.ExpandAll();
+
+        const double indent = 24;
+        var (root, grid) = CreateGrid(model, indent);
+
+        try
+        {
+            PumpLayout(grid);
+            AssertIndentation(grid, childA, indent, level: 1);
+
+            rootNode.Children.Clear();
+            rootNode.Children.Add(childB);
+            model.ExpandAll();
+            PumpLayout(grid);
+
+            Assert.Null(model.FindNode(childA));
+            Assert.NotNull(model.FindNode(childB));
+            AssertIndentation(grid, childB, indent, level: 1);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    private static DataGridRow FindRowForItem(DataGrid grid, Node item)
+    {
+        var row = grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .FirstOrDefault(candidate => candidate.DataContext is HierarchicalNode node &&
+                ReferenceEquals(node.Item, item));
+
+        if (row != null)
+        {
+            return row;
+        }
+
+        var model = grid.HierarchicalModel;
+        if (model != null)
+        {
+            var rowIndex = model.IndexOf(item);
+            if (rowIndex >= 0)
+            {
+                var slot = grid.SlotFromRowIndex(rowIndex);
+                if (grid.ColumnDefinitions.Count > 0)
+                {
+                    var columnIndex = grid.ColumnsInternal.FirstVisibleNonFillerColumn?.Index ?? 0;
+                    grid.ScrollSlotIntoView(columnIndex, slot, forCurrentCellChange: false, forceHorizontalScroll: false);
+                }
+
+                PumpLayout(grid);
+
+                if (slot >= grid.DisplayData.FirstScrollingSlot && slot <= grid.DisplayData.LastScrollingSlot)
+                {
+                    if (grid.DisplayData.GetDisplayedElement(slot) is DataGridRow displayedRow)
+                    {
+                        return displayedRow;
+                    }
+                }
+            }
+        }
+
+        var nodeItem = model?.FindNode(item);
+        var scrollTarget = nodeItem ?? (object)item;
+
+        if (grid.ColumnDefinitions.Count > 0)
+        {
+            grid.ScrollIntoView(scrollTarget, grid.ColumnDefinitions[0]);
+        }
+
+        PumpLayout(grid);
+
+        return grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .First(candidate => candidate.DataContext is HierarchicalNode node &&
+                ReferenceEquals(node.Item, item));
+    }
+
+    private static DataGridHierarchicalPresenter FindPresenter(DataGridRow row)
+    {
+        return row.GetVisualDescendants()
+            .OfType<DataGridHierarchicalPresenter>()
+            .First();
+    }
+
+    private static void AssertIndentation(DataGrid grid, Node item, double indent, int level)
+    {
+        var row = FindRowForItem(grid, item);
+        var presenter = FindPresenter(row);
+        var expected = new Thickness(indent * level, 0, 0, 0);
+        Assert.Equal(expected, presenter.Padding);
+    }
+
+    private static (Window root, DataGrid grid) CreateGrid(HierarchicalModel<Node> model, double indent)
+    {
+        var root = new Window
+        {
+            Width = 600,
+            Height = 400,
+        };
+
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            HierarchicalRowsEnabled = true,
+            HierarchicalModel = model
+        };
+
+        grid.ColumnsInternal.Add(new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Binding = new Binding("Item.Name"),
+            Indent = indent
+        });
+
+        root.Content = grid;
+        root.Show();
+        PumpLayout(grid);
+
+        return (root, grid);
+    }
+
+    private static void PumpLayout(DataGrid grid)
+    {
+        Dispatcher.UIThread.RunJobs();
+        if (grid.GetVisualRoot() is Window window)
+        {
+            window.ApplyTemplate();
+            window.UpdateLayout();
+        }
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private sealed class Node
+    {
+        public Node(string name)
+        {
+            Name = name;
+            Children = new ObservableCollection<Node>();
+        }
+
+        public string Name { get; }
+
+        public ObservableCollection<Node> Children { get; }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.CollectionOps.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.CollectionOps.cs
@@ -511,9 +511,23 @@ namespace Avalonia.Collections
             (args.Action == NotifyCollectionChangedAction.Remove ||
             args.Action == NotifyCollectionChangedAction.Replace))
             {
-                for (var i = 0; i < args.OldItems.Count; i++)
+                var isReplace = args.Action == NotifyCollectionChangedAction.Replace;
+                var oldStartingIndex = args.OldStartingIndex;
+
+                if (oldStartingIndex >= 0 && args.OldItems.Count > 1)
                 {
-                    ProcessRemoveEvent(args.OldItems[i], args.Action == NotifyCollectionChangedAction.Replace, args.OldStartingIndex + i);
+                    for (var i = args.OldItems.Count - 1; i >= 0; i--)
+                    {
+                        ProcessRemoveEvent(args.OldItems[i], isReplace, oldStartingIndex + i);
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < args.OldItems.Count; i++)
+                    {
+                        var indexHint = oldStartingIndex >= 0 ? oldStartingIndex + i : (int?)null;
+                        ProcessRemoveEvent(args.OldItems[i], isReplace, indexHint);
+                    }
                 }
             }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.DataSource.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.DataSource.cs
@@ -453,6 +453,13 @@ internal
                 slot >= 0 &&
                 GetRowSelection(slot);
 
+            if (currentItem != null && (slot < 0 || slot >= SlotCount))
+            {
+                ClearRowSelection(true);
+                SetCurrentCellCore(-1, -1);
+                return;
+            }
+
             if (_selectionModelAdapter != null &&
                 _selectionModelAdapter.Model.SelectedIndexes.Count > 0 &&
                 !currentInSelection)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Display.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Display.cs
@@ -285,10 +285,7 @@ namespace Avalonia.Controls
                 row.Cells[CurrentColumnIndex].UpdatePseudoClasses();
             }
 
-            if (row.IsSelected || row.IsRecycled)
-            {
-                row.ApplyState();
-            }
+            row.ApplyState();
 
             // Show or hide RowDetails based on DataGrid settings
             EnsureRowDetailsVisibility(row, raiseNotification: false, animate: false);
@@ -373,6 +370,11 @@ namespace Avalonia.Controls
                 // Move hidden elements off-screen immediately to avoid stale bounds being picked up
                 // by layout-sensitive logic (e.g., tests that inspect all rows).
                 element.Arrange(new Rect(-10000, -10000, size.Width, size.Height));
+            }
+
+            if (element is DataGridRow row)
+            {
+                row.ClearPointerOverState();
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
@@ -38,7 +38,6 @@ namespace Avalonia.Controls
             using var _ = DataGridDiagnostics.BeginRowGenerate();
             activity?.SetTag(DataGridDiagnostics.Tags.RowIndex, rowIndex);
             activity?.SetTag(DataGridDiagnostics.Tags.Slot, slot);
-
             string source = null;
             DataGridRow dataGridRow = GetGeneratedRow(dataContext);
             bool isOwnContainer = false;
@@ -221,14 +220,12 @@ namespace Avalonia.Controls
                 {
                     LoadRowVisualsForDisplay(row);
 
-                    if (IsRowRecyclable(row))
+                    if (_rowsPresenter != null && !_rowsPresenter.Children.Contains(row))
                     {
-                        if (_rowsPresenter != null && !_rowsPresenter.Children.Contains(row))
-                        {
-                            _rowsPresenter.Children.Add(row);
-                        }
+                        _rowsPresenter.Children.Add(row);
                     }
-                    else
+
+                    if (!IsRowRecyclable(row))
                     {
                         element.Clip = null;
                         Debug.Assert(row.Index == RowIndexFromSlot(slot));

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Lifecycle.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Lifecycle.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Controls
 
         private void OnAddedElement_Phase2(int slot, bool updateVerticalScrollBarOnly)
         {
-            if (slot < DisplayData.FirstScrollingSlot - 1)
+            if (_suppressVerticalOffsetAdjustments == 0 && slot < DisplayData.FirstScrollingSlot - 1)
             {
                 // The element was added above our viewport so it pushes the VerticalOffset down
                 var estimator = RowHeightEstimator;

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.Layout.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.Layout.cs
@@ -164,6 +164,11 @@ namespace Avalonia.Controls
             }
         }
 
+        internal void ClearPointerOverState()
+        {
+            PseudoClassesHelper.Set(PseudoClasses, ":pointerover", false);
+        }
+
         internal void ClearDragDropState()
         {
             PseudoClassesHelper.Set(PseudoClasses, ":dragging", false);

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -403,7 +403,7 @@ internal
                     }
                     else
                     {
-                        OwningGrid.MouseOverRowIndex = null;
+                        OwningGrid.RequestPointerOverRefreshFromRow();
                     }
                 }
             }

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
@@ -112,7 +112,9 @@ internal
             };
 
             presenter.ToggleRequested += PresenterOnToggleRequested;
-            presenter.Bind(DataGridHierarchicalPresenter.LevelProperty, new Binding(nameof(HierarchicalNode.Level)));
+            presenter.Bind(
+                DataGridHierarchicalPresenter.LevelProperty,
+                new Binding(nameof(HierarchicalNode.Level)) { Mode = BindingMode.OneWay });
             presenter.Bind(
                 DataGridHierarchicalPresenter.IsExpandedProperty,
                 new Binding(nameof(HierarchicalNode.IsExpanded)) { Mode = BindingMode.OneWay });


### PR DESCRIPTION
Fix grouping indentation refresh for recycled headers and add headless coverage

# Summary
- Sync row-group header/footer metadata with current grouping info before applying indentation so padding stays correct after regrouping, scrolling, and recycling.
- Refresh grouping indentation when group headers are rebuilt to avoid stale padding for newly realized headers.
- Add headless tests that validate indentation across programmatic grouping mutations, header recycling via scrolling, and hierarchical child-collection resets.

# Implementation Details
- Grouping layout updates
  - Sync `DataGridRowGroupHeader` state (RowGroupInfo, level, property name, summary row state, pseudo classes) before computing indentation.
  - Update footer state from current RowGroupInfo before applying margins.
  - Trigger indentation refresh when `RowGroupSublevelIndents` are initialized or resized.
- Tests
  - New programmatic grouping tests assert indentation for every group header after multiple grouping mutations, including scrolling to recycle headers.
  - New hierarchical indentation test covers child-collection reset and verifies updated padding.

# Tests
- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DataGridProgrammaticGroupingIndentationTests|FullyQualifiedName~DataGridHierarchicalIndentationTests" -m:1 -v:minimal -clp:ErrorsOnly`
