### PR TITLE
Fix CurrentSlot Assert During Selection Refresh

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionPropertyTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Selection/DataGridSelectionPropertyTests.cs
@@ -584,6 +584,26 @@ public class DataGridSelectionPropertyTests
         AssertSelected();
     }
 
+    [AvaloniaFact]
+    public void RefreshSelectionFromModel_Resets_Invalid_CurrentSlot()
+    {
+        var items = new ObservableCollection<string> { "A", "B" };
+        var grid = CreateGrid(items);
+        grid.UpdateLayout();
+
+        grid.SelectedIndex = 0;
+        grid.UpdateLayout();
+
+        SetPrivateProperty(grid, "CurrentColumnIndex", 0);
+        SetPrivateProperty(grid, "CurrentSlot", grid.SlotCount);
+
+        grid.RefreshSelectionFromModel();
+        grid.UpdateLayout();
+
+        Assert.True(grid.CurrentSlot >= 0 && grid.CurrentSlot < grid.SlotCount);
+        Assert.Equal(grid.SlotFromRowIndex(0), grid.CurrentSlot);
+    }
+
     private static DataGrid CreateGrid(IEnumerable items)
     {
         var root = new Window
@@ -609,6 +629,13 @@ public class DataGridSelectionPropertyTests
         root.Content = grid;
         root.Show();
         return grid;
+    }
+
+    private static void SetPrivateProperty<TValue>(object target, string propertyName, TValue value)
+    {
+        var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        property!.SetValue(target, value);
     }
 
     private sealed class VisibleColumnItem

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
@@ -68,7 +68,7 @@ internal
                 {
                     slot = backupSlot;
                 }
-                if (slot < 0 || slot > SlotCount)
+                if (slot < 0 || slot >= SlotCount)
                 {
                     return;
                 }
@@ -291,6 +291,12 @@ internal
             _syncingSelectionModel = true;
             try
             {
+                if (CurrentColumnIndex > -1 && (CurrentSlot < 0 || CurrentSlot >= SlotCount))
+                {
+                    CurrentColumnIndex = -1;
+                    CurrentSlot = -1;
+                }
+
                 var indexes = _selectionModelAdapter?.Model.SelectedIndexes;
                 if (_selectionModelAdapter?.Model.Source == null || indexes == null || indexes.Count == 0)
                 {


### PR DESCRIPTION
# PR Summary: Fix CurrentSlot Assert During Selection Refresh

## Bug
- The flyout selection sample can crash with an assertion failure:
  ```
  CurrentSlot < SlotCount
  ```
  triggered from `SetCurrentCellCore` while selection is being refreshed during sort/view updates.

## Root Cause
- `ApplySelectionFromSelectionModel` may run while `CurrentSlot` still points to a slot that is now out of range after an ItemsSource/sort refresh.
- `ProcessSelectionAndCurrency` treated `backupSlot == SlotCount` as valid, letting an out-of-range slot proceed into current-cell updates.
- The combination allowed `SetCurrentCellCore` to be called with `slot >= SlotCount`, tripping the debug assert.

## Fix
- Guard `ProcessSelectionAndCurrency` against `backupSlot == SlotCount` by treating `slot >= SlotCount` as invalid.
- Reset `CurrentColumnIndex`/`CurrentSlot` to `-1` before applying selection when the current slot is out of range.
- This keeps current-cell updates within valid bounds and prevents the assertion during refresh.

## Tests Added
- `DataGridSelectionPropertyTests.RefreshSelectionFromModel_Resets_Invalid_CurrentSlot`

## Test Command
```
dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~RefreshSelectionFromModel_Resets_Invalid_CurrentSlot"
```
