### PR TITLE
Fix pivot/outline bindings to avoid ConvertBack

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Pivoting/PivotTableBuilder.cs
+++ b/src/Avalonia.Controls.DataGrid/Pivoting/PivotTableBuilder.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Data.Core;
 using Avalonia.Data.Converters;
 
@@ -3118,6 +3119,7 @@ namespace Avalonia.Controls.DataGridPivoting
             CultureInfo? converterCulture)
         {
             var binding = DataGridBindingDefinition.CreateCached(property, getter);
+            binding.Mode = BindingMode.OneWay;
             binding.Converter = new PivotArrayIndexConverter(index, converter, converterParameter);
             binding.ConverterParameter = converterParameter;
             if (!string.IsNullOrEmpty(stringFormat))

--- a/src/Avalonia.Controls.DataGrid/Reporting/OutlineReportBuilder.cs
+++ b/src/Avalonia.Controls.DataGrid/Reporting/OutlineReportBuilder.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Globalization;
 using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.DataGridPivoting;
+using Avalonia.Data;
 using Avalonia.Data.Core;
 using Avalonia.Data.Converters;
 
@@ -365,7 +366,9 @@ namespace Avalonia.Controls.DataGridReporting
                 null,
                 typeof(TValue));
 
-            return DataGridBindingDefinition.Create<HierarchicalNode, TValue>(propertyInfo, node => getter((OutlineRow)node.Item!));
+            var binding = DataGridBindingDefinition.Create<HierarchicalNode, TValue>(propertyInfo, node => getter((OutlineRow)node.Item!));
+            binding.Mode = BindingMode.OneWay;
+            return binding;
         }
 
         private static DataGridBindingDefinition CreateArrayBinding(
@@ -379,6 +382,7 @@ namespace Avalonia.Controls.DataGridReporting
             CultureInfo? converterCulture)
         {
             var binding = DataGridBindingDefinition.CreateCached(property, getter);
+            binding.Mode = BindingMode.OneWay;
             binding.Converter = new OutlineArrayIndexConverter(index, converter, converterParameter);
             binding.ConverterParameter = converterParameter;
             if (!string.IsNullOrEmpty(stringFormat))


### PR DESCRIPTION
# Pivot/Outline binding fixes

## Summary
- Marked pivot and outline report bindings as `OneWay` to prevent ConvertBack from firing in read-only value flows.
- Ensured array-indexed converters are used in a forward-only binding path, avoiding `NotSupportedException` from ConvertBack.

## Files touched
- `src/Avalonia.Controls.DataGrid/Pivoting/PivotTableBuilder.cs`
  - Added `BindingMode.OneWay` to cached bindings used for pivot array indexing.
- `src/Avalonia.Controls.DataGrid/Reporting/OutlineReportBuilder.cs`
  - Added `BindingMode.OneWay` to outline row bindings and array-indexed bindings.

## Why
- The outline and pivot builders create bindings for display-only data. Allowing two-way binding routes ConvertBack calls into converters that explicitly do not support it.
- Forcing `OneWay` keeps the binding behavior aligned with usage (read-only display) and prevents the ConvertBack exception.
