### PR TITLE
Bind the presenter content to its `DataContext` whenever no explicit column binding is supplied

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
@@ -24,6 +24,7 @@ internal
     {
         private static readonly IValueConverter _isExpandableConverter =
             new FuncValueConverter<bool, bool>(value => !value);
+        private static readonly Binding _dataContextBinding = new Binding { Mode = BindingMode.OneWay };
 
         private readonly Lazy<IDataTemplate?> _cellTemplate;
 
@@ -154,6 +155,10 @@ internal
             if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
             {
                 presenter.Bind(ContentControl.ContentProperty, Binding);
+            }
+            else if (dataItem != DataGridCollectionView.NewItemPlaceholder)
+            {
+                presenter.Bind(ContentControl.ContentProperty, _dataContextBinding);
             }
             else
             {

--- a/src/DataGridSample/Converters/IconKeyToGeometryConverter.cs
+++ b/src/DataGridSample/Converters/IconKeyToGeometryConverter.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace DataGridSample.Converters
+{
+    public class IconKeyToGeometryConverter : IValueConverter
+    {
+        // Fluent UI System Icons (24px regular) path data.
+        private static readonly Geometry FolderGeometry = Geometry.Parse(
+            "M3.5 6.25V8H8.12868C8.32759 8 8.51836 7.92098 8.65901 7.78033L10.1893 6.25L8.65901 4.71967C8.51836 4.57902 8.32759 4.5 8.12868 4.5H5.25C4.2835 4.5 3.5 5.2835 3.5 6.25ZM2 6.25C2 4.45507 3.45507 3 5.25 3H8.12868C8.72542 3 9.29771 3.23705 9.71967 3.65901L11.5607 5.5H18.75C20.5449 5.5 22 6.95507 22 8.75V17.75C22 19.5449 20.5449 21 18.75 21H5.25C3.45507 21 2 19.5449 2 17.75V6.25ZM3.5 9.5V17.75C3.5 18.7165 4.2835 19.5 5.25 19.5H18.75C19.7165 19.5 20.5 18.7165 20.5 17.75V8.75C20.5 7.7835 19.7165 7 18.75 7H11.5607L9.71967 8.84099C9.29771 9.26295 8.72542 9.5 8.12868 9.5H3.5Z");
+
+        private static readonly Geometry DocumentGeometry = Geometry.Parse(
+            "M6 2C4.89543 2 4 2.89543 4 4V20C4 21.1046 4.89543 22 6 22H18C19.1046 22 20 21.1046 20 20V9.82777C20 9.29733 19.7893 8.78863 19.4142 8.41355L13.5864 2.58579C13.2114 2.21071 12.7027 2 12.1722 2H6ZM5.5 4C5.5 3.72386 5.72386 3.5 6 3.5H12V8C12 9.10457 12.8954 10 14 10H18.5V20C18.5 20.2761 18.2761 20.5 18 20.5H6C5.72386 20.5 5.5 20.2761 5.5 20V4ZM17.3793 8.5H14C13.7239 8.5 13.5 8.27614 13.5 8V4.62066L17.3793 8.5Z");
+
+        private static readonly Geometry CodeGeometry = Geometry.Parse(
+            "M8.06562 18.9434L14.5656 4.44339C14.7351 4.06542 15.1788 3.89637 15.5568 4.0658C15.9033 4.22112 16.0742 4.60695 15.9698 4.96131L15.9344 5.05698L9.43438 19.557C9.26495 19.935 8.82118 20.104 8.44321 19.9346C8.09673 19.7793 7.92581 19.3934 8.03024 19.0391L8.06562 18.9434L14.5656 4.44339L8.06562 18.9434ZM2.21967 11.4699L6.46967 7.21986C6.76256 6.92696 7.23744 6.92696 7.53033 7.21986C7.7966 7.48612 7.8208 7.90279 7.60295 8.1964L7.53033 8.28052L3.81066 12.0002L7.53033 15.7199C7.82322 16.0127 7.82322 16.4876 7.53033 16.7805C7.26406 17.0468 6.8474 17.071 6.55379 16.8531L6.46967 16.7805L2.21967 12.5305C1.9534 12.2642 1.9292 11.8476 2.14705 11.554L2.21967 11.4699L6.46967 7.21986L2.21967 11.4699ZM16.4697 7.21986C16.7359 6.95359 17.1526 6.92938 17.4462 7.14724L17.5303 7.21986L21.7803 11.4699C22.0466 11.7361 22.0708 12.1528 21.8529 12.4464L21.7803 12.5305L17.5303 16.7805C17.2374 17.0734 16.7626 17.0734 16.4697 16.7805C16.2034 16.5143 16.1792 16.0976 16.3971 15.804L16.4697 15.7199L20.1893 12.0002L16.4697 8.28052C16.1768 7.98762 16.1768 7.51275 16.4697 7.21986Z");
+
+        private static readonly Dictionary<string, Geometry> Map = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Folder"] = FolderGeometry,
+            ["Document"] = DocumentGeometry,
+            ["Code"] = CodeGeometry
+        };
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo? culture)
+        {
+            if (value is string key && Map.TryGetValue(key, out var geometry))
+            {
+                return geometry;
+            }
+
+            return DocumentGeometry;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo? culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -119,6 +119,9 @@
     <TabItem Header="Hierarchical Root Items">
       <pages:HierarchicalRootItemsPage />
     </TabItem>
+    <TabItem Header="Hierarchical Templated Cells">
+      <pages:HierarchicalTemplatedCellPage />
+    </TabItem>
     <TabItem Header="Grouped Selection">
       <pages:GroupedSelectionPage />
     </TabItem>

--- a/src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml
+++ b/src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml
@@ -1,0 +1,99 @@
+<!--
+  Copyright (c) Wiesław Šoltés. All rights reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for details.
+-->
+<UserControl
+    x:Class="DataGridSample.Pages.HierarchicalTemplatedCellPage"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+    xmlns:converters="clr-namespace:DataGridSample.Converters"
+    xmlns:hier="clr-namespace:Avalonia.Controls.DataGridHierarchical;assembly=Avalonia.Controls.DataGrid"
+    x:DataType="viewModels:HierarchicalTemplatedCellViewModel"
+    d:DesignHeight="720"
+    d:DesignWidth="1100"
+    mc:Ignorable="d">
+
+  <UserControl.DataContext>
+    <viewModels:HierarchicalTemplatedCellViewModel />
+  </UserControl.DataContext>
+
+  <UserControl.Resources>
+    <converters:IconKeyToGeometryConverter x:Key="IconKeyToGeometryConverter" />
+  </UserControl.Resources>
+
+  <Grid Margin="12"
+        RowDefinitions="Auto,Auto,*"
+        ColumnDefinitions="*"
+        RowSpacing="8">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2"
+                 Text="Hierarchical templated cells" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="The first column uses Fluent icons inside a templated hierarchical cell. Expand or collapse nodes to verify icons remain aligned even as rows are virtualized and recycled." />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1"
+                Orientation="Horizontal"
+                Spacing="8">
+      <Button Content="Expand all"
+              Command="{Binding ExpandAllCommand}" />
+      <Button Content="Collapse all"
+              Command="{Binding CollapseAllCommand}" />
+    </StackPanel>
+
+    <DataGrid Grid.Row="2"
+              AutoGenerateColumns="False"
+              HierarchicalModel="{Binding Model}"
+              HierarchicalRowsEnabled="True"
+              CanUserResizeColumns="True"
+              HeadersVisibility="Column"
+              GridLinesVisibility="Horizontal"
+              UseLogicalScrollable="True"
+              RowHeight="32"
+              x:DataType="viewModels:HierarchicalTemplatedCellViewModel">
+      <DataGrid.Columns>
+        <DataGridHierarchicalColumn Header="Icon"
+                                    Width="110"
+                                    x:CompileBindings="False">
+          <DataGridHierarchicalColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <Border Background="Transparent"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      IsVisible="{Binding Item.IsIconVisible}">
+                <Path Width="16"
+                      Height="16"
+                      Stretch="Uniform"
+                      Data="{Binding Item.IconKey, Converter={StaticResource IconKeyToGeometryConverter}}"
+                      Fill="{Binding $parent[DataGridRow].Foreground}" />
+              </Border>
+            </DataTemplate>
+          </DataGridHierarchicalColumn.CellTemplate>
+        </DataGridHierarchicalColumn>
+
+        <DataGridTemplateColumn Header="Name"
+                                Width="*"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock Text="{Binding Item.Name}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+
+        <DataGridTemplateColumn Header="Icon Key"
+                                Width="120"
+                                x:CompileBindings="False">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="hier:HierarchicalNode">
+              <TextBlock Text="{Binding Item.IconKey}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml.cs
+++ b/src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    public partial class HierarchicalTemplatedCellPage : UserControl
+    {
+        public HierarchicalTemplatedCellPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DataGridSample/Program.cs
+++ b/src/DataGridSample/Program.cs
@@ -51,6 +51,7 @@ public static class Program
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalExpandCollapseItemsViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalRootItemsViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalPathSelectionViewModel.TreeItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(HierarchicalTemplatedCellViewModel.TreeItem))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DocumentProperty))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DataGridCollectionViewGroup))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(DataGridPathGroupDescription))]

--- a/src/DataGridSample/ViewModels/HierarchicalTemplatedCellViewModel.cs
+++ b/src/DataGridSample/ViewModels/HierarchicalTemplatedCellViewModel.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridHierarchical;
+using DataGridSample.Mvvm;
+
+namespace DataGridSample.ViewModels
+{
+    public class HierarchicalTemplatedCellViewModel : ObservableObject
+    {
+        public class TreeItem
+        {
+            public TreeItem(string name, string iconKey, bool isIconVisible)
+            {
+                Name = name;
+                IconKey = iconKey;
+                IsIconVisible = isIconVisible;
+                Children = new ObservableCollection<TreeItem>();
+            }
+
+            public string Name { get; }
+
+            public string IconKey { get; }
+
+            public bool IsIconVisible { get; }
+
+            public ObservableCollection<TreeItem> Children { get; }
+        }
+
+        public HierarchicalTemplatedCellViewModel()
+        {
+            var root = CreateTree();
+            var options = new HierarchicalOptions<TreeItem>
+            {
+                ChildrenSelector = item => item.Children,
+                IsLeafSelector = item => item.Children.Count == 0,
+                AutoExpandRoot = true,
+                MaxAutoExpandDepth = 0,
+                VirtualizeChildren = true
+            };
+
+            Model = new HierarchicalModel<TreeItem>(options);
+            Model.SetRoot(root);
+            if (Model.Root is { } rootNode)
+            {
+                Model.Expand(rootNode);
+            }
+
+            ExpandAllCommand = new RelayCommand(_ => Model.ExpandAll());
+            CollapseAllCommand = new RelayCommand(_ => Model.CollapseAll());
+        }
+
+        public HierarchicalModel<TreeItem> Model { get; }
+
+        public RelayCommand ExpandAllCommand { get; }
+
+        public RelayCommand CollapseAllCommand { get; }
+
+        private static TreeItem CreateTree()
+        {
+            var root = new TreeItem("Workspace", "Folder", isIconVisible: true);
+
+            for (var groupIndex = 1; groupIndex <= 6; groupIndex++)
+            {
+                var group = new TreeItem($"Category {groupIndex}", "Folder", isIconVisible: true);
+
+                for (var itemIndex = 1; itemIndex <= 12; itemIndex++)
+                {
+                    var iconKey = itemIndex % 3 == 0 ? "Code" : "Document";
+                    var isVisible = itemIndex % 7 != 0;
+                    group.Children.Add(new TreeItem($"Item {groupIndex}.{itemIndex}", iconKey, isVisible));
+                }
+
+                root.Children.Add(group);
+            }
+
+            return root;
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary: Hierarchical templated cell rebinding and sample repro

## Context / Issue
Issue #171 reports that templated icons in a hierarchical `DataGrid` change unexpectedly after expanding rows. The scenario uses a `DataGridHierarchicalColumn` with a templated cell and an icon converter (binding through `HierarchicalNode.Item`). When virtualization and row recycling kick in, the visuals end up out of sync with the underlying node.

## Root Cause
`DataGridHierarchicalColumn.BindContent` only assigns `presenter.Content = dataItem` when the column has no explicit `Binding`. That is a one-time assignment made when the cell element is created. During hierarchical virtualization, rows are recycled and their `DataContext` is updated in `RefreshHierarchicalIndentation`, but the hierarchical presenter content is **not** rebinding to the new `DataContext`.  

Result: templated cells keep rendering the stale `HierarchicalNode` (from the previously recycled row), so bindings like `Item.IconKey` or converters are evaluated against the wrong item, producing the "random" icon changes seen in the report.

## Fix
Bind the presenter content to its `DataContext` whenever no explicit column binding is supplied:

- Add a reusable `Binding` (`_dataContextBinding`) in `DataGridHierarchicalColumn`.
- In `BindContent`, when `Binding` is null and the row is not the new-item placeholder, bind `Content` to the current `DataContext` instead of assigning it once.

This ensures recycled rows automatically rebind the hierarchical presenter content as the row’s `DataContext` changes, keeping templated bindings aligned with the correct node.

## Tests
Added a headless regression test to prove the rebinding behavior under row recycling:

- **Test:** `Templated_Hierarchical_Cell_Rebinds_When_Row_Recycled`  
- **What it does:**  
  - Builds a large hierarchical tree so virtualization is active.  
  - Uses a `DataGridHierarchicalColumn` with a templated cell binding to `Item.Name`.  
  - Scrolls to force row recycling.  
  - Verifies the recycled rows’ `DataGridHierarchicalPresenter.Content` matches the new `HierarchicalNode`, and the `TextBlock` displays the correct name.

This directly targets the original failure mode: stale presenter content after recycling.

## Sample / Repro Page
Added a dedicated sample page that mirrors the issue scenario and showcases the fix:

- **New page:** `HierarchicalTemplatedCellPage`
- **Key behaviors:**  
  - Hierarchical model with `VirtualizeChildren = true`.  
  - First column is a templated hierarchical cell with icon visibility and a converter driven by `Item.IconKey`.  
  - Additional columns show the name and icon key for quick visual validation.  
  - Includes Expand/Collapse controls for quick stress testing.

Support code includes:
- **Converter:** `IconKeyToGeometryConverter` to map icon keys to simple geometries.
- **ViewModel:** `HierarchicalTemplatedCellViewModel` to seed a multi-level tree with varying icon keys/visibility.
- **Tab registration:** Adds the page to `MainWindow.axaml` for quick access.
- **Trimming:** Adds a `DynamicDependency` entry for the new `TreeItem` type.

## Files Touched
- `src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs`  
  Rebinds hierarchical presenter content to `DataContext` when no explicit binding exists.
- `src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs`  
  Adds the row-recycling rebinding regression test.
- `src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml`  
  New sample page with templated icons and virtualization stress.
- `src/DataGridSample/Pages/HierarchicalTemplatedCellPage.axaml.cs`  
  Page code-behind.
- `src/DataGridSample/ViewModels/HierarchicalTemplatedCellViewModel.cs`  
  Sample data + hierarchical model setup.
- `src/DataGridSample/Converters/IconKeyToGeometryConverter.cs`  
  Maps icon keys to geometries for the sample.
- `src/DataGridSample/MainWindow.axaml`  
  Adds the new sample tab.
- `src/DataGridSample/Program.cs`  
  Adds trimming hints for the new sample item type.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/171