### PR TITLE
fix: Preserve selection by identity in DataGrid with new model

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Selection/IdentitySelectionModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Selection/IdentitySelectionModel.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Avalonia.Controls.Selection;
+using Avalonia.Threading;
+
+namespace Avalonia.Controls.DataGridSelection
+{
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    class IdentitySelectionModel : ISelectionModel
+    {
+        private readonly SelectionModel<object?> _inner = new();
+        private readonly Func<object, object> _identitySelector;
+        private INotifyCollectionChanged _sourceNotifications;
+        private List<object> _selectionSnapshot = new();
+        private bool _sourceMutationInProgress;
+        private bool _suppressSnapshotUpdates;
+        private int _sourceChangeVersion;
+
+        public IdentitySelectionModel(Func<object, object> identitySelector)
+        {
+            _identitySelector = identitySelector ?? throw new ArgumentNullException(nameof(identitySelector));
+            _inner.SelectionChanged += InnerSelectionChanged;
+            _inner.IndexesChanged += (sender, args) => IndexesChanged?.Invoke(this, args);
+            _inner.LostSelection += (sender, args) => LostSelection?.Invoke(this, args);
+            _inner.SourceReset += (sender, args) => SourceReset?.Invoke(this, args);
+            _inner.PropertyChanged += InnerPropertyChanged;
+        }
+
+        public IEnumerable Source
+        {
+            get => _inner.Source;
+            set
+            {
+                if (ReferenceEquals(_inner.Source, value))
+                {
+                    return;
+                }
+
+                DetachSourceNotifications();
+                AttachSourceNotifications(value as INotifyCollectionChanged);
+                _inner.Source = value;
+                UpdateSelectionSnapshot();
+            }
+        }
+
+        public bool SingleSelect
+        {
+            get => _inner.SingleSelect;
+            set => _inner.SingleSelect = value;
+        }
+
+        public int SelectedIndex
+        {
+            get => _inner.SelectedIndex;
+            set => _inner.SelectedIndex = value;
+        }
+
+        public IReadOnlyList<int> SelectedIndexes => _inner.SelectedIndexes;
+
+        public object SelectedItem
+        {
+            get => _inner.SelectedItem;
+            set => _inner.SelectedItem = value;
+        }
+
+        public IReadOnlyList<object?> SelectedItems => _inner.SelectedItems;
+
+        public int AnchorIndex
+        {
+            get => _inner.AnchorIndex;
+            set => _inner.AnchorIndex = value;
+        }
+
+        public int Count => _inner.Count;
+
+        public event EventHandler<SelectionModelIndexesChangedEventArgs> IndexesChanged;
+        public event EventHandler<SelectionModelSelectionChangedEventArgs> SelectionChanged;
+        public event EventHandler LostSelection;
+        public event EventHandler SourceReset;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void BeginBatchUpdate() => _inner.BeginBatchUpdate();
+        public void EndBatchUpdate() => _inner.EndBatchUpdate();
+        public bool IsSelected(int index) => _inner.IsSelected(index);
+        public void Select(int index) => _inner.Select(index);
+        public void Deselect(int index) => _inner.Deselect(index);
+        public void SelectRange(int start, int end) => _inner.SelectRange(start, end);
+        public void DeselectRange(int start, int end) => _inner.DeselectRange(start, end);
+        public void SelectAll() => _inner.SelectAll();
+        public void Clear() => _inner.Clear();
+
+        private void InnerSelectionChanged(object sender, SelectionModelSelectionChangedEventArgs e)
+        {
+            if (!_sourceMutationInProgress && !_suppressSnapshotUpdates)
+            {
+                UpdateSelectionSnapshot();
+            }
+
+            SelectionChanged?.Invoke(this, e);
+        }
+
+        private void InnerPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            PropertyChanged?.Invoke(this, e);
+        }
+
+        private void AttachSourceNotifications(INotifyCollectionChanged source)
+        {
+            _sourceNotifications = source;
+            if (_sourceNotifications != null)
+            {
+                _sourceNotifications.CollectionChanged += SourceOnCollectionChanged;
+            }
+        }
+
+        private void DetachSourceNotifications()
+        {
+            if (_sourceNotifications != null)
+            {
+                _sourceNotifications.CollectionChanged -= SourceOnCollectionChanged;
+                _sourceNotifications = null;
+            }
+        }
+
+        private void SourceOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_selectionSnapshot.Count == 0)
+            {
+                return;
+            }
+
+            var snapshot = new List<object>(_selectionSnapshot);
+            var version = ++_sourceChangeVersion;
+            _sourceMutationInProgress = true;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (version != _sourceChangeVersion)
+                {
+                    return;
+                }
+
+                _sourceMutationInProgress = false;
+                RestoreSelectionSnapshot(snapshot);
+            }, DispatcherPriority.Background);
+        }
+
+        private void RestoreSelectionSnapshot(IReadOnlyList<object> snapshot)
+        {
+            if (snapshot == null || snapshot.Count == 0 || Source == null)
+            {
+                return;
+            }
+
+            if (SelectionMatchesSnapshot(snapshot))
+            {
+                return;
+            }
+
+            var indexes = FindIndexes(snapshot);
+            if (indexes.Count == 0)
+            {
+                return;
+            }
+
+            _suppressSnapshotUpdates = true;
+            try
+            {
+                using (_inner.BatchUpdate())
+                {
+                    _inner.Clear();
+                    foreach (var index in indexes)
+                    {
+                        _inner.Select(index);
+                    }
+                }
+            }
+            finally
+            {
+                _suppressSnapshotUpdates = false;
+            }
+
+            UpdateSelectionSnapshot();
+        }
+
+        private bool SelectionMatchesSnapshot(IReadOnlyList<object> snapshot)
+        {
+            if (_inner.SelectedItems.Count != snapshot.Count)
+            {
+                return false;
+            }
+
+            if (snapshot.Count == 1)
+            {
+                return Equals(GetIdentity(snapshot[0]), GetIdentity(_inner.SelectedItems[0]));
+            }
+
+            var matched = new bool[_inner.SelectedItems.Count];
+            foreach (var snapshotItem in snapshot)
+            {
+                var identity = GetIdentity(snapshotItem);
+                var found = false;
+                for (var i = 0; i < _inner.SelectedItems.Count; i++)
+                {
+                    if (matched[i])
+                    {
+                        continue;
+                    }
+
+                    if (!Equals(identity, GetIdentity(_inner.SelectedItems[i])))
+                    {
+                        continue;
+                    }
+
+                    matched[i] = true;
+                    found = true;
+                    break;
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private List<int> FindIndexes(IReadOnlyList<object> snapshot)
+        {
+            var indexes = new List<int>(snapshot.Count);
+            if (Source is IList list)
+            {
+                foreach (var snapshotItem in snapshot)
+                {
+                    var identity = GetIdentity(snapshotItem);
+                    for (var i = 0; i < list.Count; i++)
+                    {
+                        if (!Equals(identity, GetIdentity(list[i])))
+                        {
+                            continue;
+                        }
+
+                        indexes.Add(i);
+                        break;
+                    }
+                }
+
+                return indexes;
+            }
+
+            foreach (var snapshotItem in snapshot)
+            {
+                var identity = GetIdentity(snapshotItem);
+                var index = 0;
+                foreach (var candidate in Source)
+                {
+                    if (Equals(identity, GetIdentity(candidate)))
+                    {
+                        indexes.Add(index);
+                        break;
+                    }
+
+                    index++;
+                }
+            }
+
+            return indexes;
+        }
+
+        private object GetIdentity(object item)
+        {
+            return item == null ? null : _identitySelector(item);
+        }
+
+        private void UpdateSelectionSnapshot()
+        {
+            _selectionSnapshot.Clear();
+            foreach (var item in _inner.SelectedItems)
+            {
+                var identity = GetIdentity(item);
+                if (identity != null)
+                {
+                    _selectionSnapshot.Add(identity);
+                }
+            }
+        }
+    }
+}

--- a/src/DataGridSample.UnitTests/DynamicDataStreamingSourceCachePageTests.cs
+++ b/src/DataGridSample.UnitTests/DynamicDataStreamingSourceCachePageTests.cs
@@ -1,0 +1,64 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class DynamicDataStreamingSourceCachePageTests
+{
+    [AvaloniaFact]
+    public void Replacement_Update_Under_Sort_Preserves_Row_Selection()
+    {
+        var page = new DynamicDataStreamingSourceCachePage();
+        var window = CreateHostWindow(page);
+
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<DynamicDataStreamingSourceCacheViewModel>(page.DataContext);
+
+            viewModel.LoadSelectionReproCommand.Execute(null);
+            PumpLayout(window);
+
+            viewModel.SelectMiddleRowCommand.Execute(null);
+            PumpLayout(window);
+
+            Assert.Equal(2, viewModel.SelectedId);
+
+            viewModel.ReplaceSelectedAndMoveCommand.Execute(null);
+            PumpLayout(window);
+
+            Assert.Equal(2, viewModel.ExpectedSelectedId);
+            Assert.Equal(2, viewModel.SelectedId);
+            Assert.Contains("Selection stayed", viewModel.SelectionStatus);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static Window CreateHostWindow(Control content)
+    {
+        var window = new Window
+        {
+            Width = 1200,
+            Height = 800,
+            Content = content
+        };
+        window.ApplySampleTheme();
+        return window;
+    }
+
+    private static void PumpLayout(Control control)
+    {
+        Dispatcher.UIThread.RunJobs();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/src/DataGridSample/Pages/DynamicDataStreamingSourceCachePage.axaml
+++ b/src/DataGridSample/Pages/DynamicDataStreamingSourceCachePage.axaml
@@ -52,6 +52,10 @@
                      Increment="1"
                      Value="{Binding MaxPrice, Mode=TwoWay}" />
       <Button Content="Clear filters" Command="{Binding ClearFiltersCommand}" />
+      <Button Content="Load selection repro" Command="{Binding LoadSelectionReproCommand}" />
+      <Button Content="Select middle row" Command="{Binding SelectMiddleRowCommand}" />
+      <Button Content="Replace selected" Command="{Binding ReplaceSelectedAndMoveCommand}" />
+      <Button Content="Run drift repro" Command="{Binding RunSelectionDriftReproCommand}" />
       <CheckBox Content="Multi-sort with Shift"
                 IsChecked="{Binding MultiSortEnabled}" />
       <StackPanel Orientation="Horizontal" Spacing="6">
@@ -74,6 +78,7 @@
               RowHeightEstimator="{x:Null}"
               SelectionMode="Single"
               SelectionUnit="FullRow"
+              Selection="{Binding SelectionModel}"
               AutoGenerateColumns="False"
               CanUserReorderColumns="False"
               CanUserResizeColumns="False"
@@ -116,6 +121,9 @@
           <TextBlock Text="{Binding ItemsCount, StringFormat='Items: {0}'}" />
           <TextBlock Text="{Binding Updates, StringFormat='Updates: {0}'}" />
           <TextBlock Text="{Binding RunState, StringFormat='State: {0}'}" />
+          <TextBlock Text="{Binding ExpectedSelectedId, StringFormat='Expected selected Id: {0}'}" />
+          <TextBlock Text="{Binding SelectedId, StringFormat='Actual selected Id: {0}'}" />
+          <TextBlock Text="{Binding SelectionStatus}" TextWrapping="Wrap" />
         </StackPanel>
       </Border>
 

--- a/src/DataGridSample/ViewModels/DynamicDataStreamingSourceCacheViewModel.cs
+++ b/src/DataGridSample/ViewModels/DynamicDataStreamingSourceCacheViewModel.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using Avalonia.Controls.DataGridFiltering;
 using Avalonia.Controls.DataGridSorting;
+using Avalonia.Controls.DataGridSelection;
+using Avalonia.Controls.Selection;
 using Avalonia.Threading;
 using DataGridSample.Adapters;
 using DataGridSample.Models;
@@ -41,6 +44,8 @@ namespace DataGridSample.ViewModels
         private IFilteringModel? _filteringModel;
         private bool _multiSortEnabled = true;
         private SortCycleMode _sortCycleMode = SortCycleMode.AscendingDescendingNone;
+        private int? _expectedSelectedId;
+        private string _selectionStatus = "No selection.";
 
         public DynamicDataStreamingSourceCacheViewModel()
         {
@@ -52,12 +57,21 @@ namespace DataGridSample.ViewModels
 
             var subscription = _source.Connect()
                 .Filter(_filterSubject)
-                .SortAndBind(out _view, _sortSubject)
+                .SortAndBind(out _view, _sortSubject, new()
+                {
+                    UseReplaceForUpdates = true
+                })
                 .Subscribe();
             _cleanup.Add(subscription);
 
             _viewNotifications = _view;
             _viewNotifications.CollectionChanged += ViewCollectionChanged;
+
+            SelectionModel = new IdentitySelectionModel(item => item is StreamingItem stream ? stream.Id : item)
+            {
+                SingleSelect = true
+            };
+            SelectionModel.SelectionChanged += SelectionModelOnSelectionChanged;
 
             SortingModel = new SortingModel
             {
@@ -84,6 +98,10 @@ namespace DataGridSample.ViewModels
             ResetCommand = new RelayCommand(_ => ResetItems());
             ClearSortsCommand = new RelayCommand(_ => SortingModel.Clear());
             ClearFiltersCommand = new RelayCommand(_ => ClearFilters());
+            LoadSelectionReproCommand = new RelayCommand(_ => LoadSelectionRepro());
+            SelectMiddleRowCommand = new RelayCommand(_ => SelectMiddleRow());
+            ReplaceSelectedAndMoveCommand = new RelayCommand(_ => ReplaceSelectedAndMove());
+            RunSelectionDriftReproCommand = new RelayCommand(_ => RunSelectionDriftRepro());
 
             ResetItems();
         }
@@ -93,6 +111,8 @@ namespace DataGridSample.ViewModels
         public DynamicDataStreamingSortingAdapterFactory SortingAdapterFactory => _sortingAdapterFactory;
 
         public DynamicDataStreamingFilteringAdapterFactory FilteringAdapterFactory => _filteringAdapterFactory;
+
+        public ISelectionModel SelectionModel { get; }
 
         public ISortingModel SortingModel
         {
@@ -123,6 +143,14 @@ namespace DataGridSample.ViewModels
         public RelayCommand ClearSortsCommand { get; }
 
         public RelayCommand ClearFiltersCommand { get; }
+
+        public RelayCommand LoadSelectionReproCommand { get; }
+
+        public RelayCommand SelectMiddleRowCommand { get; }
+
+        public RelayCommand ReplaceSelectedAndMoveCommand { get; }
+
+        public RelayCommand RunSelectionDriftReproCommand { get; }
 
         public int TargetCount
         {
@@ -179,6 +207,20 @@ namespace DataGridSample.ViewModels
         public int ItemsCount => _view.Count;
 
         public string RunState => IsRunning ? "Running" : "Stopped";
+
+        public int? ExpectedSelectedId
+        {
+            get => _expectedSelectedId;
+            private set => SetProperty(ref _expectedSelectedId, value);
+        }
+
+        public int? SelectedId => SelectionModel.SelectedItem is StreamingItem item ? item.Id : null;
+
+        public string SelectionStatus
+        {
+            get => _selectionStatus;
+            private set => SetProperty(ref _selectionStatus, value);
+        }
 
         public string? SymbolFilter
         {
@@ -279,6 +321,8 @@ namespace DataGridSample.ViewModels
             });
 
             Updates = 0;
+            ExpectedSelectedId = null;
+            UpdateSelectionStatus();
         }
 
         private void ApplyUpdates()
@@ -394,6 +438,74 @@ namespace DataGridSample.ViewModels
             FilteringModel.Clear();
         }
 
+        private void LoadSelectionRepro()
+        {
+            Stop();
+            SymbolFilter = string.Empty;
+            MinPrice = null;
+            MaxPrice = null;
+            FilteringModel.Clear();
+            SortingModel.Apply(new[]
+            {
+                new SortingDescriptor(nameof(StreamingItem.Price), ListSortDirection.Ascending, nameof(StreamingItem.Price))
+            });
+
+            _source.Edit(cache =>
+            {
+                cache.Clear();
+                cache.AddOrUpdate(new StreamingItem { Id = 1, Symbol = "AAA", Price = 10, PriceDisplay = "10.00", UpdatedAt = DateTime.Today, UpdatedAtDisplay = "10:00:00" });
+                cache.AddOrUpdate(new StreamingItem { Id = 2, Symbol = "BBB", Price = 20, PriceDisplay = "20.00", UpdatedAt = DateTime.Today, UpdatedAtDisplay = "10:00:01" });
+                cache.AddOrUpdate(new StreamingItem { Id = 3, Symbol = "CCC", Price = 30, PriceDisplay = "30.00", UpdatedAt = DateTime.Today, UpdatedAtDisplay = "10:00:02" });
+            });
+
+            SelectionModel.Clear();
+            ExpectedSelectedId = null;
+            Updates = 0;
+            UpdateSelectionStatus();
+        }
+
+        private void SelectMiddleRow()
+        {
+            if (_view.Count < 2)
+            {
+                return;
+            }
+
+            SelectionModel.Select(1);
+            ExpectedSelectedId = SelectedId;
+            UpdateSelectionStatus();
+        }
+
+        private void ReplaceSelectedAndMove()
+        {
+            if (SelectionModel.SelectedItem is not StreamingItem selected)
+            {
+                return;
+            }
+
+            ExpectedSelectedId = selected.Id;
+
+            var replacement = new StreamingItem
+            {
+                Id = selected.Id,
+                Symbol = selected.Symbol,
+                Price = 999,
+                PriceDisplay = "999.00",
+                UpdatedAt = DateTime.Today.AddSeconds(30),
+                UpdatedAtDisplay = "10:00:30"
+            };
+
+            _source.AddOrUpdate(replacement);
+            UpdateSelectionStatus();
+        }
+
+        private void RunSelectionDriftRepro()
+        {
+            LoadSelectionRepro();
+            SelectMiddleRow();
+            ReplaceSelectedAndMove();
+        }
+
         private void SortingModelOnSortingChanged(object? sender, SortingChangedEventArgs e)
         {
             UpdateSortSummaries(e.NewDescriptors);
@@ -464,6 +576,7 @@ namespace DataGridSample.ViewModels
             Stop();
             SortingModel.SortingChanged -= SortingModelOnSortingChanged;
             FilteringModel.FilteringChanged -= FilteringModelOnFilteringChanged;
+            SelectionModel.SelectionChanged -= SelectionModelOnSelectionChanged;
             _viewNotifications.CollectionChanged -= ViewCollectionChanged;
             _sortSubject.Dispose();
             _filterSubject.Dispose();
@@ -475,6 +588,34 @@ namespace DataGridSample.ViewModels
         public record FilterDescriptorSummary(string Column, string Operator, string Value);
 
         private void ViewCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-            => OnPropertyChanged(nameof(ItemsCount));
+        {
+            OnPropertyChanged(nameof(ItemsCount));
+            OnPropertyChanged(nameof(SelectedId));
+            UpdateSelectionStatus();
+        }
+
+        private void SelectionModelOnSelectionChanged(object? sender, SelectionModelSelectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(SelectedId));
+            UpdateSelectionStatus();
+        }
+
+        private void UpdateSelectionStatus()
+        {
+            var selectedId = SelectedId;
+            var expectedId = ExpectedSelectedId;
+
+            if (expectedId == null)
+            {
+                SelectionStatus = selectedId == null
+                    ? "No selection."
+                    : $"Selected Id {selectedId}.";
+                return;
+            }
+
+            SelectionStatus = selectedId == expectedId
+                ? $"Selection stayed on Id {selectedId}."
+                : $"Selection drifted. Expected Id {expectedId}, actual Id {(selectedId?.ToString() ?? "none")}.";
+        }
     }
 }


### PR DESCRIPTION
**Summary**

Fix selection drift when a `SelectionModel` is bound to a `DataGrid` whose backing view replaces row instances during sorted DynamicData updates.

This adds an identity-based selection model for `ProDataGrid` and updates the closest DynamicData sample to cover the failure mode directly.

**What changed**

- Added `IdentitySelectionModel` to preserve logical selection by stable item identity instead of object reference/index alone
- Updated the `DynamicDataStreamingSourceCache` sample to use `IdentitySelectionModel` with `StreamingItem.Id`
- Added a focused regression test for replacement updates under sort:
  - `Replacement_Update_Under_Sort_Preserves_Row_Selection`

**Why**

With `SortAndBind(..., UseReplaceForUpdates = true)`, a keyed item update can replace the selected row instance and move it due to sorting. A plain `SelectionModel` follows the transient index/object change and selection drifts to the wrong row. This is the same failure mode seen in downstream apps that consume `ProDataGrid` with snapshot-style data updates.

**Validation**

Passed:

- `DataGridSample.Tests.DynamicDataStreamingSourceCachePageTests`

This proves the selected logical row remains selected after a replacement update that changes sort position.