### PR TITLE
Fix hierarchical range notifications so SelectionModel remains aligned after ExpandAll/CollapseAll

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalSelectionExpandCollapseTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalSelectionExpandCollapseTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.Selection;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Hierarchical;
+
+public class HierarchicalSelectionExpandCollapseTests
+{
+    private sealed class TreeItem
+    {
+        public TreeItem(string name)
+        {
+            Name = name;
+            Children = new ObservableCollection<TreeItem>();
+        }
+
+        public string Name { get; }
+
+        public ObservableCollection<TreeItem> Children { get; }
+    }
+
+    [AvaloniaFact]
+    public void SelectionModel_Allows_MouseSelection_After_ExpandAll_CollapseAll()
+    {
+        var root = BuildTree();
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = item => ((TreeItem)item).Children,
+            IsLeafSelector = item => ((TreeItem)item).Children.Count == 0,
+            VirtualizeChildren = false
+        });
+        model.SetRoot(root);
+
+        var selection = new SelectionModel<HierarchicalNode> { SingleSelect = true };
+
+        var grid = new DataGrid
+        {
+            HierarchicalRowsEnabled = true,
+            HierarchicalModel = model,
+            Selection = selection,
+            SelectionMode = DataGridSelectionMode.Single,
+            AutoGenerateColumns = false
+        };
+
+        grid.ColumnsInternal.Add(new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Binding = new Binding("Item.Name")
+        });
+
+        var window = new Window
+        {
+            Width = 800,
+            Height = 600,
+            Content = grid
+        };
+
+        window.SetThemeStyles();
+        window.Show();
+        PumpLayout(grid);
+
+        model.ExpandAll();
+        PumpLayout(grid);
+        model.CollapseAll();
+        PumpLayout(grid);
+        model.ExpandAll();
+        PumpLayout(grid);
+
+        var target = root.Children[1];
+        var exception = Record.Exception(() => InvokeMouseSelection(grid, model, target));
+
+        Assert.Null(exception);
+        Assert.NotNull(selection.SelectedItem);
+        Assert.True(selection.SelectedItem is HierarchicalNode node && ReferenceEquals(node.Item, target));
+
+        window.Close();
+    }
+
+    private static void InvokeMouseSelection(DataGrid grid, HierarchicalModel model, TreeItem target)
+    {
+        var rowIndex = model.IndexOf(target);
+        if (rowIndex < 0)
+        {
+            throw new InvalidOperationException("Target item is not visible in the flattened hierarchy.");
+        }
+
+        var slot = grid.SlotFromRowIndex(rowIndex);
+        var handled = grid.UpdateStateOnMouseLeftButtonDown(
+            CreateLeftPointerArgs(grid),
+            columnIndex: 0,
+            slot: slot,
+            allowEdit: false);
+
+        if (!handled)
+        {
+            throw new InvalidOperationException("Mouse selection was not handled by the grid.");
+        }
+    }
+
+    private static PointerPressedEventArgs CreateLeftPointerArgs(Control target)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var properties = new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed);
+        return new PointerPressedEventArgs(target, pointer, target, new Point(0, 0), 0, properties, KeyModifiers.None);
+    }
+
+    private static void PumpLayout(DataGrid grid)
+    {
+        Dispatcher.UIThread.RunJobs();
+        if (grid.GetVisualRoot() is Window window)
+        {
+            window.ApplyTemplate();
+            window.UpdateLayout();
+        }
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TreeItem BuildTree()
+    {
+        var root = new TreeItem("Root");
+        for (var i = 0; i < 3; i++)
+        {
+            var child = new TreeItem($"Child {i + 1}");
+            for (var j = 0; j < 2; j++)
+            {
+                child.Children.Add(new TreeItem($"Child {i + 1}.{j + 1}"));
+            }
+            root.Children.Add(child);
+        }
+
+        return root;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/ObservableRangeCollectionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/ObservableRangeCollectionTests.cs
@@ -1,0 +1,322 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia.Controls.DataGridHierarchical;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Hierarchical;
+
+public class ObservableRangeCollectionTests
+{
+    [Fact]
+    public void AddRange_Raises_Add_With_All_Items()
+    {
+        var collection = new ObservableRangeCollection<int>();
+        NotifyCollectionChangedEventArgs? args = null;
+        var propertyChanges = new List<string?>();
+        ((INotifyPropertyChanged)collection).PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName);
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.AddRange(new[] { 1, 2, 3 });
+
+        Assert.NotNull(args);
+        Assert.Equal(NotifyCollectionChangedAction.Add, args!.Action);
+        Assert.NotNull(args.NewItems);
+        Assert.Equal(3, args.NewItems!.Count);
+        Assert.Equal(new[] { 1, 2, 3 }, args.NewItems.Cast<int>().ToArray());
+        Assert.Equal(0, args.NewStartingIndex);
+        Assert.Contains(nameof(collection.Count), propertyChanges);
+        Assert.Contains("Item[]", propertyChanges);
+        Assert.Equal(new[] { 1, 2, 3 }, collection.ToArray());
+    }
+
+    [Fact]
+    public void RemoveRange_Raises_Remove_With_All_Items()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3, 4 });
+        NotifyCollectionChangedEventArgs? args = null;
+        var propertyChanges = new List<string?>();
+        ((INotifyPropertyChanged)collection).PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName);
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.RemoveRange(1, 2);
+
+        Assert.NotNull(args);
+        Assert.Equal(NotifyCollectionChangedAction.Remove, args!.Action);
+        Assert.NotNull(args.OldItems);
+        Assert.Equal(2, args.OldItems!.Count);
+        Assert.Equal(new[] { 2, 3 }, args.OldItems.Cast<int>().ToArray());
+        Assert.Equal(1, args.OldStartingIndex);
+        Assert.Contains(nameof(collection.Count), propertyChanges);
+        Assert.Contains("Item[]", propertyChanges);
+        Assert.Equal(new[] { 1, 4 }, collection.ToArray());
+    }
+
+    [Fact]
+    public void AddRange_Throws_When_Items_Null()
+    {
+        var collection = new ObservableRangeCollection<int>();
+
+        Assert.Throws<ArgumentNullException>(() => collection.AddRange(null!));
+    }
+
+    [Fact]
+    public void AddRange_Empty_Does_Not_Raise_CollectionChanged()
+    {
+        var collection = new ObservableRangeCollection<int>();
+        var raised = false;
+        collection.CollectionChanged += (_, __) => raised = true;
+
+        collection.AddRange(Array.Empty<int>());
+
+        Assert.False(raised);
+        Assert.Empty(collection);
+    }
+
+    [Fact]
+    public void AddRange_Materializes_Enumerable_Items()
+    {
+        var collection = new ObservableRangeCollection<int>();
+        IEnumerable<int> items = YieldItems();
+        NotifyCollectionChangedEventArgs? args = null;
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.AddRange(items);
+
+        Assert.Equal(new[] { 1, 2, 3 }, collection.ToArray());
+        Assert.NotNull(args);
+        Assert.Equal(3, args!.NewItems!.Count);
+    }
+
+    [Fact]
+    public void InsertRange_Inserts_At_Index_And_Raises_Add()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 4 });
+        NotifyCollectionChangedEventArgs? args = null;
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.InsertRange(1, new[] { 2, 3 });
+
+        Assert.Equal(new[] { 1, 2, 3, 4 }, collection.ToArray());
+        Assert.NotNull(args);
+        Assert.Equal(NotifyCollectionChangedAction.Add, args!.Action);
+        Assert.Equal(1, args.NewStartingIndex);
+        Assert.Equal(new[] { 2, 3 }, args.NewItems!.Cast<int>().ToArray());
+    }
+
+    [Fact]
+    public void InsertRange_Uses_List_For_Notify_When_Items_Are_GenericOnlyList()
+    {
+        var collection = new ObservableRangeCollection<int>();
+        var items = new GenericOnlyList<int> { 7, 8 };
+        NotifyCollectionChangedEventArgs? args = null;
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.InsertRange(0, items);
+
+        Assert.Equal(new[] { 7, 8 }, collection.ToArray());
+        Assert.NotNull(args);
+        Assert.NotNull(args!.NewItems);
+        Assert.Equal(2, args.NewItems!.Count);
+        Assert.Equal(new[] { 7, 8 }, args.NewItems.Cast<int>().ToArray());
+    }
+
+    [Fact]
+    public void InsertRange_Empty_Does_Not_Raise_CollectionChanged()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+        var raised = false;
+        collection.CollectionChanged += (_, __) => raised = true;
+
+        collection.InsertRange(1, Array.Empty<int>());
+
+        Assert.False(raised);
+        Assert.Equal(new[] { 1, 2 }, collection.ToArray());
+    }
+
+    [Fact]
+    public void InsertRange_Throws_When_Items_Null()
+    {
+        var collection = new ObservableRangeCollection<int>();
+
+        Assert.Throws<ArgumentNullException>(() => collection.InsertRange(0, null!));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    public void InsertRange_Throws_When_Index_Invalid(int index)
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.InsertRange(index, new[] { 3 }));
+    }
+
+    [Fact]
+    public void GetRange_Returns_Copy_Of_Items()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3, 4 });
+
+        var range = collection.GetRange(1, 2);
+
+        Assert.Equal(new[] { 2, 3 }, range.ToArray());
+        range[0] = 99;
+        Assert.Equal(2, collection[1]);
+    }
+
+    [Fact]
+    public void GetRange_Throws_When_Index_Negative()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.GetRange(-1, 1));
+    }
+
+    [Fact]
+    public void GetRange_Throws_When_Count_Negative()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.GetRange(0, -1));
+    }
+
+    [Fact]
+    public void GetRange_Throws_When_End_Beyond_Count()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.GetRange(2, 2));
+    }
+
+    [Fact]
+    public void RemoveRange_Count_Zero_Does_Not_Raise_CollectionChanged()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+        var raised = false;
+        collection.CollectionChanged += (_, __) => raised = true;
+
+        collection.RemoveRange(0, 0);
+
+        Assert.False(raised);
+        Assert.Equal(new[] { 1, 2 }, collection.ToArray());
+    }
+
+    [Fact]
+    public void RemoveRange_Throws_When_Index_Negative()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveRange(-1, 1));
+    }
+
+    [Fact]
+    public void RemoveRange_Throws_When_End_Beyond_Count()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveRange(1, 2));
+    }
+
+    [Fact]
+    public void ResetWith_Throws_When_Items_Null()
+    {
+        var collection = new ObservableRangeCollection<int>();
+
+        Assert.Throws<ArgumentNullException>(() => collection.ResetWith(null!));
+    }
+
+    [Fact]
+    public void ResetWith_Raises_Reset_And_Replaces_Items()
+    {
+        var collection = new ObservableRangeCollection<int>(new[] { 1, 2 });
+        NotifyCollectionChangedEventArgs? args = null;
+        var propertyChanges = new List<string?>();
+        ((INotifyPropertyChanged)collection).PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName);
+        collection.CollectionChanged += (_, e) => args = e;
+
+        collection.ResetWith(new[] { 3, 4 });
+
+        Assert.Equal(new[] { 3, 4 }, collection.ToArray());
+        Assert.NotNull(args);
+        Assert.Equal(NotifyCollectionChangedAction.Reset, args!.Action);
+        Assert.Contains(nameof(collection.Count), propertyChanges);
+        Assert.Contains("Item[]", propertyChanges);
+    }
+
+    private sealed class GenericOnlyList<T> : IList<T>
+    {
+        private readonly List<T> _items = new();
+
+        public T this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = value;
+        }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(T item)
+        {
+            _items.Add(item);
+        }
+
+        public void Clear()
+        {
+            _items.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return _items.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            _items.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        public int IndexOf(T item)
+        {
+            return _items.IndexOf(item);
+        }
+
+        public void Insert(int index, T item)
+        {
+            _items.Insert(index, item);
+        }
+
+        public bool Remove(T item)
+        {
+            return _items.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _items.RemoveAt(index);
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+    }
+
+    private static IEnumerable<int> YieldItems()
+    {
+        yield return 1;
+        yield return 2;
+        yield return 3;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/ObservableRangeCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/ObservableRangeCollection.cs
@@ -50,9 +50,10 @@ namespace Avalonia.Controls.DataGridHierarchical
                 Items.Insert(index + i, materialized[i]);
             }
 
+            var notifyItems = materialized as IList ?? materialized.ToList();
             RaiseChange(new NotifyCollectionChangedEventArgs(
                 NotifyCollectionChangedAction.Add,
-                materialized,
+                notifyItems,
                 index));
         }
 
@@ -92,9 +93,10 @@ namespace Avalonia.Controls.DataGridHierarchical
                 Items.RemoveAt(index);
             }
 
+            var notifyItems = (IList)removed;
             RaiseChange(new NotifyCollectionChangedEventArgs(
                 NotifyCollectionChangedAction.Remove,
-                removed,
+                notifyItems,
                 index));
         }
 

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -110,6 +110,9 @@
     <TabItem Header="SelectionModel Select by Item">
       <pages:SelectionModelItemSelectionPage />
     </TabItem>
+    <TabItem Header="Hierarchical Selection">
+      <pages:HierarchicalSelectionModelExpandCollapsePage />
+    </TabItem>
     <TabItem Header="Grouped Selection">
       <pages:GroupedSelectionPage />
     </TabItem>

--- a/src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml
+++ b/src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml
@@ -1,0 +1,123 @@
+<!--
+  Copyright (c) Wiesław Šoltés. All rights reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for details.
+-->
+<UserControl
+    x:Class="DataGridSample.Pages.HierarchicalSelectionModelExpandCollapsePage"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+    xmlns:hier="clr-namespace:Avalonia.Controls.DataGridHierarchical;assembly=Avalonia.Controls.DataGrid"
+    x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel"
+    d:DesignHeight="720"
+    d:DesignWidth="1100"
+    mc:Ignorable="d">
+
+  <UserControl.DataContext>
+    <viewModels:HierarchicalSelectionModelExpandCollapseViewModel />
+  </UserControl.DataContext>
+
+  <Grid Margin="12"
+        ColumnDefinitions="2*,*"
+        RowDefinitions="Auto,Auto,*"
+        ColumnSpacing="12"
+        RowSpacing="8">
+    <StackPanel Grid.ColumnSpan="2"
+                Spacing="4">
+      <TextBlock Classes="h2"
+                 Text="Hierarchical Selection" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="SelectionModel&lt;HierarchicalNode&gt; stays aligned after ExpandAll and CollapseAll operations." />
+    </StackPanel>
+
+    <WrapPanel Grid.Row="1"
+               Grid.ColumnSpan="2">
+      <Button Content="Expand all"
+              Command="{Binding ExpandAllCommand}"
+              Margin="0 0 8 8" />
+      <Button Content="Collapse all"
+              Command="{Binding CollapseAllCommand}"
+              Margin="0 0 8 8" />
+      <Button Content="Clear selection"
+              Command="{Binding ClearSelectionCommand}"
+              Margin="0 0 8 8" />
+    </WrapPanel>
+
+    <DataGrid Grid.Row="2"
+              Grid.Column="0"
+              AutoGenerateColumns="False"
+              HierarchicalModel="{Binding Model}"
+              HierarchicalRowsEnabled="True"
+              Selection="{Binding SelectionModel}"
+              SelectionMode="Extended"
+              HeadersVisibility="Column"
+              GridLinesVisibility="Horizontal"
+              x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel">
+      <DataGrid.Columns>
+        <DataGridHierarchicalColumn Header="Name"
+                                    Width="2*"
+                                    x:CompileBindings="False"
+                                    Binding="{Binding Item}">
+          <DataGridHierarchicalColumn.CellTemplate>
+            <DataTemplate x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel+TreeItem">
+              <TextBlock Text="{Binding Name}" />
+            </DataTemplate>
+          </DataGridHierarchicalColumn.CellTemplate>
+        </DataGridHierarchicalColumn>
+
+        <DataGridTemplateColumn Header="Id"
+                                Width="80"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel+TreeItem"
+                         DataContext="{Binding Item}"
+                         Text="{Binding Id}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+
+        <DataGridTemplateColumn Header="Children"
+                                Width="90"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel+TreeItem"
+                         DataContext="{Binding Item}"
+                         Text="{Binding Children.Count}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+
+    <StackPanel Grid.Row="2"
+                Grid.Column="1"
+                Spacing="8">
+      <TextBlock Classes="h3"
+                 Text="SelectionModel state" />
+      <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="4"
+              Padding="4">
+        <StackPanel Spacing="4">
+          <TextBlock Text="{Binding VisibleCount, StringFormat='Visible nodes: {0}'}" />
+          <TextBlock Text="{Binding SelectedCount, StringFormat='Selected count: {0}'}" />
+          <ItemsControl ItemsSource="{Binding SelectionModel.SelectedItems}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate x:DataType="hier:HierarchicalNode">
+                <TextBlock x:DataType="viewModels:HierarchicalSelectionModelExpandCollapseViewModel+TreeItem"
+                           DataContext="{Binding Item}"
+                           Text="{Binding Name}" />
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </Border>
+      <TextBlock Text="Expand/collapse all, then click rows to verify SelectionModel stays aligned."
+                 TextWrapping="Wrap" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml.cs
+++ b/src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    public partial class HierarchicalSelectionModelExpandCollapsePage : UserControl
+    {
+        public HierarchicalSelectionModelExpandCollapsePage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DataGridSample/Program.cs
+++ b/src/DataGridSample/Program.cs
@@ -47,6 +47,7 @@ public static class Program
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSampleViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalUndoRedoViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSelectionViewModel.TreeItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalSelectionModelExpandCollapseViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalPathSelectionViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DocumentProperty))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DataGridCollectionViewGroup))]

--- a/src/DataGridSample/ViewModels/HierarchicalSelectionModelExpandCollapseViewModel.cs
+++ b/src/DataGridSample/ViewModels/HierarchicalSelectionModelExpandCollapseViewModel.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.Selection;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class HierarchicalSelectionModelExpandCollapseViewModel : ObservableObject
+    {
+        public sealed class TreeItem
+        {
+            public TreeItem(int id, string name, TreeItem? parent = null)
+            {
+                Id = id;
+                Name = name;
+                Parent = parent;
+                Children = new ObservableCollection<TreeItem>();
+            }
+
+            public int Id { get; }
+
+            public string Name { get; }
+
+            public TreeItem? Parent { get; }
+
+            public ObservableCollection<TreeItem> Children { get; }
+        }
+
+        private int _visibleCount;
+        private int _selectedCount;
+
+        public HierarchicalSelectionModelExpandCollapseViewModel()
+        {
+            Roots = BuildSample();
+
+            var options = new HierarchicalOptions<TreeItem>
+            {
+                ChildrenSelector = item => item.Children,
+                IsLeafSelector = item => item.Children.Count == 0,
+                VirtualizeChildren = false
+            };
+
+            Model = new HierarchicalModel<TreeItem>(options);
+            Model.SetRoots(Roots);
+            Model.FlattenedChanged += (_, __) => UpdateVisibleCount();
+
+            SelectionModel = new SelectionModel<HierarchicalNode> { SingleSelect = false };
+            SelectionModel.SelectionChanged += (_, __) => UpdateSelectedCount();
+
+            ExpandAllCommand = new RelayCommand(_ => Model.ExpandAll());
+            CollapseAllCommand = new RelayCommand(_ => Model.CollapseAll());
+            ClearSelectionCommand = new RelayCommand(_ => SelectionModel.Clear());
+
+            UpdateVisibleCount();
+            UpdateSelectedCount();
+        }
+
+        public ObservableCollection<TreeItem> Roots { get; }
+
+        public HierarchicalModel<TreeItem> Model { get; }
+
+        public SelectionModel<HierarchicalNode> SelectionModel { get; }
+
+        public RelayCommand ExpandAllCommand { get; }
+
+        public RelayCommand CollapseAllCommand { get; }
+
+        public RelayCommand ClearSelectionCommand { get; }
+
+        public int VisibleCount
+        {
+            get => _visibleCount;
+            private set => SetProperty(ref _visibleCount, value);
+        }
+
+        public int SelectedCount
+        {
+            get => _selectedCount;
+            private set => SetProperty(ref _selectedCount, value);
+        }
+
+        private void UpdateVisibleCount()
+        {
+            VisibleCount = Model.Count;
+        }
+
+        private void UpdateSelectedCount()
+        {
+            SelectedCount = SelectionModel.SelectedItems.Count;
+        }
+
+        private static ObservableCollection<TreeItem> BuildSample()
+        {
+            var roots = new ObservableCollection<TreeItem>();
+            var id = 1;
+
+            for (var group = 1; group <= 3; group++)
+            {
+                var root = new TreeItem(id++, $"Group {group}");
+                for (var child = 1; child <= 3; child++)
+                {
+                    var childNode = new TreeItem(id++, $"Item {group}.{child}", root);
+                    for (var leaf = 1; leaf <= 2; leaf++)
+                    {
+                        childNode.Children.Add(new TreeItem(id++, $"Item {group}.{child}.{leaf}", childNode));
+                    }
+                    root.Children.Add(childNode);
+                }
+                roots.Add(root);
+            }
+
+            return roots;
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary: Hierarchical Selection Expand/Collapse + ObservableRangeCollection Coverage

## Overview
This change fixes hierarchical range notifications so SelectionModel remains aligned after ExpandAll/CollapseAll, adds extensive headless coverage for ObservableRangeCollection, and introduces a sample page demonstrating the behavior.

## Key Changes
- Corrected hierarchical ObservableRangeCollection range notifications to ensure list semantics are preserved for add/remove events, keeping selection indices aligned after expand/collapse.
- Added comprehensive ObservableRangeCollection unit tests covering null/empty inputs, invalid ranges, copy semantics, and property/collection change notifications.
- Added a headless regression test for hierarchical selection after ExpandAll/CollapseAll.
- Added a new sample page and view model to exercise hierarchical selection state and commands.
- Wired the sample into the main UI and added trimming hints for the new TreeItem type.
- Shortened the sample tab/page title for readability.

## Files Touched
- `src/Avalonia.Controls.DataGrid/Hierarchical/ObservableRangeCollection.cs`
- `src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/ObservableRangeCollectionTests.cs`
- `src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalSelectionExpandCollapseTests.cs`
- `src/DataGridSample/ViewModels/HierarchicalSelectionModelExpandCollapseViewModel.cs`
- `src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml`
- `src/DataGridSample/Pages/HierarchicalSelectionModelExpandCollapsePage.axaml.cs`
- `src/DataGridSample/MainWindow.axaml`
- `src/DataGridSample/Program.cs`

## Tests
- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter FullyQualifiedName~HierarchicalSelectionExpandCollapseTests`
- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter FullyQualifiedName~ObservableRangeCollectionTests`

## Notes
- Test runs produced existing warnings from unrelated files (nullable/obsolete API warnings).

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/166
