### PR TITLE
Avoid closure allocation in DataGridColumn.CoerceWidth

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.Width.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.Width.cs
@@ -57,8 +57,13 @@ namespace Avalonia.Controls
                     double totalStarValues = 0;
                     double totalStarDesiredValues = 0;
                     double totalNonStarDisplayWidths = 0;
-                    foreach (DataGridColumn column in target.OwningGrid.ColumnsInternal.GetDisplayedColumns(c => c.IsVisible && c != target && !double.IsNaN(c.Width.DesiredValue)))
+                    foreach (DataGridColumn column in target.OwningGrid.ColumnsInternal.GetDisplayedColumns())
                     {
+                        if (!column.IsVisible || column == target || double.IsNaN(column.Width.DesiredValue))
+                        {
+                            continue;
+                        }
+
                         if (column.Width.IsStar)
                         {
                             totalStarValues += column.Width.Value;


### PR DESCRIPTION
## Summary

This PR prevents the allocation caused by capturing `target` inside of `CoerceWidth`, which allocates 32 bytes every time the function is called, including early exits.

This quickly adds up, as `CoerceWidth` gets called multiple times per scroll, per column.

## Changes

- Inlined the column filter of GetDisplayedColumns