### PR TITLE
Fix DoubleTapped on Unselected Rows

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.DragSelection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.DragSelection.cs
@@ -40,7 +40,7 @@ internal
         private int _dragLastColumnIndex = -1;
         private bool _dragCapturePending;
 
-        internal void TryBeginSelectionDrag(PointerPressedEventArgs e, int columnIndex, bool startDragging, bool deferCapture)
+        internal void TryBeginSelectionDrag(PointerPressedEventArgs e, int columnIndex, bool startDragging)
         {
             if (!startDragging)
             {
@@ -77,7 +77,8 @@ internal
             _dragLastColumnIndex = CurrentColumnIndex;
             _dragAnchorSlot = AnchorSlot != -1 ? AnchorSlot : CurrentSlot;
             _dragAnchorCell = null;
-            _dragCapturePending = deferCapture;
+            // Defer capture until drag threshold so taps/double taps keep original source.
+            _dragCapturePending = true;
 
             if (!_isRowSelectionDragging)
             {
@@ -112,10 +113,7 @@ internal
                 }
             }
 
-            if (!deferCapture)
-            {
-                _dragPointer.Capture(this);
-            }
+            // Capture happens once the drag threshold is met.
         }
 
         private bool ShouldDragSelectRows(int columnIndex)

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -248,7 +248,7 @@ internal
                         bool allowEdit = !e.Handled && focusWithin && isSelected && !ctrl &&
                                          OwningGrid.ShouldBeginEditOnPointer(e);
                         var handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, ColumnIndex, OwningRow.Slot, allowEdit);
-                        OwningGrid.TryBeginSelectionDrag(e, ColumnIndex, shouldHandleSelection, allowEdit);
+                        OwningGrid.TryBeginSelectionDrag(e, ColumnIndex, shouldHandleSelection);
 
                         // Do not handle PointerPressed with touch or pen,
                         // so we can start scroll gesture on the same event.

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -229,7 +229,7 @@ internal
                     Debug.Assert(sender is DataGridRowHeader);
                     Debug.Assert(sender == this);
                     e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, -1, Slot, false);
-                    OwningGrid.TryBeginSelectionDrag(e, -1, startDragging: true, deferCapture: false);
+                    OwningGrid.TryBeginSelectionDrag(e, -1, startDragging: true);
                 }
             }
             else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)

--- a/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
+++ b/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
@@ -37,6 +37,7 @@ namespace Avalonia.Controls.DataGridDragDrop
         private DataGridRowDropPosition? _indicatorPosition;
         private bool _disposed;
         private IPointer? _capturedPointer;
+        private bool _capturePending;
         private readonly bool _setAllowDrop;
         private Canvas? _dropAdorner;
         private bool _hideDropAdorner;
@@ -363,12 +364,10 @@ namespace Avalonia.Controls.DataGridDragDrop
                 return;
             }
 
-            e.Pointer.Capture(_grid);
-            _capturedPointer = e.Pointer;
-
             _pointerId = e.Pointer.Id;
-            _pointerStart = e.GetPosition(_grid);
+            _pointerStart = gridPoint;
             _dragStartRow = row;
+            _capturePending = true;
         }
 
         private void OnPointerMoved(object? sender, PointerEventArgs e)
@@ -397,6 +396,16 @@ namespace Avalonia.Controls.DataGridDragDrop
                 return;
             }
 
+            if (_capturePending)
+            {
+                _capturePending = false;
+                if (e.Pointer.Captured == null)
+                {
+                    e.Pointer.Capture(_grid);
+                }
+                _capturedPointer = e.Pointer;
+            }
+
             StartDragAsync(e);
         }
 
@@ -416,6 +425,7 @@ namespace Avalonia.Controls.DataGridDragDrop
             _pointerStart = default;
             _dragStartRow = null;
             _dragInfo = null;
+            _capturePending = false;
             _capturedPointer?.Capture(null);
             _capturedPointer = null;
         }


### PR DESCRIPTION
# PR Summary: Fix DoubleTapped on Unselected Rows (Pointer Capture)

## Bug
- DoubleTapped does not raise on an arbitrary (unselected) DataGrid row. The event only fires when double-tapping the already selected row.
- Repro reported in `ProDataGrid` issue #194 and seen in the sample's BasicPage.

## Root Cause
- Avalonia's gesture system raises `DoubleTapped` on the current pointer capture target.
- DataGrid selection and row-reorder code captured the pointer immediately on `PointerPressed`.
- This caused subsequent double-tap presses to be captured by the `DataGrid` (not the row/cell), so `DoubleTapped` was raised on the grid instead of the row. Handlers attached to rows therefore never fired unless the row was already selected (and thus not changing capture behavior).

## Fix
- Defer pointer capture for selection drag until the drag threshold is actually met.
  - `DataGrid.Input.DragSelection.cs`: `TryBeginSelectionDrag` now always defers capture and only captures after the drag threshold is exceeded.
  - `DataGridCell.cs` and `DataGridRowHeader.cs`: updated to call the new `TryBeginSelectionDrag` signature.
- Defer pointer capture for row drag-drop until the drag threshold is met.
  - `DataGridRowDragDropController.cs`: `PointerPressed` no longer captures immediately; capture now occurs only after the drag threshold in `PointerMoved`.

This keeps the original row/cell as the capture target during taps and double taps, restoring the expected `DoubleTapped` routing.

## Tests Added
- `DataGridInputMouseSelectionTests`
  - `DoubleTapped_Raises_On_Unselected_Row`
  - `SelectionDrag_Defers_Pointer_Capture_Until_Threshold`
  - `RowHeaderSelectionDrag_Defers_Pointer_Capture_Until_Threshold`
- `DataGridRowDragDropControllerTests`
  - `PointerPressed_Defers_Capture_For_Row_Drag`

## Test Command
```
dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~DoubleTapped_Raises_On_Unselected_Row|FullyQualifiedName~SelectionDrag_Defers_Pointer_Capture_Until_Threshold|FullyQualifiedName~RowHeaderSelectionDrag_Defers_Pointer_Capture_Until_Threshold|FullyQualifiedName~PointerPressed_Defers_Capture_For_Row_Drag"
```

Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/194