### PR TITLE
Practical fixes and changes to state saving/restoring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +94,7 @@ jobs:
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
-        if: always()
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         with:
           name: Test Results (${{ matrix.os }})
           path: artifacts/test/**/*.trx

--- a/src/Avalonia.Controls.DataGrid.UnitTests/State/DataGridStateFilteringTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/State/DataGridStateFilteringTests.cs
@@ -48,6 +48,7 @@ public class DataGridStateFilteringTests
             Assert.Same(nameColumn, restored.ColumnId);
             Assert.Equal(FilteringOperator.Contains, restored.Operator);
             Assert.Equal("Item 1", restored.Value);
+            Assert.Equal("Name", ((DataGridColumn)restored.ColumnId).ColumnKey);
         }
         finally
         {
@@ -80,7 +81,7 @@ public class DataGridStateFilteringTests
             var state = grid.CaptureFilteringState(options);
 
             Assert.NotNull(state);
-            Assert.Same(nameDefinition, state.Descriptors[0].ColumnId);
+            Assert.Equal("Name", state.Descriptors[0].ColumnId);
 
             grid.FilteringModel.Clear();
             grid.FilteringModel.OwnsViewFilter = false;
@@ -92,6 +93,8 @@ public class DataGridStateFilteringTests
             Assert.Same(nameDefinition, restored.ColumnId);
             Assert.Equal(FilteringOperator.Contains, restored.Operator);
             Assert.Equal("Item 1", restored.Value);
+            Assert.IsType<DataGridColumnDefinition>(restored.ColumnId, exactMatch: false);
+            Assert.Equal("Name", ((DataGridColumnDefinition)restored.ColumnId).ColumnKey);
         }
         finally
         {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/State/DataGridStateSearchTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/State/DataGridStateSearchTests.cs
@@ -113,7 +113,7 @@ public class DataGridStateSearchTests
             Assert.NotNull(state);
             Assert.NotNull(state.Descriptors[0].ColumnIds);
             Assert.Same(nameDefinition, state.Descriptors[0].ColumnIds[0]);
-            Assert.Same(nameDefinition, state.Current.ColumnKey);
+            Assert.Same("Name", state.Current.ColumnKey);
 
             grid.SearchModel.Clear();
             grid.SearchModel.HighlightMode = SearchHighlightMode.None;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/State/StateTestHelper.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/State/StateTestHelper.cs
@@ -72,21 +72,25 @@ internal static class StateTestHelper
         grid.ColumnsInternal.Add(new DataGridTextColumn
         {
             Header = "Id",
+            ColumnKey = nameof(StateTestItem.Id),
             Binding = new Binding(nameof(StateTestItem.Id)),
         });
         grid.ColumnsInternal.Add(new DataGridTextColumn
         {
             Header = "Name",
+            ColumnKey = nameof(StateTestItem.Name),
             Binding = new Binding(nameof(StateTestItem.Name)),
         });
         grid.ColumnsInternal.Add(new DataGridTextColumn
         {
             Header = "Category",
+            ColumnKey = nameof(StateTestItem.Category),
             Binding = new Binding(nameof(StateTestItem.Category)),
         });
         grid.ColumnsInternal.Add(new DataGridTextColumn
         {
             Header = "Group",
+            ColumnKey = nameof(StateTestItem.Group),
             Binding = new Binding(nameof(StateTestItem.Group)),
         });
 
@@ -180,6 +184,7 @@ internal static class StateTestHelper
         return new DataGridTextColumnDefinition
         {
             Header = header,
+            ColumnKey = propertyName,
             Binding = DataGridBindingDefinition.Create<StateTestItem, TValue>(propertyInfo, getter)
         };
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/StatePersistence/DataGridStatePersistenceTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/StatePersistence/DataGridStatePersistenceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
@@ -116,6 +117,95 @@ public class DataGridStatePersistenceTests
                 .ToArray();
 
             Assert.Equal(new[] { 12, 14 }, selectedIds);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void SerializeAndRestoreState_RoundTrips_Filtering_ColumnDefinition()
+    {
+        var items = StateTestHelper.CreateItems(40);
+        var (grid, root, definitions) = StateTestHelper.CreateGridWithDefinitions(items);
+
+        try
+        {
+            var idColumn = definitions[0];
+
+            grid.FilteringModel.Apply(new[]
+            {
+                new FilteringDescriptor(idColumn, FilteringOperator.Equals, nameof(StateTestItem.Id), 1),
+            });
+
+            Dispatcher.UIThread.RunJobs();
+
+            var options = StateTestHelper.CreateKeyedOptions(grid, items);
+            var payload = DataGridStatePersistence.SerializeStateToString(
+                grid,
+                DataGridStateSections.Filtering,
+                options);
+
+            Assert.False(string.IsNullOrWhiteSpace(payload));
+
+            grid.FilteringModel.Clear();
+
+            DataGridStatePersistence.RestoreStateFromString(
+                grid,
+                payload,
+                DataGridStateSections.All,
+                options);
+
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(grid.FilteringModel.Descriptors);
+            Assert.IsType<DataGridColumnDefinition>(grid.FilteringModel.Descriptors[0].ColumnId, exactMatch: false);
+            Assert.Equal("Id", ((DataGridColumnDefinition)grid.FilteringModel.Descriptors[0].ColumnId).ColumnKey);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void SerializeAndRestoreState_RoundTrips_Filtering_MaterializedColumn()
+    {
+        var items = StateTestHelper.CreateItems(40);
+        var (grid, root) = StateTestHelper.CreateGrid(items);
+
+        try
+        {
+            var idColumn = grid.ColumnsInternal[0];
+            grid.FilteringModel.Apply(new[]
+            {
+                new FilteringDescriptor(idColumn, FilteringOperator.Equals, nameof(StateTestItem.Id), 1),
+            });
+
+            Dispatcher.UIThread.RunJobs();
+
+            var options = StateTestHelper.CreateKeyedOptions(grid, items);
+            var payload = DataGridStatePersistence.SerializeStateToString(
+                grid,
+                DataGridStateSections.Filtering,
+                options);
+
+            Assert.False(string.IsNullOrWhiteSpace(payload));
+
+            grid.FilteringModel.Clear();
+
+            DataGridStatePersistence.RestoreStateFromString(
+                grid,
+                payload,
+                DataGridStateSections.All,
+                options);
+
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(grid.FilteringModel.Descriptors);
+            Assert.IsType<DataGridColumn>(grid.FilteringModel.Descriptors[0].ColumnId, exactMatch: false);
+            Assert.Equal("Id", ((DataGridColumn)grid.FilteringModel.Descriptors[0].ColumnId).ColumnKey);
         }
         finally
         {
@@ -304,6 +394,105 @@ public class DataGridStatePersistenceTests
         Assert.Single(restored.Filtering.Descriptors);
         Assert.Equal(FilteringOperator.Custom, restored.Filtering.Descriptors[0].Operator);
         Assert.Same(predicate, restored.Filtering.Descriptors[0].Predicate);
+    }
+
+    [Fact]
+    public void Mapper_RoundTrips_FilteringValueToken()
+    {
+        Func<object, bool> predicate = _ => true;
+        object value = "filtering:value0";
+        var registry = new TokenRegistry
+        {
+            FilteringPredicate = predicate,
+            FilteringValues = [ value ]
+        };
+
+        var runtime = new DataGridState
+        {
+            Sections = DataGridStateSections.Filtering,
+            Filtering = new DataGridFilteringState
+            {
+                Descriptors = new[]
+                {
+                    new FilteringDescriptor(
+                        "Name",
+                        FilteringOperator.Custom,
+                        nameof(StateTestItem.Name),
+                        predicate: predicate,
+                        value: value)
+                },
+                OwnsViewFilter = true
+            }
+        };
+
+        var options = new DataGridStatePersistenceOptions
+        {
+            TokenProvider = registry,
+            TokenResolver = registry
+        };
+
+        var persisted = DataGridStatePersistenceMapper.ToPersisted(runtime, stateOptions: null, options);
+        Assert.Equal("filtering:predicate", persisted.Filtering.Descriptors[0].PredicateToken);
+
+        var restored = DataGridStatePersistenceMapper.ToRuntime(
+            persisted,
+            DataGridStateSections.All,
+            stateOptions: null,
+            options);
+
+        Assert.Single(restored.Filtering.Descriptors);
+        Assert.Equal(FilteringOperator.Custom, restored.Filtering.Descriptors[0].Operator);
+        Assert.Same(value, restored.Filtering.Descriptors[0].Value);
+    }
+
+    [Fact]
+    public void Mapper_RoundTrips_FilteringValuesToken()
+    {
+        Func<object, bool> predicate = _ => true;
+        object[] values = [ "filtering:value1", "filtering:value2"];
+        var registry = new TokenRegistry
+        {
+            FilteringPredicate = predicate,
+            FilteringValues = values
+        };
+
+        var runtime = new DataGridState
+        {
+            Sections = DataGridStateSections.Filtering,
+            Filtering = new DataGridFilteringState
+            {
+                Descriptors = new[]
+                {
+                    new FilteringDescriptor(
+                        "Name",
+                        FilteringOperator.Custom,
+                        nameof(StateTestItem.Name),
+                        predicate: predicate,
+                        values: values)
+                },
+                OwnsViewFilter = true
+            }
+        };
+
+        var options = new DataGridStatePersistenceOptions
+        {
+            TokenProvider = registry,
+            TokenResolver = registry
+        };
+
+        var persisted = DataGridStatePersistenceMapper.ToPersisted(runtime, stateOptions: null, options);
+        Assert.Equal("filtering:predicate", persisted.Filtering.Descriptors[0].PredicateToken);
+
+        var restored = DataGridStatePersistenceMapper.ToRuntime(
+            persisted,
+            DataGridStateSections.All,
+            stateOptions: null,
+            options);
+
+        Assert.Single(restored.Filtering.Descriptors);
+        Assert.Equal(FilteringOperator.Custom, restored.Filtering.Descriptors[0].Operator);
+        Assert.Same(values[0], restored.Filtering.Descriptors[0].Values[0]);
+        Assert.Same(values[1], restored.Filtering.Descriptors[0].Values[1]);
     }
 
     [Fact]
@@ -1185,15 +1374,17 @@ public class DataGridStatePersistenceTests
 
         public Func<object, bool> FilteringPredicate { get; set; }
 
+        public object[] FilteringValues { get; set; }
+
         public Func<ConditionalFormattingContext, bool> ConditionalFormattingPredicate { get; set; }
 
         public ControlTheme ConditionalFormattingTheme { get; set; }
 
         public IValueConverter GroupingValueConverter { get; set; }
 
-        public bool TryGetSortingComparerToken(IComparer comparer, out string token)
+        public bool TryGetSortingComparerToken(SortingDescriptor descriptor, out string token)
         {
-            if (ReferenceEquals(comparer, SortingComparer))
+            if (ReferenceEquals(descriptor.Comparer, SortingComparer))
             {
                 token = "sorting:comparer";
                 return true;
@@ -1203,9 +1394,9 @@ public class DataGridStatePersistenceTests
             return false;
         }
 
-        public bool TryGetFilteringPredicateToken(Func<object, bool> predicate, out string token)
+        public bool TryGetFilteringPredicateToken(FilteringDescriptor descriptor, out string token)
         {
-            if (ReferenceEquals(predicate, FilteringPredicate))
+            if (ReferenceEquals(descriptor.Predicate, FilteringPredicate))
             {
                 token = "filtering:predicate";
                 return true;
@@ -1215,11 +1406,24 @@ public class DataGridStatePersistenceTests
             return false;
         }
 
+        public bool TryGetFilteringValueToken(FilteringDescriptor descriptor, object value, out string token)
+        {
+            var idx = FilteringValues.IndexOf(value);
+            if (idx != -1)
+            {
+                token = value.ToString()!;
+                return true;
+            }
+
+            token = null;
+            return false;
+        }
+
         public bool TryGetConditionalFormattingPredicateToken(
-            Func<ConditionalFormattingContext, bool> predicate,
+            ConditionalFormattingDescriptor descriptor,
             out string token)
         {
-            if (ReferenceEquals(predicate, ConditionalFormattingPredicate))
+            if (ReferenceEquals(descriptor.Predicate, ConditionalFormattingPredicate))
             {
                 token = "conditional:predicate";
                 return true;
@@ -1229,9 +1433,9 @@ public class DataGridStatePersistenceTests
             return false;
         }
 
-        public bool TryGetConditionalFormattingThemeToken(ControlTheme theme, out string token)
+        public bool TryGetConditionalFormattingThemeToken(ConditionalFormattingDescriptor descriptor, out string token)
         {
-            if (ReferenceEquals(theme, ConditionalFormattingTheme))
+            if (ReferenceEquals(descriptor.Theme, ConditionalFormattingTheme))
             {
                 token = "conditional:theme";
                 return true;
@@ -1265,7 +1469,11 @@ public class DataGridStatePersistenceTests
             return false;
         }
 
-        public bool TryResolveFilteringPredicate(string token, out Func<object, bool> predicate)
+        public bool TryResolveFilteringPredicate(
+            string token,
+            object value,
+            List<object> values,
+            out Func<object, bool> predicate)
         {
             if (string.Equals(token, "filtering:predicate", StringComparison.Ordinal))
             {
@@ -1274,6 +1482,18 @@ public class DataGridStatePersistenceTests
             }
 
             predicate = null;
+            return false;
+        }
+
+        public bool TryResolveFilteringValue(string token, out object value)
+        {
+            if (token.StartsWith("filtering:value", StringComparison.Ordinal))
+            {
+                value = token;
+                return value != null;
+            }
+
+            value = null;
             return false;
         }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/StatePersistence/DataGridStatePersistenceTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/StatePersistence/DataGridStatePersistenceTests.cs
@@ -731,6 +731,88 @@ public class DataGridStatePersistenceTests
     }
 
     [Fact]
+    public void Mapper_RestoresValues_WhenInFilterScalarValuePersistedAsNull()
+    {
+        var persisted = new DataGridPersistedState
+        {
+            Version = 1,
+            Sections = DataGridStateSections.Filtering,
+            Filtering = new DataGridPersistedState.FilteringState
+            {
+                Descriptors = new[]
+                {
+                    new DataGridPersistedState.FilteringDescriptorState
+                    {
+                        ColumnId = PersistedString("Category"),
+                        Operator = FilteringOperator.In,
+                        PropertyPath = nameof(StateTestItem.Category),
+                        Value = new DataGridPersistedState.PersistedValue { Type = "null" },
+                        Values = new[]
+                        {
+                            PersistedString("A"),
+                            PersistedString("B")
+                        }
+                    }
+                },
+                OwnsViewFilter = false
+            }
+        };
+
+        var runtime = DataGridStatePersistenceMapper.ToRuntime(persisted, DataGridStateSections.Filtering, null, null);
+
+        Assert.Equal(DataGridStateSections.Filtering, runtime.Sections);
+        Assert.NotNull(runtime.Filtering);
+        Assert.Single(runtime.Filtering.Descriptors);
+        var descriptor = runtime.Filtering.Descriptors[0];
+        Assert.Equal(FilteringOperator.In, descriptor.Operator);
+        Assert.NotNull(descriptor.Values);
+        Assert.Equal(2, descriptor.Values.Count);
+        Assert.Equal("A", descriptor.Values[0]);
+        Assert.Equal("B", descriptor.Values[1]);
+    }
+
+    [Fact]
+    public void Mapper_RestoresValues_WhenBetweenFilterScalarValuePersistedAsNull()
+    {
+        var persisted = new DataGridPersistedState
+        {
+            Version = 1,
+            Sections = DataGridStateSections.Filtering,
+            Filtering = new DataGridPersistedState.FilteringState
+            {
+                Descriptors = new[]
+                {
+                    new DataGridPersistedState.FilteringDescriptorState
+                    {
+                        ColumnId = PersistedString("Id"),
+                        Operator = FilteringOperator.Between,
+                        PropertyPath = nameof(StateTestItem.Id),
+                        Value = new DataGridPersistedState.PersistedValue { Type = "null" },
+                        Values = new[]
+                        {
+                            new DataGridPersistedState.PersistedValue { Type = "int32", Value = "3" },
+                            new DataGridPersistedState.PersistedValue { Type = "int32", Value = "7" }
+                        }
+                    }
+                },
+                OwnsViewFilter = false
+            }
+        };
+
+        var runtime = DataGridStatePersistenceMapper.ToRuntime(persisted, DataGridStateSections.Filtering, null, null);
+
+        Assert.Equal(DataGridStateSections.Filtering, runtime.Sections);
+        Assert.NotNull(runtime.Filtering);
+        Assert.Single(runtime.Filtering.Descriptors);
+        var descriptor = runtime.Filtering.Descriptors[0];
+        Assert.Equal(FilteringOperator.Between, descriptor.Operator);
+        Assert.NotNull(descriptor.Values);
+        Assert.Equal(2, descriptor.Values.Count);
+        Assert.Equal(3, descriptor.Values[0]);
+        Assert.Equal(7, descriptor.Values[1]);
+    }
+
+    [Fact]
     public void PerSectionPersistenceRoundTrip_Search()
     {
         var runtime = new DataGridState

--- a/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnDefinition.cs
+++ b/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnDefinition.cs
@@ -396,6 +396,7 @@ namespace Avalonia.Controls
         protected virtual void ApplyBaseProperties(DataGridColumn column, DataGridColumnDefinitionContext context)
         {
             column.Header = Header;
+            column.ColumnKey = ColumnKey;
             column.SortMemberPath = SortMemberPath;
             column.Tag = Tag;
             column.CustomSortComparer = CustomSortComparer;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.State.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.State.cs
@@ -1342,6 +1342,11 @@ namespace Avalonia.Controls
             return null;
         }
 
+        private DataGridColumnDefinition FindColumnDefinitionByColumnKey(object key)
+        {
+            return _columnDefinitionsSource.FirstOrDefault(x => object.Equals(x.ColumnKey, key));
+        }
+
         private DataGridColumn FindColumnByDefinition(DataGridColumnDefinition definition)
         {
             if (definition == null)
@@ -1455,10 +1460,21 @@ namespace Avalonia.Controls
                 return null;
             }
 
+            bool? columnDefinition = null;
             var columnId = descriptor.ColumnId;
+            if (columnId is DataGridColumnDefinition definition)
+            {
+                columnId = ResolveColumnKey(definition, options, null, -1);
+                columnDefinition = true;
+            }
+
             if (columnId is DataGridColumn column)
             {
                 columnId = GetColumnKey(column, options);
+                if (columnDefinition == null)
+                {
+                    columnDefinition = false;
+                }
             }
 
             return new FilteringDescriptor(
@@ -1469,7 +1485,10 @@ namespace Avalonia.Controls
                 descriptor.Values,
                 descriptor.Predicate,
                 descriptor.Culture,
-                descriptor.StringComparisonMode);
+                descriptor.StringComparisonMode)
+            {
+                ColumnIdIsColumnDefinition = columnDefinition
+            };
         }
 
         private FilteringDescriptor ResolveFilteringDescriptor(FilteringDescriptor descriptor, DataGridStateOptions options)
@@ -1480,12 +1499,23 @@ namespace Avalonia.Controls
             }
 
             var columnId = descriptor.ColumnId;
-            if (columnId is not DataGridColumnDefinition)
+            if (columnId is not DataGridColumn && columnId is not DataGridColumnDefinition)
             {
-                var resolved = ResolveColumnKey(columnId, options, descriptor.PropertyPath, -1);
-                if (resolved != null)
+                if (descriptor.ColumnIdIsColumnDefinition == true)
                 {
-                    columnId = resolved;
+                    var resolved = FindColumnDefinitionByColumnKey(columnId);
+                    if (resolved != null)
+                    {
+                        columnId = resolved;
+                    }
+                }
+                else if (descriptor.ColumnIdIsColumnDefinition == false)
+                {
+                    var resolved = ResolveColumnKey(columnId, options, descriptor.PropertyPath, -1);
+                    if (resolved != null)
+                    {
+                        columnId = resolved;
+                    }
                 }
             }
 

--- a/src/Avalonia.Controls.DataGrid/Filtering/FilteringModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/FilteringModel.cs
@@ -86,6 +86,11 @@ namespace Avalonia.Controls.DataGridFiltering
 
         public StringComparison? StringComparisonMode { get; }
 
+        /// <summary>
+        /// True = <see cref="DataGridColumnDefinition" />, False = <see cref="DataGridColumn" />, Null = unknown
+        /// </summary>
+        internal bool? ColumnIdIsColumnDefinition { get; set; }
+
         public bool HasPredicate => Predicate != null;
 
         public override bool Equals(object obj)

--- a/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceMapper.cs
+++ b/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceMapper.cs
@@ -429,7 +429,7 @@ namespace Avalonia.Controls
                     string comparerToken = null;
                     if (descriptor.Comparer != null
                         && !context.TryGetSortingComparerToken(
-                            descriptor.Comparer,
+                            descriptor,
                             $"Sorting.Descriptors[{i}].Comparer",
                             out comparerToken))
                     {
@@ -556,7 +556,7 @@ namespace Avalonia.Controls
                     string predicateToken = null;
                     if (descriptor.Predicate != null
                         && !context.TryGetFilteringPredicateToken(
-                            descriptor.Predicate,
+                            descriptor,
                             $"Filtering.Descriptors[{i}].Predicate",
                             out predicateToken))
                     {
@@ -574,17 +574,20 @@ namespace Avalonia.Controls
                         }
                     }
 
+                    DataGridPersistedState.PersistedValue value = null;
+                    IReadOnlyList<DataGridPersistedState.PersistedValue> values = null;
+
                     if (!TryMapValueToPersisted(descriptor.ColumnId, $"Filtering.Descriptors[{i}].ColumnId", context, out var columnId))
                     {
                         continue;
                     }
 
-                    if (!TryMapValueToPersisted(descriptor.Value, $"Filtering.Descriptors[{i}].Value", context, out var value))
+                    if (!context.TryGetFilteringValueToken(descriptor, out var valueToken) && !TryMapValueToPersisted(descriptor.Value, $"Filtering.Descriptors[{i}].Value", context, out value))
                     {
                         continue;
                     }
 
-                    if (!TryMapValuesToPersisted(descriptor.Values, $"Filtering.Descriptors[{i}].Values", context, out var values))
+                    if (!context.TryGetFilteringValuesTokens(descriptor, out var valuesTokens) && !TryMapValuesToPersisted(descriptor.Values, $"Filtering.Descriptors[{i}].Values", context, out values))
                     {
                         continue;
                     }
@@ -595,10 +598,13 @@ namespace Avalonia.Controls
                         Operator = descriptor.Operator,
                         PropertyPath = descriptor.PropertyPath,
                         Value = value,
+                        ValueToken = valueToken,
                         Values = values,
+                        ValuesTokens = valuesTokens,
                         CultureName = descriptor.Culture?.Name,
                         StringComparisonMode = descriptor.StringComparisonMode,
-                        PredicateToken = predicateToken
+                        PredicateToken = predicateToken,
+                        ColumnIdIsColumnDefinition = descriptor.ColumnIdIsColumnDefinition
                     });
                 }
             }
@@ -634,9 +640,33 @@ namespace Avalonia.Controls
                         continue;
                     }
 
+                    if (!TryMapValueToRuntime(descriptor.ColumnId, $"Filtering.Descriptors[{i}].ColumnId", context, out var columnId))
+                    {
+                        continue;
+                    }
+
+                    if (columnId == null)
+                    {
+                        if (!context.Unsupported($"Filtering.Descriptors[{i}].ColumnId", "Column id cannot be null."))
+                        {
+                            continue;
+                        }
+                    }
+
+                    List<object> values = null;
+                    if (!context.TryResolveFilteringValue(descriptor.ValueToken, out var value) && !DataGridStatePersistenceValueConverter.TryReadValue(descriptor.Value, out value, out _))
+                    {
+                        if (!context.TryResolveFilteringValues(descriptor.ValuesTokens, out values) && !TryMapValuesToRuntime(descriptor.Values, $"Filtering.Descriptors[{i}].Values", context, out values))
+                        {
+                            continue;
+                        }
+                    }
+
                     if (!context.TryResolveFilteringPredicate(
                             descriptor.PredicateToken,
                             $"Filtering.Descriptors[{i}].PredicateToken",
+                            value,
+                            values,
                             out var predicate))
                     {
                         continue;
@@ -653,29 +683,6 @@ namespace Avalonia.Controls
                         }
                     }
 
-                    if (!TryMapValueToRuntime(descriptor.ColumnId, $"Filtering.Descriptors[{i}].ColumnId", context, out var columnId))
-                    {
-                        continue;
-                    }
-
-                    if (columnId == null)
-                    {
-                        if (!context.Unsupported($"Filtering.Descriptors[{i}].ColumnId", "Column id cannot be null."))
-                        {
-                            continue;
-                        }
-                    }
-
-                    if (!TryMapValueToRuntime(descriptor.Value, $"Filtering.Descriptors[{i}].Value", context, out var value))
-                    {
-                        continue;
-                    }
-
-                    if (!TryMapValuesToRuntime(descriptor.Values, $"Filtering.Descriptors[{i}].Values", context, out var values))
-                    {
-                        continue;
-                    }
-
                     if (!TryParseCulture(descriptor.CultureName, $"Filtering.Descriptors[{i}].CultureName", context, out var culture))
                     {
                         continue;
@@ -689,7 +696,10 @@ namespace Avalonia.Controls
                         values,
                         predicate: predicate,
                         culture: culture,
-                        stringComparison: descriptor.StringComparisonMode));
+                        stringComparison: descriptor.StringComparisonMode)
+                    {
+                        ColumnIdIsColumnDefinition = descriptor.ColumnIdIsColumnDefinition
+                    });
                 }
             }
 
@@ -878,7 +888,7 @@ namespace Avalonia.Controls
                     string predicateToken = null;
                     if (descriptor.Predicate != null
                         && !context.TryGetConditionalFormattingPredicateToken(
-                            descriptor.Predicate,
+                            descriptor,
                             $"ConditionalFormatting.Descriptors[{i}].Predicate",
                             out predicateToken))
                     {
@@ -888,7 +898,7 @@ namespace Avalonia.Controls
                     string themeToken = null;
                     if (descriptor.Theme != null
                         && !context.TryGetConditionalFormattingThemeToken(
-                            descriptor.Theme,
+                            descriptor,
                             $"ConditionalFormatting.Descriptors[{i}].Theme",
                             out themeToken))
                     {
@@ -1732,16 +1742,16 @@ namespace Avalonia.Controls
                 return false;
             }
 
-            public bool TryGetSortingComparerToken(IComparer comparer, string path, out string token)
+            public bool TryGetSortingComparerToken(SortingDescriptor descriptor, string path, out string token)
             {
                 token = null;
-                if (comparer == null)
+                if (descriptor.Comparer == null)
                 {
                     return true;
                 }
 
                 if (_tokenProvider != null
-                    && _tokenProvider.TryGetSortingComparerToken(comparer, out token)
+                    && _tokenProvider.TryGetSortingComparerToken(descriptor, out token)
                     && !string.IsNullOrWhiteSpace(token))
                 {
                     return true;
@@ -1750,16 +1760,16 @@ namespace Avalonia.Controls
                 return Unsupported(path, "Sorting comparer is runtime-only and no token provider mapping exists.");
             }
 
-            public bool TryGetFilteringPredicateToken(Func<object, bool> predicate, string path, out string token)
+            public bool TryGetFilteringPredicateToken(FilteringDescriptor descriptor, string path, out string token)
             {
                 token = null;
-                if (predicate == null)
+                if (descriptor.Predicate == null)
                 {
                     return true;
                 }
 
                 if (_tokenProvider != null
-                    && _tokenProvider.TryGetFilteringPredicateToken(predicate, out token)
+                    && _tokenProvider.TryGetFilteringPredicateToken(descriptor, out token)
                     && !string.IsNullOrWhiteSpace(token))
                 {
                     return true;
@@ -1768,19 +1778,70 @@ namespace Avalonia.Controls
                 return Unsupported(path, "Filtering predicate is runtime-only and no token provider mapping exists.");
             }
 
-            public bool TryGetConditionalFormattingPredicateToken(
-                Func<ConditionalFormattingContext, bool> predicate,
-                string path,
-                out string token)
+            public bool TryGetFilteringValueToken(FilteringDescriptor descriptor, out string token)
             {
                 token = null;
-                if (predicate == null)
+                if (descriptor.Value == null)
                 {
                     return true;
                 }
 
                 if (_tokenProvider != null
-                    && _tokenProvider.TryGetConditionalFormattingPredicateToken(predicate, out token)
+                    && _tokenProvider.TryGetFilteringValueToken(descriptor, descriptor.Value, out token)
+                    && !string.IsNullOrWhiteSpace(token))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            public bool TryGetFilteringValuesTokens(FilteringDescriptor descriptor, out string[] tokens)
+            {
+                tokens = null;
+                if (descriptor.Values == null || descriptor.Values.Count == 0)
+                {
+                    return true;
+                }
+
+                if (_tokenProvider == null)
+                {
+                    return false;
+                }
+
+                var ret = new string[descriptor.Values.Count];
+
+                for (var x = 0;x < ret.Length;x++)
+                {
+                    if (!_tokenProvider.TryGetFilteringValueToken(descriptor, descriptor.Values[x], out ret[x]))
+                    {
+                        return false;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(ret[x]))
+                    {
+                        return false;
+                    }
+                }
+
+                tokens = ret;
+
+                return true;
+            }
+
+            public bool TryGetConditionalFormattingPredicateToken(
+                ConditionalFormattingDescriptor descriptor,
+                string path,
+                out string token)
+            {
+                token = null;
+                if (descriptor.Predicate == null)
+                {
+                    return true;
+                }
+
+                if (_tokenProvider != null
+                    && _tokenProvider.TryGetConditionalFormattingPredicateToken(descriptor, out token)
                     && !string.IsNullOrWhiteSpace(token))
                 {
                     return true;
@@ -1789,16 +1850,16 @@ namespace Avalonia.Controls
                 return Unsupported(path, "Conditional formatting predicate is runtime-only and no token provider mapping exists.");
             }
 
-            public bool TryGetConditionalFormattingThemeToken(ControlTheme theme, string path, out string token)
+            public bool TryGetConditionalFormattingThemeToken(ConditionalFormattingDescriptor descriptor, string path, out string token)
             {
                 token = null;
-                if (theme == null)
+                if (descriptor.Theme == null)
                 {
                     return true;
                 }
 
                 if (_tokenProvider != null
-                    && _tokenProvider.TryGetConditionalFormattingThemeToken(theme, out token)
+                    && _tokenProvider.TryGetConditionalFormattingThemeToken(descriptor, out token)
                     && !string.IsNullOrWhiteSpace(token))
                 {
                     return true;
@@ -1843,7 +1904,7 @@ namespace Avalonia.Controls
                 return Unsupported(path, $"Cannot resolve sorting comparer token '{token}'.");
             }
 
-            public bool TryResolveFilteringPredicate(string token, string path, out Func<object, bool> predicate)
+            public bool TryResolveFilteringPredicate(string token, string path, object value, List<object> values, out Func<object, bool> predicate)
             {
                 predicate = null;
                 if (string.IsNullOrWhiteSpace(token))
@@ -1852,13 +1913,68 @@ namespace Avalonia.Controls
                 }
 
                 if (_tokenResolver != null
-                    && _tokenResolver.TryResolveFilteringPredicate(token, out predicate)
+                    && _tokenResolver.TryResolveFilteringPredicate(token, value, values, out predicate)
                     && predicate != null)
                 {
                     return true;
                 }
 
                 return Unsupported(path, $"Cannot resolve filtering predicate token '{token}'.");
+            }
+
+            public bool TryResolveFilteringValue(string token, out object value)
+            {
+                value = null;
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    return false;
+                }
+
+                if (_tokenResolver != null
+                    && _tokenResolver.TryResolveFilteringValue(token, out value)
+                    && value != null)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            public bool TryResolveFilteringValues(string[] tokens, out List<object> values)
+            {
+                values = null;
+
+                if (_tokenResolver == null)
+                {
+                    return false;
+                }
+
+                if (tokens == null || tokens.Length == 0)
+                {
+                    values = [];
+                    return true;
+                }
+
+                var ret = new List<object>(tokens.Length);
+
+                for (var x = 0;x < tokens.Length; x++)
+                {
+                    if (string.IsNullOrWhiteSpace(tokens[x]))
+                    {
+                        return false;
+                    }
+
+                    if (!_tokenResolver.TryResolveFilteringValue(tokens[x], out var value) || value == null)
+                    {
+                        return false;
+                    }
+
+                    ret.Add(value);
+                }
+
+                values = ret;
+
+                return true;
             }
 
             public bool TryResolveConditionalFormattingPredicate(

--- a/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceMapper.cs
+++ b/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceMapper.cs
@@ -654,7 +654,7 @@ namespace Avalonia.Controls
                     }
 
                     List<object> values = null;
-                    if (!context.TryResolveFilteringValue(descriptor.ValueToken, out var value) && !DataGridStatePersistenceValueConverter.TryReadValue(descriptor.Value, out value, out _))
+                    if (!context.TryResolveFilteringValue(descriptor.ValueToken, out var value) && !DataGridStatePersistenceValueConverter.TryReadValue(descriptor.Value, out value, out _) || value == null)
                     {
                         if (!context.TryResolveFilteringValues(descriptor.ValuesTokens, out values) && !TryMapValuesToRuntime(descriptor.Values, $"Filtering.Descriptors[{i}].Values", context, out values))
                         {

--- a/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceModels.cs
+++ b/src/Avalonia.Controls.DataGrid/StatePersistence/DataGridStatePersistenceModels.cs
@@ -127,13 +127,15 @@ namespace Avalonia.Controls
     #endif
     interface IDataGridStatePersistenceTokenProvider
     {
-        bool TryGetSortingComparerToken(IComparer comparer, out string token);
+        bool TryGetSortingComparerToken(SortingDescriptor descriptor, out string token);
 
-        bool TryGetFilteringPredicateToken(Func<object, bool> predicate, out string token);
+        bool TryGetFilteringPredicateToken(FilteringDescriptor descriptor, out string token);
 
-        bool TryGetConditionalFormattingPredicateToken(Func<ConditionalFormattingContext, bool> predicate, out string token);
+        bool TryGetFilteringValueToken(FilteringDescriptor descriptor, object value, out string token);
 
-        bool TryGetConditionalFormattingThemeToken(ControlTheme theme, out string token);
+        bool TryGetConditionalFormattingPredicateToken(ConditionalFormattingDescriptor descriptor, out string token);
+
+        bool TryGetConditionalFormattingThemeToken(ConditionalFormattingDescriptor descriptor, out string token);
 
         bool TryGetGroupingValueConverterToken(IValueConverter converter, out string token);
     }
@@ -150,7 +152,9 @@ namespace Avalonia.Controls
     {
         bool TryResolveSortingComparer(string token, out IComparer comparer);
 
-        bool TryResolveFilteringPredicate(string token, out Func<object, bool> predicate);
+        bool TryResolveFilteringPredicate(string token, object value, List<object> values, out Func<object, bool> predicate);
+
+        bool TryResolveFilteringValue(string token, out object value);
 
         bool TryResolveConditionalFormattingPredicate(string token, out Func<ConditionalFormattingContext, bool> predicate);
 
@@ -331,14 +335,19 @@ namespace Avalonia.Controls
             public string PropertyPath { get; set; }
 
             public PersistedValue Value { get; set; }
+            public string ValueToken { get; set; }
 
             public IReadOnlyList<PersistedValue> Values { get; set; }
+
+            public string[] ValuesTokens { get; set; }
 
             public string CultureName { get; set; }
 
             public StringComparison? StringComparisonMode { get; set; }
 
             public string PredicateToken { get; set; }
+
+            public bool? ColumnIdIsColumnDefinition { get; set; }
         }
 
         #if !DATAGRID_INTERNAL


### PR DESCRIPTION
I have put serialized state saving and restoring to practice and discovered a couple of things that I think need changing. The most important one is the ability to resolve `FilteringDescriptorState` `value` and `values`, with other less major fixes.

## Resolve `value` and `values` in filtering descriptor state

Added tokens for which `value` and `values` can be restored, like it was done with other objects that are unknown to the library and are not recreateable by its own.

## Expose parent objects to IDataGridStatePersistenceTokenProvider methods

Expose parent objects to `IDataGridStatePersistenceTokenProvider` methods to provide more information needed to resolve tokens. For example, if sorting is used with column definitions and `DataGridTextColumnDefinition`, a `DataGridColumnValueAccessorComparer` is automatically generated, which makes it hard to determine which column is bound to sort descriptor. Descriptors are now passed in most of the methods of `IDataGridStatePersistenceTokenProvider`, which also eliminates a need of tracking object instances of comparers or predicates in order to generate tokens out of them. Now, matching by `ColumnKey` is possible, as it is done the same in other places. Tests still have tracking by object instances done though, I did not see a need to redo it as it works.

## Populate `ColumnKey` in resolved `DataGridColumnDefinition`s

This aligns `DataGridColumnDefinition`s more closely as they were before saving+restoring. They are still different, for example the filtering predicate will most likely originate from a different place compared to organic filtering descriptor.

With `ColumnKey`s now populated, check in `CaptureAndRestoreSearchState_Resolves_Definition_Columns` is changed to adjust for non-fallback behavior (`DataGridColumnMetadata.GetDefinitionKey` previously fell back to `(object)definition`)

## `ColumnId` restoration to original form in `FilteringDescriptor`

As a side note, `ColumnKey` and `ColumnId` are used interchangibly in some places, and it is not really clear whether library users should put column instances, their definitions or string keys (most often in form of `nameof(Xxx)`). `Filtering Model (End-to-End)` instructs to use string keys, however they weren't really compatible with how calls to `IDataGridStatePersistenceTokenProvider` methods behaved, and it seems that most of the tests expect instances there.

I modified it to resolve `DataGridColumn` or `DataGridColumnDefinition` depending on what was there before state is saved with best effort fallbacks. There is no good way to tell which one we should restore after the state is saved though, so `ColumnIdIsColumnDefinition` is added to `FilteringDescriptor`