### PR TITLE
Refresh cell validation after programmatic changes

### DIFF
--- a/src/Avalonia.Controls.DataGrid.LeakTests/LeakTests.cs
+++ b/src/Avalonia.Controls.DataGrid.LeakTests/LeakTests.cs
@@ -1016,6 +1016,24 @@ public class LeakTests
     }
 
     [ReleaseFact]
+    public void DataGrid_RemovedNotifyDataErrorInfoCell_DoesNotLeak()
+    {
+        var items = new ObservableCollection<NotifyDataErrorRowItem>
+        {
+            new NotifyDataErrorRowItem("A")
+        };
+        items[0].SetErrors(new[] { "Invalid" });
+
+        var (grid, cellRef) = RunInSession(() =>
+            RunRemovedNotifyDataErrorInfoCell(items));
+
+        AssertCollected(cellRef);
+
+        GC.KeepAlive(grid);
+        GC.KeepAlive(items);
+    }
+
+    [ReleaseFact]
     public void DataGrid_NotifyDataErrorInfo_ErrorsChanged_DoesNotLeak()
     {
         var items = new ObservableCollection<NotifyDataErrorRowItem>
@@ -1815,6 +1833,52 @@ public class LeakTests
         CleanupWindow(window);
 
         return gridRef;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (DataGrid Grid, WeakReference CellRef) RunRemovedNotifyDataErrorInfoCell(
+        ObservableCollection<NotifyDataErrorRowItem> items)
+    {
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ItemsSource = items
+        };
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(NotifyDataErrorRowItem.Name))
+        });
+
+        var window = new Window
+        {
+            Width = 600,
+            Height = 300,
+            Content = grid
+        };
+        window.SetThemeStyles();
+        ShowWindow(window);
+        grid.ScrollIntoView(items[0], grid.Columns[0]);
+        Dispatcher.UIThread.RunJobs();
+        PumpLayout(grid);
+
+        grid.SelectedItem = items[0];
+        grid.CurrentCell = new DataGridCellInfo(items[0], grid.Columns[0], 0, 0);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(grid.BeginEdit());
+        Dispatcher.UIThread.RunJobs();
+        var row = Assert.IsType<DataGridRow>(grid.EditingRow);
+        DataGridCell cell = row.Cells[0];
+        Assert.True(grid.CancelEdit(DataGridEditingUnit.Cell));
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(DataValidationErrors.GetHasErrors(cell));
+        var cellRef = new WeakReference(cell);
+
+        grid.Columns.RemoveAt(0);
+        Dispatcher.UIThread.RunJobs();
+        CleanupWindow(window);
+
+        return (grid, cellRef);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -479,12 +479,14 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
-    public void INotifyDataErrorInfo_change_preserves_binding_validation_on_other_property()
+    public void INotifyDataErrorInfo_all_property_change_preserves_binding_validation()
     {
         var (grid, root, item, _, warningColumn) = CreateMixedValidationGrid();
 
         try
         {
+            item.ErrorValue = "Valid";
+            grid.UpdateLayout();
             int slot = grid.SlotFromRowIndex(0);
             Assert.True(grid.UpdateSelectionAndCurrency(
                 warningColumn.Index,
@@ -501,16 +503,39 @@ public class DataGridValidationTests
             textBox.Text = "X";
             UpdateEditingElementSource(textBox);
             Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Row, exitEditingMode: true));
             grid.UpdateLayout();
 
             Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
             Assert.True(DataValidationErrors.GetHasErrors(warningCell));
 
-            item.ErrorValue = "Valid";
+            item.NotifyAllPropertiesChanged();
             grid.UpdateLayout();
 
             Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
             Assert.True(DataValidationErrors.GetHasErrors(warningCell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void INotifyDataErrorInfo_all_property_change_clears_removed_indei_error()
+    {
+        var (grid, root, item, errorColumn, _) = CreateMixedValidationGrid();
+
+        try
+        {
+            DataGridCell errorCell = FindCell(grid, item, errorColumn.Index);
+            Assert.Equal(DataGridValidationSeverity.Error, errorCell.ValidationSeverity);
+
+            item.ClearErrorsAndNotifyAllProperties();
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.None, errorCell.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(errorCell));
         }
         finally
         {
@@ -1883,6 +1908,17 @@ public class DataGridValidationTests
             }
 
             return Array.Empty<object>();
+        }
+
+        public void ClearErrorsAndNotifyAllProperties()
+        {
+            _errors.Clear();
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(null));
+        }
+
+        public void NotifyAllPropertiesChanged()
+        {
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(null));
         }
 
         private void SetError(string propertyName, DataGridValidationResult? error)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -714,6 +714,69 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_clear_preserves_identical_setter_warning_after_edit()
+    {
+        var item = new SameMessageValidationItem();
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+        root.SetThemeStyles(DataGridTheme.Simple);
+        var grid = new DataGrid
+        {
+            ItemsSource = new ObservableCollection<SameMessageValidationItem> { item },
+            AutoGenerateColumns = false
+        };
+        var column = new DataGridTextColumn
+        {
+            Header = "Value",
+            Binding = TwoWayBinding(nameof(SameMessageValidationItem.Value))
+        };
+        grid.ColumnsInternal.Add(column);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                column.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            TextBox textBox = Assert.IsType<TextBox>(cell.Content);
+            textBox.Text = "Rejected";
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            grid.UpdateLayout();
+
+            Assert.Equal(
+                2,
+                DataValidationErrors.GetErrors(cell).Count(
+                    error => ErrorContainsMessage(error, SameMessageValidationItem.ErrorMessage)));
+
+            item.ClearModelError();
+            grid.UpdateLayout();
+
+            Assert.Single(
+                DataValidationErrors.GetErrors(cell),
+                error => ErrorContainsMessage(error, SameMessageValidationItem.ErrorMessage));
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(cell.IsValid);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_change_refreshes_non_editing_cell_on_editing_row()
     {
         var (grid, root, item, errorColumn, warningColumn) = CreateMixedValidationGrid();
@@ -2169,6 +2232,58 @@ public class DataGridValidationTests
             field = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             return true;
+        }
+    }
+
+    private sealed class SameMessageValidationItem : INotifyPropertyChanged, INotifyDataErrorInfo
+    {
+        public const string ErrorMessage = "Value is rejected.";
+
+        private string _value = "Initial";
+        private bool _hasModelError = true;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                if (string.Equals(value, "Rejected", StringComparison.Ordinal))
+                {
+                    throw new DataValidationException(
+                        new DataGridValidationResult(ErrorMessage, DataGridValidationSeverity.Warning));
+                }
+
+                if (!string.Equals(_value, value, StringComparison.Ordinal))
+                {
+                    _value = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+                }
+            }
+        }
+
+        public bool HasErrors => _hasModelError;
+
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (_hasModelError &&
+                (string.IsNullOrEmpty(propertyName) || propertyName == nameof(Value)))
+            {
+                return new[]
+                {
+                    new DataGridValidationResult(ErrorMessage, DataGridValidationSeverity.Warning)
+                };
+            }
+
+            return Array.Empty<object>();
+        }
+
+        public void ClearModelError()
+        {
+            _hasModelError = false;
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Value)));
         }
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -12,6 +12,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Headless.XUnit;
@@ -640,6 +641,71 @@ public class DataGridValidationTests
 
             Assert.Equal(DataGridValidationSeverity.None, errorCell.ValidationSeverity);
             Assert.False(DataValidationErrors.GetHasErrors(errorCell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void INotifyDataErrorInfo_clear_preserves_same_cell_setter_warning_after_edit()
+    {
+        var item = new MixedValidationItem
+        {
+            WarningValue = "Okay"
+        };
+        item.SetWarningValueError();
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+        root.SetThemeStyles(DataGridTheme.Simple);
+        var grid = new DataGrid
+        {
+            ItemsSource = new ObservableCollection<MixedValidationItem> { item },
+            AutoGenerateColumns = false
+        };
+        var warningColumn = new MixedSourceValidationColumn();
+        grid.ColumnsInternal.Add(warningColumn);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                warningColumn.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell warningCell = FindCell(grid, item, warningColumn.Index);
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            grid.UpdateLayout();
+
+            Assert.Contains(
+                DataValidationErrors.GetErrors(warningCell),
+                error => ErrorContainsMessage(error, "Model warning"));
+            Assert.Contains(
+                DataValidationErrors.GetErrors(warningCell),
+                error => ErrorContainsMessage(error, "Warning value should"));
+
+            item.ClearWarningValueError();
+            grid.UpdateLayout();
+
+            Assert.DoesNotContain(
+                DataValidationErrors.GetErrors(warningCell),
+                error => ErrorContainsMessage(error, "Model warning"));
+            Assert.Contains(
+                DataValidationErrors.GetErrors(warningCell),
+                error => ErrorContainsMessage(error, "Warning value should"));
+            Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
         }
         finally
         {
@@ -2057,6 +2123,18 @@ public class DataGridValidationTests
             ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(null));
         }
 
+        public void SetWarningValueError()
+        {
+            SetError(
+                nameof(WarningValue),
+                new DataGridValidationResult("Model warning.", DataGridValidationSeverity.Warning));
+        }
+
+        public void ClearWarningValueError()
+        {
+            SetError(nameof(WarningValue), null);
+        }
+
         private void SetError(string propertyName, DataGridValidationResult? error)
         {
             if (error == null)
@@ -2091,6 +2169,68 @@ public class DataGridValidationTests
             field = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             return true;
+        }
+    }
+
+    private sealed class MixedSourceValidationColumn : DataGridComboBoxColumn
+    {
+        public MixedSourceValidationColumn()
+        {
+            Header = "Warning";
+            SelectedValueBinding = TwoWayBinding(nameof(MixedValidationItem.WarningValue));
+        }
+
+        protected override Control GenerateEditingElement(
+            DataGridCell cell,
+            object dataItem,
+            out ICellEditBinding editBinding)
+        {
+            editBinding = new MixedSourceEditBinding();
+            return new TextBox();
+        }
+
+        protected override object PrepareCellForEdit(
+            Control editingElement,
+            Avalonia.Interactivity.RoutedEventArgs editingEventArgs)
+        {
+            return null!;
+        }
+    }
+
+    private sealed class MixedSourceEditBinding : ICellEditBinding
+    {
+        public bool IsValid => true;
+
+        public IEnumerable<Exception> ValidationErrors => new Exception[]
+        {
+            new DataValidationException(
+                new DataGridValidationResult("Model warning.", DataGridValidationSeverity.Warning)),
+            new DataValidationException(
+                new DataGridValidationResult(
+                    "Warning value should be at least 3 characters.",
+                    DataGridValidationSeverity.Warning))
+        };
+
+        public IObservable<bool> ValidationChanged { get; } = new EmptyValidationObservable();
+
+        public bool CommitEdit() => true;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EmptyValidationObservable : IObservable<bool>
+    {
+        public IDisposable Subscribe(IObserver<bool> observer) => EmptyValidationDisposable.Instance;
+    }
+
+    private sealed class EmptyValidationDisposable : IDisposable
+    {
+        public static EmptyValidationDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
         }
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -834,6 +834,60 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_error_overrides_custom_binding_warning_during_edit()
+    {
+        var item = new SameMessageValidationItem(DataGridValidationSeverity.Error);
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+        root.SetThemeStyles(DataGridTheme.Simple);
+        var grid = new DataGrid
+        {
+            ItemsSource = new ObservableCollection<SameMessageValidationItem> { item },
+            AutoGenerateColumns = false
+        };
+        var column = new SameMessageCustomValidationColumn();
+        grid.ColumnsInternal.Add(column);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                column.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            DataGridRow row = FindRow(grid, item);
+            Assert.False(grid.CommitEdit());
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.Error, cell.ValidationSeverity);
+            Assert.False(cell.IsValid);
+            Assert.Equal(DataGridValidationSeverity.Error, row.ValidationSeverity);
+            Assert.False(row.IsValid);
+            Assert.False(grid.IsValid);
+            Assert.Equal(
+                2,
+                DataValidationErrors.GetErrors(cell).Count(
+                    error => ErrorContainsMessage(error, SameMessageValidationItem.ErrorMessage)));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_change_refreshes_non_editing_cell_on_editing_row()
     {
         var (grid, root, item, errorColumn, warningColumn) = CreateMixedValidationGrid();
@@ -2296,8 +2350,15 @@ public class DataGridValidationTests
     {
         public const string ErrorMessage = "Value is rejected.";
 
+        private readonly DataGridValidationSeverity _modelSeverity;
         private string _value = "Initial";
         private bool _hasModelError = true;
+
+        public SameMessageValidationItem(
+            DataGridValidationSeverity modelSeverity = DataGridValidationSeverity.Warning)
+        {
+            _modelSeverity = modelSeverity;
+        }
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
@@ -2330,7 +2391,7 @@ public class DataGridValidationTests
             {
                 return new[]
                 {
-                    new DataGridValidationResult(ErrorMessage, DataGridValidationSeverity.Warning)
+                    new DataGridValidationResult(ErrorMessage, _modelSeverity)
                 };
             }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -413,6 +413,39 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_committed_warning_is_cleared_by_later_model_change()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                column.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+
+            item.Code = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.None, cell.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_validation_restores_on_row_recycle()
     {
         var (grid, root, item, column) = CreateNotifyValidationGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -544,6 +544,38 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_change_refreshes_non_editing_cell_on_editing_row()
+    {
+        var (grid, root, item, errorColumn, warningColumn) = CreateMixedValidationGrid();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                warningColumn.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell errorCell = FindCell(grid, item, errorColumn.Index);
+            Assert.Equal(DataGridValidationSeverity.Error, errorCell.ValidationSeverity);
+
+            item.ErrorValue = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.None, errorCell.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(errorCell));
+            Assert.Equal(warningColumn.Index, grid.EditingColumnIndex);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Grid_invalid_when_offscreen_item_has_error()
     {
         var (grid, root, errorItem, items) = CreateOffscreenErrorValidationGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -731,7 +731,7 @@ public class DataGridValidationTests
         var column = new DataGridTextColumn
         {
             Header = "Value",
-            Binding = TwoWayBinding(nameof(SameMessageValidationItem.Value))
+            Binding = new Binding(nameof(SameMessageValidationItem.Value))
         };
         grid.ColumnsInternal.Add(column);
         root.Content = grid;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -479,6 +479,46 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_change_preserves_binding_validation_on_other_property()
+    {
+        var (grid, root, item, _, warningColumn) = CreateMixedValidationGrid();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                warningColumn.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            grid.UpdateLayout();
+
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell warningCell = FindCell(grid, item, warningColumn.Index);
+            TextBox textBox = Assert.IsType<TextBox>(warningCell.Content);
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(warningCell));
+
+            item.ErrorValue = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.Warning, warningCell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(warningCell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Grid_invalid_when_offscreen_item_has_error()
     {
         var (grid, root, errorItem, items) = CreateOffscreenErrorValidationGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -448,6 +448,37 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_programmatic_change_refreshes_realized_cell_validation()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid(initialCode: "Valid");
+
+        try
+        {
+            var cell = FindCell(grid, item, column.Index);
+            Assert.Equal(DataGridValidationSeverity.None, cell.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+
+            item.Code = "X";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(((IPseudoClasses)cell.Classes).Contains(":warning"));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+
+            item.Code = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.None, cell.ValidationSeverity);
+            Assert.False(((IPseudoClasses)cell.Classes).Contains(":warning"));
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Grid_invalid_when_offscreen_item_has_error()
     {
         var (grid, root, errorItem, items) = CreateOffscreenErrorValidationGrid();
@@ -830,14 +861,19 @@ public class DataGridValidationTests
 
     private static (DataGrid grid, Window root, NotifyValidationItem item, DataGridTextColumn column) CreateNotifyValidationGrid()
     {
-        return CreateNotifyValidationGrid(TwoWayBinding(nameof(NotifyValidationItem.Code)));
+        return CreateNotifyValidationGrid(TwoWayBinding(nameof(NotifyValidationItem.Code)), "X");
     }
 
-    private static (DataGrid grid, Window root, NotifyValidationItem item, DataGridTextColumn column) CreateNotifyValidationGrid(BindingBase binding)
+    private static (DataGrid grid, Window root, NotifyValidationItem item, DataGridTextColumn column) CreateNotifyValidationGrid(string initialCode)
+    {
+        return CreateNotifyValidationGrid(TwoWayBinding(nameof(NotifyValidationItem.Code)), initialCode);
+    }
+
+    private static (DataGrid grid, Window root, NotifyValidationItem item, DataGridTextColumn column) CreateNotifyValidationGrid(BindingBase binding, string initialCode = "X")
     {
         var item = new NotifyValidationItem
         {
-            Code = "X"
+            Code = initialCode
         };
 
         var items = new ObservableCollection<NotifyValidationItem> { item };

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -777,6 +777,63 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_clear_preserves_identical_custom_binding_warning_after_edit()
+    {
+        var item = new SameMessageValidationItem();
+        var root = new Window
+        {
+            Width = 600,
+            Height = 300
+        };
+        root.SetThemeStyles(DataGridTheme.Simple);
+        var grid = new DataGrid
+        {
+            ItemsSource = new ObservableCollection<SameMessageValidationItem> { item },
+            AutoGenerateColumns = false
+        };
+        var column = new SameMessageCustomValidationColumn();
+        grid.ColumnsInternal.Add(column);
+        root.Content = grid;
+        root.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                column.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            grid.UpdateLayout();
+
+            Assert.Equal(
+                2,
+                DataValidationErrors.GetErrors(cell).Count(
+                    error => ErrorContainsMessage(error, SameMessageValidationItem.ErrorMessage)));
+
+            item.ClearModelError();
+            grid.UpdateLayout();
+
+            Assert.Single(
+                DataValidationErrors.GetErrors(cell),
+                error => ErrorContainsMessage(error, SameMessageValidationItem.ErrorMessage));
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(cell.IsValid);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_change_refreshes_non_editing_cell_on_editing_row()
     {
         var (grid, root, item, errorColumn, warningColumn) = CreateMixedValidationGrid();
@@ -2284,6 +2341,54 @@ public class DataGridValidationTests
         {
             _hasModelError = false;
             ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Value)));
+        }
+    }
+
+    private sealed class SameMessageCustomValidationColumn : DataGridComboBoxColumn
+    {
+        public SameMessageCustomValidationColumn()
+        {
+            Header = "Value";
+            SelectedValueBinding = TwoWayBinding(nameof(SameMessageValidationItem.Value));
+        }
+
+        protected override Control GenerateEditingElement(
+            DataGridCell cell,
+            object dataItem,
+            out ICellEditBinding editBinding)
+        {
+            editBinding = new SameMessageCustomEditBinding();
+            return new TextBox();
+        }
+
+        protected override object PrepareCellForEdit(
+            Control editingElement,
+            Avalonia.Interactivity.RoutedEventArgs editingEventArgs)
+        {
+            return null!;
+        }
+    }
+
+    private sealed class SameMessageCustomEditBinding : ICellEditBinding
+    {
+        public bool IsValid => true;
+
+        public IEnumerable<Exception> ValidationErrors => new[]
+        {
+            new DataValidationException(
+                new DataGridValidationResult(
+                    SameMessageValidationItem.ErrorMessage,
+                    DataGridValidationSeverity.Warning))
+        };
+
+        public IObservable<bool> ValidationChanged { get; } = new EmptyValidationObservable();
+
+        public bool HasSourceWriteError => true;
+
+        public bool CommitEdit() => true;
+
+        public void Dispose()
+        {
         }
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -479,6 +479,41 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_refresh_preserves_same_cell_binding_error()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid(initialCode: "Valid");
+
+        try
+        {
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            var bindingError = new DataValidationException(
+                new DataGridValidationResult("Binding error", DataGridValidationSeverity.Error));
+            DataValidationErrors.SetError(cell, bindingError);
+            object displayedBindingError = Assert.Single(DataValidationErrors.GetErrors(cell));
+            cell.IsValid = false;
+            cell.ValidationSeverity = DataGridValidationSeverity.Error;
+            cell.UpdatePseudoClasses();
+
+            item.Code = "X";
+            grid.UpdateLayout();
+
+            Assert.Contains(displayedBindingError, DataValidationErrors.GetErrors(cell));
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+
+            item.Code = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Same(displayedBindingError, Assert.Single(DataValidationErrors.GetErrors(cell)));
+            Assert.Equal(DataGridValidationSeverity.Error, cell.ValidationSeverity);
+            Assert.False(cell.IsValid);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_all_property_change_preserves_binding_validation()
     {
         var (grid, root, item, _, warningColumn) = CreateMixedValidationGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Validation/DataGridValidationTests.cs
@@ -446,6 +446,42 @@ public class DataGridValidationTests
     }
 
     [AvaloniaFact]
+    public void INotifyDataErrorInfo_warning_introduced_by_edit_is_later_cleared()
+    {
+        var (grid, root, item, column) = CreateNotifyValidationGrid(initialCode: "Valid");
+
+        try
+        {
+            int slot = grid.SlotFromRowIndex(0);
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                column.Index,
+                slot,
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+
+            DataGridCell cell = FindCell(grid, item, column.Index);
+            TextBox textBox = Assert.IsType<TextBox>(cell.Content);
+            textBox.Text = "X";
+            UpdateEditingElementSource(textBox);
+            Assert.True(grid.CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true));
+            Assert.Equal(DataGridValidationSeverity.Warning, cell.ValidationSeverity);
+            Assert.True(DataValidationErrors.GetHasErrors(cell));
+
+            item.Code = "Valid";
+            grid.UpdateLayout();
+
+            Assert.Equal(DataGridValidationSeverity.None, cell.ValidationSeverity);
+            Assert.False(DataValidationErrors.GetHasErrors(cell));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void INotifyDataErrorInfo_validation_restores_on_row_recycle()
     {
         var (grid, root, item, column) = CreateNotifyValidationGrid();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -532,13 +532,11 @@ internal
 
                         if (editingCell != null)
                         {
-                            var aggregateError = new AggregateException(binding.ValidationErrors);
-                            bool isNotifyDataErrorInfoValidation =
-                                _editingCellHadNotifyDataErrorInfoValidation ||
-                                HasNotifyDataErrorInfoValidation(
-                                    editingRow?.DataContext,
-                                    editingCell.OwningColumn);
-                            if (isNotifyDataErrorInfoValidation)
+                            var bindingErrors = binding.ValidationErrors.ToList();
+                            var notifyDataErrorInfoErrors = GetNotifyDataErrorInfoValidationExceptions(
+                                editingRow?.DataContext,
+                                editingCell.OwningColumn);
+                            if (notifyDataErrorInfoErrors.Count > 0)
                             {
                                 var displayedErrors = new List<object>();
                                 if (_editingCellPreservedValidationErrors is not null)
@@ -546,15 +544,26 @@ internal
                                     displayedErrors.AddRange(_editingCellPreservedValidationErrors);
                                 }
 
-                                displayedErrors.Add(aggregateError);
+                                RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
+                                if (bindingErrors.Count > 0)
+                                {
+                                    displayedErrors.Add(new AggregateException(bindingErrors));
+                                }
+
+                                object ownedError = notifyDataErrorInfoErrors.Count == 1
+                                    ? notifyDataErrorInfoErrors[0]
+                                    : new AggregateException(notifyDataErrorInfoErrors);
+                                displayedErrors.Add(ownedError);
                                 DataValidationErrors.SetErrors(editingCell, displayedErrors);
                                 _notifyDataErrorInfoCellErrors[editingCell] =
-                                    new object[] { aggregateError };
+                                    new object[] { ownedError };
                             }
                             else
                             {
                                 _notifyDataErrorInfoCellErrors.Remove(editingCell);
-                                DataValidationErrors.SetError(editingCell, aggregateError);
+                                DataValidationErrors.SetError(
+                                    editingCell,
+                                    new AggregateException(bindingErrors));
                             }
                         }
                     }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -503,16 +503,46 @@ internal
             // If we're committing, explicitly update the source but watch out for any validation errors
             if (editAction == DataGridEditAction.Commit)
             {
-                void SetValidationStatus(ICellEditBinding binding)
+                DataGridValidationSeverity SetValidationStatus(ICellEditBinding binding)
                 {
-                    var severity = ValidationUtil.GetValidationSeverity(binding.ValidationErrors);
+                    var bindingErrors = binding.ValidationErrors.ToList();
+                    var notifyDataErrorInfoErrors = editingCell is null
+                        ? new List<Exception>()
+                        : GetNotifyDataErrorInfoValidationExceptions(
+                            editingRow?.DataContext,
+                            editingCell.OwningColumn);
+                    var displayedErrors = new List<object>();
+                    if (_editingCellPreservedValidationErrors is not null)
+                    {
+                        displayedErrors.AddRange(_editingCellPreservedValidationErrors);
+                    }
+
+                    if (notifyDataErrorInfoErrors.Count > 0 && !binding.HasSourceWriteError)
+                    {
+                        RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
+                    }
+                    if (bindingErrors.Count > 0)
+                    {
+                        displayedErrors.Add(new AggregateException(bindingErrors));
+                    }
+
+                    if (notifyDataErrorInfoErrors.Count > 0)
+                    {
+                        object ownedError = notifyDataErrorInfoErrors.Count == 1
+                            ? notifyDataErrorInfoErrors[0]
+                            : new AggregateException(notifyDataErrorInfoErrors);
+                        displayedErrors.Add(ownedError);
+                        _notifyDataErrorInfoCellErrors[editingCell] = new object[] { ownedError };
+                    }
+                    else if (editingCell is not null)
+                    {
+                        _notifyDataErrorInfoCellErrors.Remove(editingCell);
+                    }
+
+                    var severity = GetDisplayedValidationSeverity(displayedErrors);
                     if (severity == DataGridValidationSeverity.None)
                     {
                         ResetValidationStatus(editingCell);
-                        if (editingElement != null)
-                        {
-                            DataValidationErrors.ClearErrors(editingElement);
-                        }
                     }
                     else
                     {
@@ -525,78 +555,36 @@ internal
                         }
                         UpdateGridValidationState();
 
-                        if (editingElement != null)
-                        {
-                            DataValidationErrors.ClearErrors(editingElement);
-                        }
-
                         if (editingCell != null)
                         {
-                            var bindingErrors = binding.ValidationErrors.ToList();
-                            var notifyDataErrorInfoErrors = GetNotifyDataErrorInfoValidationExceptions(
-                                editingRow?.DataContext,
-                                editingCell.OwningColumn);
-                            if (notifyDataErrorInfoErrors.Count > 0)
-                            {
-                                var displayedErrors = new List<object>();
-                                if (_editingCellPreservedValidationErrors is not null)
-                                {
-                                    displayedErrors.AddRange(_editingCellPreservedValidationErrors);
-                                }
-
-                                if (!binding.HasSourceWriteError)
-                                {
-                                    RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
-                                }
-                                if (bindingErrors.Count > 0)
-                                {
-                                    displayedErrors.Add(new AggregateException(bindingErrors));
-                                }
-
-                                object ownedError = notifyDataErrorInfoErrors.Count == 1
-                                    ? notifyDataErrorInfoErrors[0]
-                                    : new AggregateException(notifyDataErrorInfoErrors);
-                                displayedErrors.Add(ownedError);
-                                DataValidationErrors.SetErrors(editingCell, displayedErrors);
-                                _notifyDataErrorInfoCellErrors[editingCell] =
-                                    new object[] { ownedError };
-                            }
-                            else
-                            {
-                                _notifyDataErrorInfoCellErrors.Remove(editingCell);
-                                DataValidationErrors.SetError(
-                                    editingCell,
-                                    new AggregateException(bindingErrors));
-                            }
+                            DataValidationErrors.SetErrors(editingCell, displayedErrors);
                         }
                     }
+
+                    if (editingElement != null)
+                    {
+                        DataValidationErrors.ClearErrors(editingElement);
+                    }
+
+                    return severity;
                 }
 
                 var editBinding = CurrentColumn?.CellEditBinding;
                 if (editBinding != null)
                 {
                     editBinding.CommitEdit();
-                    var severity = ValidationUtil.GetValidationSeverity(editBinding.ValidationErrors);
-                    if (severity != DataGridValidationSeverity.None)
+                    var severity = SetValidationStatus(editBinding);
+                    if (severity == DataGridValidationSeverity.Error)
                     {
-                        SetValidationStatus(editBinding);
-
-                        if (severity == DataGridValidationSeverity.Error)
-                        {
-                            _validationSubscription?.Dispose();
-                            _validationSubscription = editBinding.ValidationChanged.Subscribe(v => SetValidationStatus(editBinding));
-
-                            ScrollSlotIntoView(CurrentColumnIndex, CurrentSlot, forCurrentCellChange: false, forceHorizontalScroll: true);
-                            return false;
-                        }
-
                         _validationSubscription?.Dispose();
-                        _validationSubscription = null;
+                        _validationSubscription = editBinding.ValidationChanged.Subscribe(v => SetValidationStatus(editBinding));
+
+                        ScrollSlotIntoView(CurrentColumnIndex, CurrentSlot, forCurrentCellChange: false, forceHorizontalScroll: true);
+                        return false;
                     }
-                    else
-                    {
-                        ResetValidationStatus(editingCell);
-                    }
+
+                    _validationSubscription?.Dispose();
+                    _validationSubscription = null;
                 }
                 else
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -346,6 +346,12 @@ internal
 
             // Finally, we can prepare the cell for editing
             _editingCellValidationSnapshot = CellValidationSnapshot.Capture(dataGridCell);
+            _editingCellHadNotifyDataErrorInfoValidation =
+                _notifyDataErrorInfoCellErrors.ContainsKey(dataGridCell);
+            _editingCellPreservedValidationErrors = _editingCellHadNotifyDataErrorInfoValidation
+                ? GetErrorsWithoutOwnedNotifyDataErrorInfoErrors(dataGridCell).ToArray()
+                : null;
+            _notifyDataErrorInfoCellErrors.Remove(dataGridCell);
             // Hide existing cell errors while editing to avoid duplicate validation visuals.
             DataValidationErrors.ClearErrors(dataGridCell);
             _editingColumnIndex = CurrentColumnIndex;
@@ -526,8 +532,25 @@ internal
 
                         if (editingCell != null)
                         {
-                            DataValidationErrors.SetError(editingCell,
-                                new AggregateException(binding.ValidationErrors));
+                            var aggregateError = new AggregateException(binding.ValidationErrors);
+                            if (_editingCellHadNotifyDataErrorInfoValidation)
+                            {
+                                var displayedErrors = new List<object>();
+                                if (_editingCellPreservedValidationErrors is not null)
+                                {
+                                    displayedErrors.AddRange(_editingCellPreservedValidationErrors);
+                                }
+
+                                displayedErrors.Add(aggregateError);
+                                DataValidationErrors.SetErrors(editingCell, displayedErrors);
+                                _notifyDataErrorInfoCellErrors[editingCell] =
+                                    new object[] { aggregateError };
+                            }
+                            else
+                            {
+                                _notifyDataErrorInfoCellErrors.Remove(editingCell);
+                                DataValidationErrors.SetError(editingCell, aggregateError);
+                            }
                         }
                     }
                 }
@@ -586,6 +609,8 @@ internal
                 }
             }
             _editingCellValidationSnapshot = null;
+            _editingCellHadNotifyDataErrorInfoValidation = false;
+            _editingCellPreservedValidationErrors = null;
 
             if (exitEditingMode)
             {
@@ -1061,6 +1086,8 @@ internal
             EditingRow = null;
             _editingRowValidationSnapshot = null;
             _editingCellValidationSnapshot = null;
+            _editingCellHadNotifyDataErrorInfoValidation = false;
+            _editingCellPreservedValidationErrors = null;
         }
 
 
@@ -1415,6 +1442,8 @@ internal
         private bool _focusEditingControl;
         private List<CellValidationSnapshot> _editingRowValidationSnapshot;
         private CellValidationSnapshot _editingCellValidationSnapshot;
+        private bool _editingCellHadNotifyDataErrorInfoValidation;
+        private object[] _editingCellPreservedValidationErrors;
 
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -544,7 +544,7 @@ internal
                                     displayedErrors.AddRange(_editingCellPreservedValidationErrors);
                                 }
 
-                                if (binding is not ICellEditBindingValidationSource { HasSourceWriteError: true })
+                                if (!binding.HasSourceWriteError)
                                 {
                                     RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
                                 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -544,7 +544,10 @@ internal
                                     displayedErrors.AddRange(_editingCellPreservedValidationErrors);
                                 }
 
-                                RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
+                                if (binding is not ICellEditBindingValidationSource { HasSourceWriteError: true })
+                                {
+                                    RemoveMatchingValidationErrors(bindingErrors, notifyDataErrorInfoErrors);
+                                }
                                 if (bindingErrors.Count > 0)
                                 {
                                     displayedErrors.Add(new AggregateException(bindingErrors));

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -533,7 +533,12 @@ internal
                         if (editingCell != null)
                         {
                             var aggregateError = new AggregateException(binding.ValidationErrors);
-                            if (_editingCellHadNotifyDataErrorInfoValidation)
+                            bool isNotifyDataErrorInfoValidation =
+                                _editingCellHadNotifyDataErrorInfoValidation ||
+                                HasNotifyDataErrorInfoValidation(
+                                    editingRow?.DataContext,
+                                    editingCell.OwningColumn);
+                            if (isNotifyDataErrorInfoValidation)
                             {
                                 var displayedErrors = new List<object>();
                                 if (_editingCellPreservedValidationErrors is not null)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -699,34 +699,62 @@ internal
             return exceptions;
         }
 
-        private static bool HasNotifyDataErrorInfoValidation(object item, DataGridColumn column)
+        private static List<Exception> GetNotifyDataErrorInfoValidationExceptions(
+            object item,
+            DataGridColumn column)
         {
             if (item is not INotifyDataErrorInfo notifyDataErrorInfo)
             {
-                return false;
+                return new List<Exception>();
             }
 
             string bindingPath = GetColumnBindingPath(column);
             if (string.IsNullOrWhiteSpace(bindingPath))
             {
-                return false;
+                return new List<Exception>();
             }
 
             IEnumerable errors = notifyDataErrorInfo.GetErrors(bindingPath);
-            if (errors is null)
-            {
-                return false;
-            }
+            return errors is null
+                ? new List<Exception>()
+                : CreateValidationExceptions(errors);
+        }
 
-            foreach (object error in errors)
+        private static void RemoveMatchingValidationErrors(
+            List<Exception> bindingErrors,
+            List<Exception> notifyDataErrorInfoErrors)
+        {
+            foreach (Exception notifyDataErrorInfoError in notifyDataErrorInfoErrors)
             {
-                if (error is not null)
+                for (int index = 0; index < bindingErrors.Count; index++)
                 {
-                    return true;
+                    if (ValidationErrorsMatch(bindingErrors[index], notifyDataErrorInfoError))
+                    {
+                        bindingErrors.RemoveAt(index);
+                        break;
+                    }
                 }
             }
+        }
 
-            return false;
+        private static bool ValidationErrorsMatch(Exception first, Exception second)
+        {
+            object firstData = ValidationUtil.UnpackDataValidationException(first);
+            object secondData = ValidationUtil.UnpackDataValidationException(second);
+            if (ReferenceEquals(firstData, secondData) || Equals(firstData, secondData))
+            {
+                return true;
+            }
+
+            if (firstData is DataGridValidationResult firstResult &&
+                secondData is DataGridValidationResult secondResult)
+            {
+                return firstResult.Severity == secondResult.Severity &&
+                    string.Equals(firstResult.Message, secondResult.Message, StringComparison.Ordinal);
+            }
+
+            return first.GetType() == second.GetType() &&
+                string.Equals(first.Message, second.Message, StringComparison.Ordinal);
         }
 
         private List<Exception> _bindingValidationErrors;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -56,7 +56,7 @@ internal
             _validationSubscription = null;
         }
 
-        private static void ClearCellValidation(DataGridCell cell)
+        private void ClearCellValidation(DataGridCell cell)
         {
             if (!cell.IsValid || cell.ValidationSeverity != DataGridValidationSeverity.None)
             {
@@ -118,14 +118,14 @@ internal
                 var errors = notifyDataErrorInfo.GetErrors(bindingPath);
                 if (errors is null)
                 {
-                    ClearCellValidation(cell);
+                    ClearNotifyDataErrorInfoValidation(cell);
                     continue;
                 }
 
                 var exceptions = CreateValidationExceptions(errors);
                 if (exceptions.Count == 0)
                 {
-                    ClearCellValidation(cell);
+                    ClearNotifyDataErrorInfoValidation(cell);
                     continue;
                 }
 
@@ -138,10 +138,51 @@ internal
                     ? exceptions[0]
                     : new AggregateException(exceptions);
                 DataValidationErrors.SetError(cell, errorException);
+                IEnumerable<object> displayedErrors = DataValidationErrors.GetErrors(cell);
+                if (displayedErrors is not null)
+                {
+                    var trackedErrors = new List<object>();
+                    foreach (object displayedError in displayedErrors)
+                    {
+                        trackedErrors.Add(displayedError);
+                    }
+
+                    _notifyDataErrorInfoCellErrors[cell] = trackedErrors.ToArray();
+                }
             }
 
             UpdateRowValidationStateFromCells(row);
             UpdateGridValidationState();
+        }
+
+        private void ClearNotifyDataErrorInfoValidation(DataGridCell cell)
+        {
+            if (!_notifyDataErrorInfoCellErrors.Remove(cell, out object[] expectedErrors))
+            {
+                return;
+            }
+
+            IEnumerable<object> currentErrors = DataValidationErrors.GetErrors(cell);
+            if (currentErrors is null)
+            {
+                return;
+            }
+
+            int index = 0;
+            foreach (object currentError in currentErrors)
+            {
+                if (index >= expectedErrors.Length || !Equals(currentError, expectedErrors[index]))
+                {
+                    return;
+                }
+
+                index++;
+            }
+
+            if (index == expectedErrors.Length)
+            {
+                ClearCellValidation(cell);
+            }
         }
 
         private void ClearRowValidation(DataGridRow row)
@@ -156,6 +197,7 @@ internal
 
             foreach (DataGridCell cell in row.Cells)
             {
+                _notifyDataErrorInfoCellErrors.Remove(cell);
                 ClearCellValidation(cell);
             }
 
@@ -585,6 +627,7 @@ internal
         private bool _isValid = true;
         private readonly HashSet<INotifyDataErrorInfo> _collectionValidationTrackedItems = new(ReferenceEqualityComparer.Instance);
         private readonly HashSet<INotifyDataErrorInfo> _collectionValidationItemsWithError = new(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<DataGridCell, object[]> _notifyDataErrorInfoCellErrors = new();
         private bool _collectionValidationStateInitialized;
         private bool _collectionValidationStateInvalidated = true;
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -72,7 +72,8 @@ internal
             DataGridRow row,
             object item,
             bool clearIfNoIndei = true,
-            string propertyName = null)
+            string propertyName = null,
+            int excludedColumnIndex = -1)
         {
             if (row is null)
             {
@@ -97,6 +98,11 @@ internal
             foreach (var column in ColumnsItemsInternal)
             {
                 if (column.Index < 0 || column.Index >= row.Cells.Count)
+                {
+                    continue;
+                }
+
+                if (column.Index == excludedColumnIndex)
                 {
                     continue;
                 }
@@ -548,13 +554,19 @@ internal
                 slot++)
             {
                 if (DisplayData.GetDisplayedElement(slot) is not DataGridRow row ||
-                    ReferenceEquals(row, EditingRow) ||
                     !ReferenceEquals(row.DataContext, notifyDataErrorInfo))
                 {
                     continue;
                 }
 
-                RestoreRowValidationState(row, notifyDataErrorInfo, propertyName: propertyName);
+                int excludedColumnIndex = ReferenceEquals(row, EditingRow)
+                    ? _editingColumnIndex
+                    : -1;
+                RestoreRowValidationState(
+                    row,
+                    notifyDataErrorInfo,
+                    propertyName: propertyName,
+                    excludedColumnIndex: excludedColumnIndex);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -68,7 +68,11 @@ internal
             DataValidationErrors.ClearErrors(cell);
         }
 
-        private void RestoreRowValidationState(DataGridRow row, object item, bool clearIfNoIndei = true)
+        private void RestoreRowValidationState(
+            DataGridRow row,
+            object item,
+            bool clearIfNoIndei = true,
+            string propertyName = null)
         {
             if (row is null)
             {
@@ -101,6 +105,12 @@ internal
                 var bindingPath = GetColumnBindingPath(column);
 
                 if (string.IsNullOrWhiteSpace(bindingPath))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(propertyName) &&
+                    !string.Equals(bindingPath, propertyName, StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -478,11 +488,13 @@ internal
             }
 
             UpdateTrackedCollectionValidationItemState(notifyDataErrorInfo);
-            RefreshRealizedRowValidationState(notifyDataErrorInfo);
+            RefreshRealizedRowValidationState(notifyDataErrorInfo, e.PropertyName);
             UpdateGridValidationState();
         }
 
-        private void RefreshRealizedRowValidationState(INotifyDataErrorInfo notifyDataErrorInfo)
+        private void RefreshRealizedRowValidationState(
+            INotifyDataErrorInfo notifyDataErrorInfo,
+            string propertyName)
         {
             if (DisplayData == null)
             {
@@ -500,7 +512,7 @@ internal
                     continue;
                 }
 
-                RestoreRowValidationState(row, notifyDataErrorInfo);
+                RestoreRowValidationState(row, notifyDataErrorInfo, propertyName: propertyName);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -699,6 +699,36 @@ internal
             return exceptions;
         }
 
+        private static bool HasNotifyDataErrorInfoValidation(object item, DataGridColumn column)
+        {
+            if (item is not INotifyDataErrorInfo notifyDataErrorInfo)
+            {
+                return false;
+            }
+
+            string bindingPath = GetColumnBindingPath(column);
+            if (string.IsNullOrWhiteSpace(bindingPath))
+            {
+                return false;
+            }
+
+            IEnumerable errors = notifyDataErrorInfo.GetErrors(bindingPath);
+            if (errors is null)
+            {
+                return false;
+            }
+
+            foreach (object error in errors)
+            {
+                if (error is not null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private List<Exception> _bindingValidationErrors;
 
         private IDisposable _validationSubscription;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -70,6 +70,14 @@ internal
             DataValidationErrors.ClearErrors(cell);
         }
 
+        internal void OnCellRemovedForValidation(DataGridCell cell)
+        {
+            if (cell is not null)
+            {
+                _notifyDataErrorInfoCellErrors.Remove(cell);
+            }
+        }
+
         private void RestoreRowValidationState(
             DataGridRow row,
             object item,

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -478,7 +478,30 @@ internal
             }
 
             UpdateTrackedCollectionValidationItemState(notifyDataErrorInfo);
+            RefreshRealizedRowValidationState(notifyDataErrorInfo);
             UpdateGridValidationState();
+        }
+
+        private void RefreshRealizedRowValidationState(INotifyDataErrorInfo notifyDataErrorInfo)
+        {
+            if (DisplayData == null)
+            {
+                return;
+            }
+
+            for (int slot = DisplayData.FirstScrollingSlot;
+                slot > -1 && slot <= DisplayData.LastScrollingSlot;
+                slot++)
+            {
+                if (DisplayData.GetDisplayedElement(slot) is not DataGridRow row ||
+                    ReferenceEquals(row, EditingRow) ||
+                    !ReferenceEquals(row.DataContext, notifyDataErrorInfo))
+                {
+                    continue;
+                }
+
+                RestoreRowValidationState(row, notifyDataErrorInfo);
+            }
         }
 
         private void DetachCollectionValidationTracking()

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Validation.cs
@@ -58,6 +58,8 @@ internal
 
         private void ClearCellValidation(DataGridCell cell)
         {
+            _notifyDataErrorInfoCellErrors.Remove(cell);
+
             if (!cell.IsValid || cell.ValidationSeverity != DataGridValidationSeverity.None)
             {
                 cell.IsValid = true;
@@ -135,7 +137,10 @@ internal
                     continue;
                 }
 
-                var severity = ValidationUtil.GetValidationSeverity(exceptions);
+                var preservedErrors = GetErrorsWithoutOwnedNotifyDataErrorInfoErrors(cell);
+                var severity = MaxSeverity(
+                    ValidationUtil.GetValidationSeverity(exceptions),
+                    GetDisplayedValidationSeverity(preservedErrors));
                 cell.IsValid = severity != DataGridValidationSeverity.Error;
                 cell.ValidationSeverity = severity;
                 cell.UpdatePseudoClasses();
@@ -143,18 +148,9 @@ internal
                 var errorException = exceptions.Count == 1
                     ? exceptions[0]
                     : new AggregateException(exceptions);
-                DataValidationErrors.SetError(cell, errorException);
-                IEnumerable<object> displayedErrors = DataValidationErrors.GetErrors(cell);
-                if (displayedErrors is not null)
-                {
-                    var trackedErrors = new List<object>();
-                    foreach (object displayedError in displayedErrors)
-                    {
-                        trackedErrors.Add(displayedError);
-                    }
-
-                    _notifyDataErrorInfoCellErrors[cell] = trackedErrors.ToArray();
-                }
+                preservedErrors.Add(errorException);
+                DataValidationErrors.SetErrors(cell, preservedErrors);
+                _notifyDataErrorInfoCellErrors[cell] = new object[] { errorException };
             }
 
             UpdateRowValidationStateFromCells(row);
@@ -168,27 +164,98 @@ internal
                 return;
             }
 
-            IEnumerable<object> currentErrors = DataValidationErrors.GetErrors(cell);
-            if (currentErrors is null)
+            List<object> preservedErrors = GetErrorsWithoutOwnedErrors(cell, expectedErrors);
+            if (preservedErrors.Count == 0)
             {
+                ClearCellValidation(cell);
                 return;
             }
 
-            int index = 0;
-            foreach (object currentError in currentErrors)
+            DataValidationErrors.SetErrors(cell, preservedErrors);
+            DataGridValidationSeverity severity = GetDisplayedValidationSeverity(preservedErrors);
+            cell.IsValid = severity != DataGridValidationSeverity.Error;
+            cell.ValidationSeverity = severity;
+            cell.UpdatePseudoClasses();
+        }
+
+        private List<object> GetErrorsWithoutOwnedNotifyDataErrorInfoErrors(DataGridCell cell)
+        {
+            return _notifyDataErrorInfoCellErrors.TryGetValue(cell, out object[] ownedErrors)
+                ? GetErrorsWithoutOwnedErrors(cell, ownedErrors)
+                : GetDisplayedErrors(cell);
+        }
+
+        private static List<object> GetErrorsWithoutOwnedErrors(DataGridCell cell, object[] ownedErrors)
+        {
+            List<object> errors = GetDisplayedErrors(cell);
+            foreach (object ownedError in ownedErrors)
             {
-                if (index >= expectedErrors.Length || !Equals(currentError, expectedErrors[index]))
+                for (int index = 0; index < errors.Count; index++)
                 {
-                    return;
+                    if (ReferenceEquals(errors[index], ownedError))
+                    {
+                        errors.RemoveAt(index);
+                        break;
+                    }
+                }
+            }
+
+            return errors;
+        }
+
+        private static List<object> GetDisplayedErrors(DataGridCell cell)
+        {
+            var errors = new List<object>();
+            IEnumerable<object> displayedErrors = DataValidationErrors.GetErrors(cell);
+            if (displayedErrors is null)
+            {
+                return errors;
+            }
+
+            foreach (object error in displayedErrors)
+            {
+                if (error is not null)
+                {
+                    errors.Add(error);
+                }
+            }
+
+            return errors;
+        }
+
+        private static DataGridValidationSeverity GetDisplayedValidationSeverity(List<object> errors)
+        {
+            DataGridValidationSeverity severity = DataGridValidationSeverity.None;
+            foreach (object error in errors)
+            {
+                severity = MaxSeverity(severity, GetDisplayedValidationSeverity(error));
+            }
+
+            return severity;
+        }
+
+        private static DataGridValidationSeverity GetDisplayedValidationSeverity(object error)
+        {
+            if (error is AggregateException aggregateException)
+            {
+                DataGridValidationSeverity severity = DataGridValidationSeverity.None;
+                foreach (Exception innerException in aggregateException.InnerExceptions)
+                {
+                    severity = MaxSeverity(severity, GetDisplayedValidationSeverity(innerException));
                 }
 
-                index++;
+                return severity;
             }
 
-            if (index == expectedErrors.Length)
-            {
-                ClearCellValidation(cell);
-            }
+            return ValidationUtil.GetValidationSeverity(
+                error as Exception ?? new DataValidationException(error));
+        }
+
+        private static DataGridValidationSeverity MaxSeverity(
+            DataGridValidationSeverity first,
+            DataGridValidationSeverity second)
+        {
+            return first >= second ? first : second;
         }
 
         private void ClearRowValidation(DataGridRow row)

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -647,6 +647,7 @@ internal
 
         private void DataGridCellCollection_CellRemoved(object sender, DataGridCellEventArgs e)
         {
+            OwningGrid?.OnCellRemovedForValidation(e.Cell);
             _cellsElement?.Children.Remove(e.Cell);
         }
 

--- a/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Data.Core;
 using Avalonia.PropertyStore;
 using Avalonia.Reactive;
 
@@ -26,12 +27,18 @@ internal
         bool CommitEdit();
     }
 
-    internal abstract class CellEditBindingBase : ICellEditBinding
+    internal interface ICellEditBindingValidationSource
+    {
+        bool HasSourceWriteError { get; }
+    }
+
+    internal abstract class CellEditBindingBase : ICellEditBinding, ICellEditBindingValidationSource
     {
         private readonly AvaloniaObject _target;
         private readonly AvaloniaProperty _property;
         private readonly string _bindingPath;
         private readonly bool _supportsDirectSourceWriteFallback;
+        private readonly bool _supportsSourceWriteResult;
         private readonly LightweightSubject<bool> _changedSubject = new();
         private readonly List<Exception> _validationErrors = new();
         private DataGridValidationSeverity _validationSeverity = DataGridValidationSeverity.None;
@@ -42,6 +49,8 @@ internal
             _target = target ?? throw new ArgumentNullException(nameof(target));
             _property = property ?? throw new ArgumentNullException(nameof(property));
             _supportsDirectSourceWriteFallback = BindingCloneHelper.SupportsDirectDataContextMemberWrite(binding);
+            _supportsSourceWriteResult = BindingCloneHelper.GetMode(binding) is
+                BindingMode.TwoWay or BindingMode.OneWayToSource;
             _bindingPath = _supportsDirectSourceWriteFallback && binding != null
                 ? BindingCloneHelper.GetPath(binding)
                 : null;
@@ -52,9 +61,11 @@ internal
         public bool IsValid => _validationSeverity != DataGridValidationSeverity.Error;
         public IEnumerable<Exception> ValidationErrors => _validationErrors;
         public IObservable<bool> ValidationChanged => _changedSubject;
+        public bool HasSourceWriteError { get; private set; }
 
         public bool CommitEdit()
         {
+            HasSourceWriteError = false;
             Exception commitError = null;
             var expression = BindingOperations.GetBindingExpressionBase(_target, _property);
             var preCommitValidationErrors = CaptureValidationErrors(expression);
@@ -66,11 +77,21 @@ internal
             {
                 try
                 {
-                    expression.UpdateSource();
+                    if (_supportsSourceWriteResult &&
+                        expression is UntypedBindingExpressionBase untypedExpression)
+                    {
+                        HasSourceWriteError = !untypedExpression.WriteValueToSource(
+                            _target.GetValue(_property));
+                    }
+                    else
+                    {
+                        expression.UpdateSource();
+                    }
                 }
                 catch (Exception ex)
                 {
                     commitError = ex;
+                    HasSourceWriteError = true;
                 }
             }
 
@@ -96,6 +117,7 @@ internal
                         usedToggleSwitchFallback = true;
                         if (writeError != null)
                         {
+                            HasSourceWriteError = true;
                             UpdateValidationErrorsFromException(writeError);
                         }
                         else

--- a/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/CellEditBinding.cs
@@ -24,15 +24,21 @@ internal
         bool IsValid { get; }
         IEnumerable<Exception> ValidationErrors { get; }
         IObservable<bool> ValidationChanged { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current validation errors were produced by a
+        /// failed write to the binding source.
+        /// </summary>
+        /// <remarks>
+        /// Custom edit bindings should return <see langword="true"/> while exposing source-write
+        /// errors so the grid does not conflate them with equivalent model validation errors.
+        /// </remarks>
+        bool HasSourceWriteError => false;
+
         bool CommitEdit();
     }
 
-    internal interface ICellEditBindingValidationSource
-    {
-        bool HasSourceWriteError { get; }
-    }
-
-    internal abstract class CellEditBindingBase : ICellEditBinding, ICellEditBindingValidationSource
+    internal abstract class CellEditBindingBase : ICellEditBinding
     {
         private readonly AvaloniaObject _target;
         private readonly AvaloniaProperty _property;


### PR DESCRIPTION
## Summary

Refresh realized DataGrid cell validation immediately when an item raises `INotifyDataErrorInfo.ErrorsChanged` after a programmatic property change.

Fixes #287.

## Problem

The collection-level `ErrorsChanged` handler recomputed grid validity but did not restore validation on realized cells. Visible severity, pseudo-classes, and `DataValidationErrors` could therefore remain stale until another grid interaction.

## Changes

- Refresh realized rows for the item that raised `ErrorsChanged`.
- Reuse the row-validation restoration path for consistent bound-column lookup, severity, pseudo-classes, and displayed errors.
- Refresh non-edited cells on the active editing row while leaving the editor-owned column untouched.
- Track INDEI-owned displayed errors separately from independent binding/setter errors.
- Expose source-write validation provenance to public custom `ICellEditBinding` implementations with a compatibility-preserving default.
- Derive edit acceptance and cell/row/grid severity from the final merged binding, preserved, and INDEI error set.
- Release per-cell ownership at the common cell-removal boundary used by dynamic column removal and cell rebuilds.
- Add Avalonia Headless and Release leak regressions for programmatic transitions, mixed validation sources, edit ownership, custom bindings, merged severity, and removed-cell collection.

## User impact

ViewModel and service-driven changes now surface or clear visible validation immediately. Clearing a model error no longer removes an independent warning on the same cell, even when it has the same message and severity, and this behavior also applies to custom edit bindings that declare source-write provenance. Edit validity consistently reflects the most severe displayed error. Dynamic column/cell rebuilds do not retain detached validated cells.

## Review hardening

Follow-up fixes:

- preserve unrelated and same-cell binding validation during INDEI refresh;
- refresh sibling cells on an editing row without disturbing the editor;
- transfer ownership when edit mode hides or replaces a cell error;
- claim INDEI warnings introduced by an edit;
- partition mixed edit aggregates by provenance;
- retain setter/binding errors that have the same message and severity as an INDEI error by using the binding engine source-write result;
- expose the provenance marker through the public edit-binding contract for third-party columns;
- cover default-mode bindings after DataGrid normalizes them to two-way editing;
- merge binding, preserved, and INDEI severities before deciding edit acceptance and visual validity;
- evict ownership when a cell leaves its row, preventing the grid dictionary from retaining removed cells.

## Validation

- `DataGridValidationTests`: **28 passed, 0 failed**.
- Full `Avalonia.Controls.DataGrid.UnitTests`: **2,261 passed, 0 failed**.
- Release leak suite: **35 passed, 0 failed**.
- `git diff --check`: clean.
- All review threads resolved.