### PR TITLE
Fix the regression where `DataGrid.KeyDown` handlers no longer fire

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -895,12 +895,15 @@ internal
             _keyDownRouteFinishedSubscription = null;
             _keyUpRouteFinishedSubscription?.Dispose();
             _keyUpRouteFinishedSubscription = null;
+            KeyDown -= DataGrid_KeyDownDirectional;
 
             if (!IsAttachedToVisualTree)
             {
                 return;
             }
 
+            // Attach after XAML handlers so user KeyDown can override directional keys.
+            KeyDown += DataGrid_KeyDownDirectional;
             _keyDownRouteFinishedSubscription = InputElement.KeyDownEvent.RouteFinished.Subscribe(OnKeyDownRouteFinished);
             _keyUpRouteFinishedSubscription = InputElement.KeyUpEvent.RouteFinished.Subscribe(OnKeyUpRouteFinished);
         }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -501,9 +501,6 @@ internal
         /// </summary>
         public DataGrid()
         {
-            // Handle arrow keys early so grid navigation wins over XYFocus.
-            KeyDown += DataGrid_KeyDownDirectional;
-
             //TODO: Check if override works
             GotFocus += DataGrid_GotFocus;
             LostFocus += DataGrid_LostFocus;

--- a/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml
+++ b/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml
@@ -12,13 +12,16 @@
   <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8" Margin="12">
     <StackPanel Grid.Row="0" Spacing="4">
       <TextBlock Classes="h2">Keyboard overrides</TextBlock>
-      <TextBlock Text="Built-in key handling respects Handled and uses KeyboardGestureOverrides for remapping (try J/K for navigation)." TextWrapping="Wrap" />
+      <TextBlock Text="Built-in key handling respects Handled and uses KeyboardGestureOverrides for remapping (try J/K for navigation). Use the toggle to intercept arrow keys via KeyDown." TextWrapping="Wrap" />
     </StackPanel>
 
     <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="12">
       <CheckBox VerticalAlignment="Center"
                 Content="Use Vim navigation (J/K)"
                 IsChecked="{Binding UseVimNavigation}" />
+      <CheckBox VerticalAlignment="Center"
+                Content="Handle arrow keys in KeyDown"
+                IsChecked="{Binding HandleDirectionalKeys}" />
       <ToggleButton x:Name="KeyboardShortcutsToggle"
                     VerticalAlignment="Center"
                     Content="Keyboard shortcuts" />

--- a/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml.cs
+++ b/src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml.cs
@@ -18,6 +18,11 @@ namespace DataGridSample.Pages
                 return;
             }
 
+            if (viewModel.HandleDirectionalKeys && e.Key is Key.Up or Key.Down or Key.Left or Key.Right)
+            {
+                e.Handled = true;
+            }
+
             var modifiers = e.KeyModifiers == KeyModifiers.None ? string.Empty : $" ({e.KeyModifiers})";
             var handled = e.Handled ? " handled" : string.Empty;
             viewModel.LastKey = $"{e.Key}{modifiers}{handled}";

--- a/src/DataGridSample/ViewModels/KeyboardGestureHandlingViewModel.cs
+++ b/src/DataGridSample/ViewModels/KeyboardGestureHandlingViewModel.cs
@@ -22,6 +22,7 @@ namespace DataGridSample.ViewModels
 
             _lastKey = "None";
             _useVimNavigation = false;
+            _handleDirectionalKeys = false;
             UpdateGestureOverrides();
         }
 
@@ -55,6 +56,14 @@ namespace DataGridSample.ViewModels
         {
             get => _lastKey;
             set => SetProperty(ref _lastKey, value);
+        }
+
+        private bool _handleDirectionalKeys;
+
+        public bool HandleDirectionalKeys
+        {
+            get => _handleDirectionalKeys;
+            set => SetProperty(ref _handleDirectionalKeys, value);
         }
 
         private void UpdateGestureOverrides()


### PR DESCRIPTION
# PR Summary: KeyDown handler regression (issues #172 / #125)

## Summary
This change fixes the regression where `DataGrid.KeyDown` handlers no longer fire (or cannot override built-in navigation) after preview 15/16. It restores the intended flow from issue #125: user `KeyDown` handlers run first, can set `Handled = true`, and built-in keyboard handling only runs if the event is still unhandled.

## Problem
- Since preview 15/16, `DataGrid` directional key handling (Up/Down/Left/Right) ran before user `KeyDown` handlers.
- This prevented handlers from receiving arrow keys and from overriding built-in navigation, even when the user wanted to handle the event.
- Issue #125 expected the order: user handler -> check `Handled` -> built-in behavior. Issue #172 reported the regression.

## Fix details
### 1) KeyDown directional handling re-attached on visual tree
- The directional key handler (`DataGrid_KeyDownDirectional`) is no longer attached in the constructor.
- It is now attached in `UpdateKeyboardGestureSubscriptions()` when the grid is attached to the visual tree, and removed when detached.
- This timing ensures XAML or code-behind `KeyDown` handlers (added before attach) are registered first and run before `DataGrid_KeyDownDirectional`.

**Files:**
- `src/Avalonia.Controls.DataGrid/DataGrid.cs`
- `src/Avalonia.Controls.DataGrid/DataGrid.Input.cs`

### 2) Event flow after the change
1. User handlers (from XAML or code-behind) receive `KeyDown` first.
2. If user code sets `e.Handled = true`, built-in processing does nothing.
3. If not handled, `DataGrid_KeyDownDirectional` processes directional keys and sets `Handled` if it takes action.
4. Non-directional keys are still handled by the existing route-finished subscription (`OnKeyDownRouteFinished` -> `DataGrid_KeyDown`).

This aligns the behavior with #125 and fixes the regression from #172 without changing public API.

## Tests
### New headless coverage
The headless tests verify that directional keys respect user handlers and that built-in navigation still runs when not handled.

- `DirectionalKeys_KeyDown_Handler_Can_Block_BuiltIn`
  - Registers a `KeyDown` handler **before attach**, sets `Handled = true` for `Down`.
  - Asserts the handler is invoked and selection does not move.

- `DirectionalKeys_Run_After_KeyDown_Handlers_When_Not_Handled`
  - Registers a `KeyDown` handler **before attach**, does not handle the event.
  - Asserts the handler is invoked and selection moves as before.

Supporting update:
- `CreateGrid` now accepts a `beforeAttach` callback so tests can register handlers prior to attaching the control.

**File:**
- `src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardGestureOverrideTests.cs`

## Sample page updates
The existing Keyboard Overrides sample page now demonstrates the regression fix directly:
- A new toggle "Handle arrow keys in KeyDown" forces `Handled = true` for arrow keys.
- The "Last key" output includes whether the event was handled.
- This shows that user `KeyDown` handlers can now intercept directional keys and prevent built-in navigation.

**Files:**
- `src/DataGridSample/ViewModels/KeyboardGestureHandlingViewModel.cs`
- `src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml`
- `src/DataGridSample/Pages/KeyboardGestureHandlingPage.axaml.cs`

## Notes
- No public API changes.
- Existing keyboard gesture override logic remains unchanged.
- The fix preserves built-in navigation while restoring user override capabilities.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/172