### PR TITLE
Allow subclass of DataGrid to render themes immediately

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -116,6 +116,9 @@ internal
         private const double DATAGRID_defaultMinColumnWidth = 20;
         private const double DATAGRID_defaultMaxColumnWidth = double.PositiveInfinity;
 
+        // custom subclasses can inherit the base DataGrid style by default.
+        protected override Type StyleKeyOverride => typeof(DataGrid);
+
         /// <summary>
         /// Invoked when preparing a row container for an item.
         /// Mirrors ItemsControl naming while using the DataGrid row pipeline.


### PR DESCRIPTION
This line of change doesn't break any API surface, but immediately enables all controls derived from this data grid to render properly with the themes. Otherwise, they won't render unless they override it themselves.

WPF data grid has this feature, so adding it helps on feature parity.