### PR TITLE
Enhance DataGrid with row details template selector

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/RowDetailsTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/RowDetailsTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Data;
+using Xunit;
+
+namespace ProDataGrid.UnitTests.Extras
+{
+    public class RowDetailsTests
+    {
+        [Fact]
+        public void RowDetailsTemplate_IsUsed_WhenVisibilityVisible()
+        {
+            var grid = new DataGrid();
+
+            grid.Columns.Add(new DataGridTextColumn { Header = "Id", Binding = new Binding("Id") });
+            grid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = new Binding("Name") });
+
+            // Use RowDetailsTemplateSelector to select per-item templates
+            grid.RowDetailsTemplateSelector = new TestRowDetailsSelector();
+
+            grid.RowDetailsVisibilityMode = DataGridRowDetailsVisibilityMode.VisibleWhenSelected;
+
+            var items = Enumerable.Range(1, 5).Select(i => new { Id = i, Name = "Name " + i }).ToArray();
+            grid.ItemsSource = items;
+
+            // Select second item
+            grid.SelectedItem = items[1];
+
+            // The grid should create row details for the selected item when generating containers.
+            // We cannot force full visual generation in headless tests, but the RowDetailsTemplate should be set and callable.
+            // The selector should be set and return a usable template for the selected item
+            var selector = grid.RowDetailsTemplateSelector;
+            Assert.NotNull(selector);
+
+            var selectedTemplate = selector.SelectTemplate(items[1], grid);
+            Assert.NotNull(selectedTemplate);
+
+            // Call the template's factory directly (headless test) to get the produced control
+            object produced1;
+            if (selectedTemplate.Content is System.Func<object, object> factory1)
+            {
+                produced1 = factory1(items[1]);
+            }
+            else
+            {
+                produced1 = selectedTemplate.Build(items[1]);
+            }
+
+            Assert.NotNull(produced1);
+            Assert.IsType<TextBlock>(produced1);
+            Assert.Contains("DETAILS:Name 2", ((TextBlock)produced1).Text);
+
+            // Also verify a different item gets a different template (odd/even)
+            var selectedTemplate3 = selector.SelectTemplate(items[2], grid);
+            Assert.NotNull(selectedTemplate3);
+            object produced3;
+            if (selectedTemplate3.Content is System.Func<object, object> factory3)
+            {
+                produced3 = factory3(items[2]);
+            }
+            else
+            {
+                produced3 = selectedTemplate3.Build(items[2]);
+            }
+
+            Assert.NotNull(produced3);
+            Assert.IsType<TextBlock>(produced3);
+            Assert.Contains("ALT_DETAILS:Name 3", ((TextBlock)produced3).Text);
+        }
+    }
+
+    // Simple selector that returns a FuncDataTemplate rendering the Name property
+    class TestRowDetailsSelector : DataGrid.DataTemplateSelector
+    {
+        public override DataTemplate SelectTemplate(object item, AvaloniaObject container)
+        {
+            var idProp = item?.GetType().GetProperty("Id");
+            var nameProp = item?.GetType().GetProperty("Name");
+            var idVal = idProp?.GetValue(item) as int? ?? 0;
+            var nameVal = nameProp?.GetValue(item) ?? "";
+
+            var text = (idVal % 2 == 0) ? "DETAILS:" + nameVal : "ALT_DETAILS:" + nameVal;
+
+            var dt = new DataTemplate();
+            dt.Content = new System.Func<object, object>(_ => new TextBlock { Text = text });
+            return dt;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -1391,6 +1391,21 @@ internal
             set { SetValue(RowDetailsTemplateProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets the template selector that is used to select the template
+        /// </summary>
+        public static readonly StyledProperty<DataTemplateSelector> RowDetailsTemplateSelectorProperty =
+            AvaloniaProperty.Register<DataGrid, DataTemplateSelector>(nameof(RowDetailsTemplateSelector));
+
+        /// <summary>
+        /// Gets or sets the template selector that is used to select the template
+        /// </summary>
+        public DataTemplateSelector RowDetailsTemplateSelector
+        {
+            get { return GetValue(RowDetailsTemplateSelectorProperty); }
+            set { SetValue(RowDetailsTemplateSelectorProperty, value); }
+        }
+
 #if !DATAGRID_INTERNAL
         public
 #else

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Details.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Details.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls
             }
             if (RowDetailsVisibilityMode == DataGridRowDetailsVisibilityMode.Visible)
             {
-                // Total rows minus ones which explicity turned details off minus the RowGroupHeaders
+                // Total rows minus ones which explicitly turned details off minus the RowGroupHeaders
                 int groupSlotCount = RowGroupHeadersTable.GetIndexCount(lowerBound, upperBound) +
                     RowGroupFootersTable.GetIndexCount(lowerBound, upperBound);
                 return indexCount - _showDetailsTable.GetIndexCount(lowerBound, upperBound, false) - groupSlotCount;
@@ -71,12 +71,16 @@ namespace Avalonia.Controls
 
         private void UpdateRowDetailsHeightEstimate()
         {
-            if (_rowsPresenter != null && _measured && RowDetailsTemplate != null)
+            if (_rowsPresenter != null && _measured && HasRowDetailsTemplate)
             {
                 object dataItem = null;
-                if(VisibleSlotCount > 0)
-                dataItem = DataConnection.GetDataItem(0);
-                var detailsContent = RowDetailsTemplate.Build(dataItem);
+                if (VisibleSlotCount > 0)
+                {
+                    dataItem = DataConnection.GetDataItem(0);
+                }
+
+                var detailsTemplate = GetRowDetailsTemplate(dataItem, this);
+                var detailsContent = detailsTemplate?.Build(dataItem);
                 if (detailsContent != null)
                 {
                     detailsContent.DataContext = dataItem;
@@ -123,7 +127,7 @@ namespace Avalonia.Controls
             Debug.Assert(rowIndex != -1);
             if (_showDetailsTable.Contains(rowIndex))
             {
-                // The user explicity set DetailsVisibility on a row so we should respect that
+                // The user explicitly set DetailsVisibility on a row so we should respect that
                 return _showDetailsTable.GetValueAt(rowIndex);
             }
             else

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Scroll.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Scroll.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
                             NegVerticalOffset = 0;
                             //
                             if (height > 2 * CellsEstimatedHeight &&
-                            (RowDetailsVisibilityMode != DataGridRowDetailsVisibilityMode.VisibleWhenSelected || RowDetailsTemplate == null))
+                            (RowDetailsVisibilityMode != DataGridRowDetailsVisibilityMode.VisibleWhenSelected || !HasRowDetailsTemplate))
                             {
                                 // Very large scroll occurred. Instead of determining the exact number of scrolled off rows,
                                 // let's estimate the number based on RowHeight.
@@ -138,7 +138,7 @@ namespace Avalonia.Controls
                         //
 
                         if (height < -2 * CellsEstimatedHeight &&
-                        (RowDetailsVisibilityMode != DataGridRowDetailsVisibilityMode.VisibleWhenSelected || RowDetailsTemplate == null))
+                        (RowDetailsVisibilityMode != DataGridRowDetailsVisibilityMode.VisibleWhenSelected || !HasRowDetailsTemplate))
                         {
                             // Very large scroll occurred. Instead of determining the exact number of scrolled off rows,
                             // let's estimate the number based on RowHeight.

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -503,6 +503,7 @@ internal
             Visual.IsVisibleProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnIsVisibleChanged(e));
             AreRowGroupHeadersFrozenProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnAreRowGroupHeadersFrozenChanged(e));
             RowDetailsTemplateProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowDetailsTemplateChanged(e));
+            RowDetailsTemplateSelectorProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowDetailsTemplateSelectorChanged(e));
             RowDetailsVisibilityModeProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowDetailsVisibilityModeChanged(e));
             AutoGenerateColumnsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnAutoGenerateColumnsChanged(e));
             RowHeightEstimatorProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowHeightEstimatorChanged(e));

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -612,18 +612,6 @@ internal
             base.OnPointerExited(e);
         }
 
-
-
-
-
-
-
-
-
-
-
-
-
         private void DataGridCellCollection_CellAdded(object sender, DataGridCellEventArgs e)
         {
             _cellsElement?.Children.Add(e.Cell);
@@ -653,14 +641,19 @@ internal
         }
 
 
-        // Returns the actual template that should be sued for Details: either explicity set on this row
+        // Returns the actual template that should be sued for Details: either explicitly set on this row
         // or inherited from the DataGrid
         private IDataTemplate ActualDetailsTemplate
         {
             get
             {
                 Debug.Assert(OwningGrid != null);
-                return DetailsTemplate ?? OwningGrid.RowDetailsTemplate;
+                if (DetailsTemplate != null)
+                {
+                    return DetailsTemplate;
+                }
+
+                return OwningGrid.GetRowDetailsTemplate(DataContext, this);
             }
         }
 

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -263,6 +263,9 @@
     <TabItem Header="Filtering Model">
       <pages:FilteringModelSamplePage />
     </TabItem>
+    <TabItem Header="Row Details Template Selector">
+      <pages:RowDetailsPage />
+    </TabItem>
     <TabItem Header="Search Model">
       <pages:SearchModelPage />
     </TabItem>

--- a/src/DataGridSample/Models/LocalSampleDetail.cs
+++ b/src/DataGridSample/Models/LocalSampleDetail.cs
@@ -1,0 +1,9 @@
+namespace DataGridSample.Models
+{
+    public class LocalSampleDetail
+    {
+        public string Field { get; init; } = string.Empty;
+
+        public string Value { get; init; } = string.Empty;
+    }
+}

--- a/src/DataGridSample/Models/LocalSampleItem.cs
+++ b/src/DataGridSample/Models/LocalSampleItem.cs
@@ -1,0 +1,22 @@
+using System.Collections.ObjectModel;
+
+namespace DataGridSample.Models
+{
+    public class LocalSampleItem
+    {
+        public LocalSampleItem()
+        {
+            Details = new ObservableCollection<LocalSampleDetail>();
+        }
+
+        public int Id { get; set; }
+
+        public string? Name { get; set; }
+
+        public string? Info { get; set; }
+
+        public ObservableCollection<LocalSampleDetail> Details { get; }
+
+        public override string ToString() => $"{Id}: {Name} - {Info}";
+    }
+}

--- a/src/DataGridSample/Pages/RowDetailsPage.axaml
+++ b/src/DataGridSample/Pages/RowDetailsPage.axaml
@@ -1,0 +1,34 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:pages="clr-namespace:DataGridSample.Pages"
+             xmlns:local="clr-namespace:DataGridSample"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:dg="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.DataGrid"
+             x:Class="DataGridSample.Pages.RowDetailsTemplateSelectorPage">
+
+  <Grid Margin="8">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.Row="0" Orientation="Vertical" Spacing="4" Margin="0 0 0 8">
+      <TextBlock Text="Row Details Template Selector" FontSize="20" FontWeight="SemiBold"/>
+      <TextBlock Text="Select a row to reveal a richly styled details section that the selector paints differently per item." TextWrapping="Wrap"/>
+    </StackPanel>
+
+    <dg:DataGrid x:Name="SampleGrid"
+                 Grid.Row="1"
+                 AutoGenerateColumns="False"
+                 RowDetailsVisibilityMode="VisibleWhenSelected"
+                 Margin="0"
+                 x:DataType="models:LocalSampleItem">
+      <dg:DataGrid.Columns>
+        <dg:DataGridTextColumn Header="ID" Binding="{CompiledBinding Id}" Width="Auto" />
+        <dg:DataGridTextColumn Header="Name" Binding="{CompiledBinding Name}" Width="2*" />
+        <dg:DataGridTextColumn Header="Info" Binding="{CompiledBinding Info}" Width="3*" />
+      </dg:DataGrid.Columns>
+    </dg:DataGrid>
+  </Grid>
+
+</UserControl>

--- a/src/DataGridSample/Pages/RowDetailsPage.axaml.cs
+++ b/src/DataGridSample/Pages/RowDetailsPage.axaml.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using DataGridSample.Models;
+using DataGridSample.ViewModels;
+
+namespace DataGridSample.Pages
+{
+    public partial class RowDetailsTemplateSelectorPage : UserControl
+    {
+        private readonly ObservableCollection<LocalSampleItem> _items = RowDetailsSampleDataProvider.CreateSampleItems();
+
+        public RowDetailsTemplateSelectorPage()
+        {
+            InitializeComponent();
+
+            // Assign sample data
+            SampleGrid.ItemsSource = _items;
+
+            // Assign runtime selector instance to avoid XAML type-resolution conflicts
+            SampleGrid.RowDetailsTemplateSelector = new Selectors.RowDetailsTemplateSelector();
+        }
+    }
+}

--- a/src/DataGridSample/Pages/RowDetailsPage.cs
+++ b/src/DataGridSample/Pages/RowDetailsPage.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages
+{
+    // Backwards-compatible stub so XAML references to RowDetailsPage continue to work.
+    public class RowDetailsPage : RowDetailsTemplateSelectorPage
+    {
+    }
+}

--- a/src/DataGridSample/Selectors/RowDetailsTemplateSelector.cs
+++ b/src/DataGridSample/Selectors/RowDetailsTemplateSelector.cs
@@ -1,0 +1,143 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Media;
+using Avalonia.Layout;
+using DataGridSample.Models;
+using System;
+
+namespace DataGridSample.Selectors
+{
+    public class RowDetailsTemplateSelector : DataGrid.DataTemplateSelector
+    {
+        private static readonly Binding FieldBinding = new Binding(nameof(LocalSampleDetail.Field));
+        private static readonly Binding ValueBinding = new Binding(nameof(LocalSampleDetail.Value));
+
+        public override DataTemplate SelectTemplate(object item, AvaloniaObject container)
+        {
+            if (item is LocalSampleItem dataItem)
+            {
+                return CreateTemplate(dataItem);
+            }
+
+            return null;
+        }
+
+        private static DataTemplate CreateTemplate(LocalSampleItem sample)
+        {
+            var dt = new DataTemplate();
+            dt.Content = new Func<IServiceProvider, object>(_ =>
+            {
+                var even = sample.Id % 2 == 0;
+                var accentBackground = even ? new SolidColorBrush(Color.FromRgb(227, 242, 253)) : new SolidColorBrush(Color.FromRgb(255, 243, 224));
+                var accentBorder = even ? new SolidColorBrush(Color.FromRgb(30, 136, 229)) : new SolidColorBrush(Color.FromRgb(251, 140, 0));
+                var labelBrush = even ? new SolidColorBrush(Color.FromRgb(13, 71, 161)) : new SolidColorBrush(Color.FromRgb(109, 76, 65));
+
+                var border = new Border
+                {
+                    Background = accentBackground,
+                    BorderBrush = accentBorder,
+                    BorderThickness = new Thickness(1.5),
+                    CornerRadius = new CornerRadius(9),
+                    Padding = new Thickness(12),
+                    Margin = new Thickness(6, 10, 6, 6),
+                };
+
+                var containerPanel = new StackPanel
+                {
+                    Spacing = 10,
+                };
+
+                var titleText = new TextBlock
+                {
+                    Text = even ? "DETAILS VIEW" : "ALT DETAILS VIEW",
+                    FontSize = 18,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = accentBorder,
+                };
+
+                var infoText = new TextBlock
+                {
+                    Text = sample.Info ?? "No description available.",
+                    FontSize = even ? 14 : 13,
+                    FontWeight = even ? FontWeight.Normal : FontWeight.Medium,
+                    Foreground = labelBrush,
+                    TextWrapping = TextWrapping.Wrap,
+                };
+
+                var nameText = new TextBlock
+                {
+                    Text = $"Name: {sample.Name ?? "Unknown"}",
+                    FontSize = 12,
+                    FontStyle = even ? FontStyle.Normal : FontStyle.Italic,
+                    Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66))
+                };
+
+                var badge = new Border
+                {
+                    Background = accentBorder,
+                    CornerRadius = new CornerRadius(4),
+                    Padding = new Thickness(6, 2),
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    Child = new TextBlock
+                    {
+                        Text = even ? $"PRIMARY · {sample.Details.Count} rows" : $"ALTERNATE · {sample.Details.Count} rows",
+                        FontSize = 10,
+                        FontWeight = FontWeight.Bold,
+                        Foreground = Brushes.White
+                    }
+                };
+
+                containerPanel.Children.Add(titleText);
+                containerPanel.Children.Add(infoText);
+                containerPanel.Children.Add(nameText);
+                containerPanel.Children.Add(badge);
+                containerPanel.Children.Add(CreateDetailsGrid(sample, even));
+
+                border.Child = containerPanel;
+
+                return new TemplateResult<Control>(border, null!);
+            });
+
+            return dt;
+        }
+
+        private static DataGrid CreateDetailsGrid(LocalSampleItem sample, bool even)
+        {
+            var background = even ? new SolidColorBrush(Color.FromRgb(250, 250, 255)) : new SolidColorBrush(Color.FromRgb(255, 251, 241));
+            var rowBackground = even ? new SolidColorBrush(Color.FromRgb(235, 245, 255)) : new SolidColorBrush(Color.FromRgb(255, 244, 229));
+
+            var grid = new DataGrid
+            {
+                Margin = new Thickness(0, 6, 0, 0),
+                ItemsSource = sample.Details,
+                AutoGenerateColumns = false,
+                IsReadOnly = true,
+                HeadersVisibility = DataGridHeadersVisibility.Column,
+                CanUserResizeColumns = false,
+                CanUserSortColumns = false,
+                BorderThickness = new Thickness(0),
+                Background = background,
+                RowBackground = rowBackground,
+                Height = 150
+            };
+
+            grid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Field",
+                Binding = FieldBinding,
+                Width = new DataGridLength(2, DataGridLengthUnitType.Star)
+            });
+            grid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Value",
+                Binding = ValueBinding,
+                Width = new DataGridLength(3, DataGridLengthUnitType.Star)
+            });
+
+            return grid;
+        }
+    }
+}

--- a/src/DataGridSample/ViewModels/RowDetailsSampleDataProvider.cs
+++ b/src/DataGridSample/ViewModels/RowDetailsSampleDataProvider.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.ObjectModel;
+using DataGridSample.Models;
+
+namespace DataGridSample.ViewModels
+{
+    public static class RowDetailsSampleDataProvider
+    {
+        public static ObservableCollection<LocalSampleItem> CreateSampleItems(int count = 100)
+        {
+            var items = new ObservableCollection<LocalSampleItem>();
+
+            var descriptions = new[]
+            {
+                "Primary service",
+                "Replica service",
+                "Analytics worker",
+                "Telemetry ingestion",
+                "Streaming broker",
+                "Cache layer",
+                "Batch processor",
+                "Edge proxy"
+            };
+
+            var priorities = new[] { "High", "Medium", "Low" };
+            var owners = new[] { "Infrastructure", "Data", "Insights", "Observability", "Platform" };
+            var statuses = new[] { "Running", "Syncing", "Idle", "Active", "Paused" };
+            var regions = new[] { "us-east", "us-west", "eu-central", "ap-south", "sa-east" };
+
+            for (int i = 1; i <= count; i++)
+            {
+                var baseIndex = i - 1;
+                var details = new[]
+                {
+                    ("Priority", priorities[baseIndex % priorities.Length]),
+                    ("Owner", owners[baseIndex % owners.Length]),
+                    ("Status", statuses[baseIndex % statuses.Length]),
+                    ("Region", regions[baseIndex % regions.Length]),
+                    ("Last Seen", DateTime.UtcNow.AddMinutes(-baseIndex * 3).ToString("HH:mm:ss")),
+                    ("Version", $"v{1 + (baseIndex % 4)}.{baseIndex % 10}")
+                };
+
+                var item = new LocalSampleItem
+                {
+                    Id = i,
+                    Name = $"Node {i:D3}",
+                    Info = descriptions[baseIndex % descriptions.Length]
+                };
+
+                foreach (var detail in details)
+                {
+                    item.Details.Add(new LocalSampleDetail
+                    {
+                        Field = detail.Item1,
+                        Value = detail.Item2
+                    });
+                }
+
+                items.Add(item);
+            }
+
+            return items;
+        }
+    }
+}


### PR DESCRIPTION
# Row Details Template Selector

## Summary

Follow WPF's design for this feature. #191

## Goals and Constraints

* Trimming/AOT compatible
* Same API and feature parity with WPF

### New/Updated API Surface

* `DataTemplateSelector`: new base class for template selector.
  * `SelectTemplate`: abstract method to be implemented by derived classes
* `DataGrid`: adds two public properties, `RowDetailsTemplateSelectorProperty` and `RowDetailsTemplateSelector` accordingly.

• RowDetailsPage (code file) now inherits from the new page to keep legacy references intact.
• MainWindow.axaml: renames the tab to “Row Details Template Selector” to match the new narrative.

## Usage Examples / Validation

``` csharp
SampleGrid.RowDetailsTemplateSelector = new Selectors.RowDetailsTemplateSelector();
```

``` csharp
    public class RowDetailsTemplateSelector : DataGrid.DataTemplateSelector
    {
        public override DataTemplate SelectTemplate(object item, AvaloniaObject container)
        {
            if (item is Item1 dataItem1)
            {
                return CreateTemplate1(dataItem1);
            }

            if (item is Item2 dataItem2)
            {
                return CreateTemplate2(dataItem2);
            }

            return null;
        }
```

## Samples Pages Added

New `RowDetailsPage` demonstrates the feature.

## Documentation Added

None. Users might refer to WPF docs.

## Tests Added

`RowDetailsTests`.

## Notes for Reviewers

N/A

