### PR TITLE
Fx Selection Stops Working (InvalidCast in SelectedItemsView)

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Selection/SelectedItemsViewTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Selection/SelectedItemsViewTests.cs
@@ -181,6 +181,21 @@ public class SelectedItemsViewTests
         Assert.False(model.IsSelected(2));
     }
 
+    [Fact]
+    public void SelectedItemsView_Handles_Source_Items_With_Invalid_Type()
+    {
+        var model = new SelectionModel<Node>
+        {
+            SingleSelect = false,
+            Source = new object[] { new List<Node> { new Node("a") } }
+        };
+
+        var view = new SelectedItemsView(model);
+        model.Select(0);
+
+        Assert.Empty(view.Cast<Node>());
+    }
+
     private sealed class Node
     {
         public Node(string value)

--- a/src/Avalonia.Controls.DataGrid/Selection/SelectedItemsView.cs
+++ b/src/Avalonia.Controls.DataGrid/Selection/SelectedItemsView.cs
@@ -428,6 +428,10 @@ namespace Avalonia.Controls.DataGridSelection
                 {
                     yield break;
                 }
+                catch (InvalidCastException)
+                {
+                    yield break;
+                }
 
                 if (!moved)
                 {
@@ -440,6 +444,10 @@ namespace Avalonia.Controls.DataGridSelection
                     current = enumerator.Current;
                 }
                 catch (ArgumentOutOfRangeException)
+                {
+                    continue;
+                }
+                catch (InvalidCastException)
                 {
                     continue;
                 }


### PR DESCRIPTION
# PR Summary: Selection Stops Working (InvalidCast in SelectedItemsView)

## Bug
- Hierarchical DataGrid selection intermittently stops working after data updates/rebuilds.
- Users may see exceptions like:
  ```
  Unable to cast object of type 'System.Collections.Generic.List`1[Avalonia.Controls.DataGridHierarchical.HierarchicalNode]' to type 'Avalonia.Controls.DataGridHierarchical.HierarchicalNode'.
  ```
  raised during selection change processing.
- Symptoms include mouse selection getting stuck and keyboard navigation triggering exceptions.

## Root Cause
- The DataGrid selection pipeline enumerates `SelectedItemsView`, which wraps the `ISelectionModel` source.
- During hierarchical refreshes or source swaps, the underlying source can briefly yield an unexpected item type (e.g., a `List<HierarchicalNode>` instead of a `HierarchicalNode`).
- The selection model enumerator can throw `InvalidCastException` during `MoveNext()` or `Current`, which bubbles out of `SelectedItemsView.SafeEnumerate` and breaks selection change propagation.

## Fix
- Make `SelectedItemsView.SafeEnumerate` resilient to `InvalidCastException`:
  - If `MoveNext()` throws, stop enumerating to avoid tearing down selection updates.
  - If `Current` throws, skip the invalid item and continue.
- This preserves selection change notifications even when the backing source briefly contains an invalid type.

## Tests Added
- `SelectedItemsView_Handles_Source_Items_With_Invalid_Type`
  - Verifies `SelectedItemsView` does not throw and yields no items when the selection source contains a mismatched item type.

## Test Command
```
dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~SelectedItemsView_Handles_Source_Items_With_Invalid_Type"
```


Fixes https://github.com/wieslawsoltes/ProDataGrid/issues/195