### PR TITLE
Clear cell‑level validation errors

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -359,6 +359,36 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_edit_clears_cell_errors_while_editing()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid();
+
+        try
+        {
+            var slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(column.Index, slot, DataGridSelectionAction.SelectCurrent, scrollIntoView: false));
+            grid.UpdateLayout();
+
+            var cell = FindCell(grid, item, column.Index);
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            var editingCell = FindCell(grid, item, column.Index);
+            var textBox = Assert.IsType<TextBox>(editingCell.Content);
+
+            Assert.False(DataValidationErrors.GetHasErrors(editingCell));
+            Assert.True(DataValidationErrors.GetHasErrors(textBox));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_validation_restores_on_row_recycle()
     {
         var (grid, root, item, column) = CreateNotifyValidationGrid();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -328,6 +328,8 @@ internal
 
             // Finally, we can prepare the cell for editing
             _editingCellValidationSnapshot = CellValidationSnapshot.Capture(dataGridCell);
+            // Hide existing cell errors while editing to avoid duplicate validation visuals.
+            DataValidationErrors.ClearErrors(dataGridCell);
             _editingColumnIndex = CurrentColumnIndex;
             _editingEventArgs = editingEventArgs;
             dataGridCell.UpdatePseudoClasses();


### PR DESCRIPTION
Cleared cell‑level validation errors when a cell enters edit so the editing control owns the validation visuals and you don’t get the duplicate warning icon; added a regression test that exercises INotifyDataErrorInfo warnings during edit mode.

- Updated DataGrid.Editing.cs to clear cell errors on edit start to avoid duplicated icons.
- Added INotifyDataErrorInfo_edit_clears_cell_errors_while_editing in DataGridValidationTests.cs.

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/179