### PR TITLE
Honor template content reuse during row recycling

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridTemplateColumnReuseTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridTemplateColumnReuseTests.cs
@@ -50,6 +50,53 @@ public class DataGridTemplateColumnReuseTests
         Assert.Equal(2, template.BuildCount);
     }
 
+    [AvaloniaFact]
+    public void Recycled_row_reuses_existing_content_when_enabled()
+    {
+        var template = new CountingTemplate();
+        var column = new TestTemplateColumn
+        {
+            CellTemplate = template,
+            ReuseCellContent = true
+        };
+        var grid = new DataGrid();
+        grid.ColumnsInternal.Add(column);
+
+        var row = new DataGridRow
+        {
+            OwningGrid = grid,
+            DataContext = new object(),
+            Index = 0,
+            Slot = 0
+        };
+        var cell = new DataGridCell
+        {
+            OwningColumn = column
+        };
+        var initialContent = column.GenerateElementPublic(cell, row.DataContext);
+        cell.Content = initialContent;
+        row.Cells.Insert(column.Index, cell);
+
+        var root = new Window
+        {
+            Content = grid
+        };
+        root.Show();
+
+        try
+        {
+            grid.DisplayData.RecycleRow(row);
+            row.DataContext = new object();
+
+            Assert.Same(initialContent, cell.Content);
+            Assert.Equal(1, template.BuildCount);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
     private sealed class TestTemplateColumn : DataGridTemplateColumn
     {
         public Control GenerateElementPublic(DataGridCell cell, object dataItem)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridTemplateColumnReuseTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridTemplateColumnReuseTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wieslaw Soltes. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Headless.XUnit;
@@ -95,6 +96,39 @@ public class DataGridTemplateColumnReuseTests
         {
             root.Close();
         }
+    }
+
+    [AvaloniaFact]
+    public void Recycled_placeholder_content_is_replaced_when_row_becomes_data_row()
+    {
+        var displayTemplate = new CountingTemplate();
+        var newRowTemplate = new CountingTemplate();
+        var column = new TestTemplateColumn
+        {
+            CellTemplate = displayTemplate,
+            NewRowCellTemplate = newRowTemplate,
+            ReuseCellContent = true
+        };
+        var row = new DataGridRow
+        {
+            DataContext = new object(),
+            IsPlaceholder = false,
+            RecycledIsPlaceholder = true
+        };
+        var cell = new DataGridCell
+        {
+            OwningColumn = column,
+            OwningRow = row,
+            DataContext = row.DataContext
+        };
+        var placeholderContent = column.GenerateElementPublic(cell, DataGridCollectionView.NewItemPlaceholder);
+        cell.Content = placeholderContent;
+
+        column.RefreshCellContentForDataContextChange(cell);
+
+        Assert.NotSame(placeholderContent, cell.Content);
+        Assert.Equal(1, newRowTemplate.BuildCount);
+        Assert.Equal(1, displayTemplate.BuildCount);
     }
 
     private sealed class TestTemplateColumn : DataGridTemplateColumn

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -721,7 +721,7 @@ internal
                         {
                             if (column.Index >= 0 && column.Index < Cells.Count)
                             {
-                                column.RefreshCellContent((Control)Cells[column.Index].Content, nameof(DataGridTemplateColumn.CellTemplate));
+                                column.RefreshCellContentForDataContextChange(Cells[column.Index]);
                             }
                         }
                     }

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -112,26 +112,30 @@ internal
 
         protected override void EndCellEdit()
         {
-            //the next call to generate element should not resuse the current content as we need to exit edit mode
+            // The next regular generation must replace the editing control with display content.
             _forceGenerateCellFromTemplate = true;
             base.EndCellEdit();
         }
 
         protected override Control GenerateElement(DataGridCell cell, object dataItem)
         {
-            Control recycledContent = _forceGenerateCellFromTemplate ? null : cell.Content as Control;
+            var forceNewContent = _forceGenerateCellFromTemplate;
+            _forceGenerateCellFromTemplate = false;
+            return GenerateElementCore(cell, dataItem, forceNewContent);
+        }
+
+        private Control GenerateElementCore(DataGridCell cell, object dataItem, bool forceNewContent)
+        {
+            Control recycledContent = forceNewContent ? null : cell.Content as Control;
 
             // A recycled row can briefly clear its DataContext while being re-templated; avoid invoking user templates with null.
             if (dataItem is null)
             {
-                _forceGenerateCellFromTemplate = false;
                 return recycledContent ?? new Control();
             }
 
             if (dataItem == DataGridCollectionView.NewItemPlaceholder)
             {
-                _forceGenerateCellFromTemplate = false;
-
                 if (NewRowCellTemplate != null)
                 {
                     if (NewRowCellTemplate is IRecyclingDataTemplate recyclingNewRowTemplate)
@@ -147,12 +151,6 @@ internal
 
             if (CellTemplate != null)
             {
-                if (_forceGenerateCellFromTemplate)
-                {
-                    _forceGenerateCellFromTemplate = false;
-                    return CellTemplate.Build(dataItem);
-                }
-
                 if (ReuseCellContent &&
                     recycledContent != null &&
                     CellTemplate is not IRecyclingDataTemplate)
@@ -204,11 +202,20 @@ internal
             var cell = element?.Parent as DataGridCell;
             if(cell is not null && (propertyName == nameof(CellTemplate) || propertyName == nameof(NewRowCellTemplate)))
             {
-                _forceGenerateCellFromTemplate = true;
-                cell.Content = GenerateElement(cell, cell.DataContext);
+                cell.Content = GenerateElementCore(cell, cell.DataContext, forceNewContent: true);
             }
 
             base.RefreshCellContent(element, propertyName);
+        }
+
+        internal void RefreshCellContentForDataContextChange(DataGridCell cell)
+        {
+            if (cell is null)
+            {
+                return;
+            }
+
+            cell.Content = GenerateElementCore(cell, cell.DataContext, forceNewContent: false);
         }
         
         public override bool IsReadOnly

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -215,7 +215,9 @@ internal
                 return;
             }
 
-            cell.Content = GenerateElementCore(cell, cell.DataContext, forceNewContent: false);
+            DataGridRow row = cell.OwningRow;
+            bool placeholderStateChanged = row != null && row.RecycledIsPlaceholder != row.IsPlaceholder;
+            cell.Content = GenerateElementCore(cell, cell.DataContext, placeholderStateChanged);
         }
         
         public override bool IsReadOnly


### PR DESCRIPTION
## Summary

Honor `DataGridTemplateColumn.ReuseCellContent` when a recycled row is assigned to another ordinary data item, while retaining forced regeneration for template changes and edit-mode transitions.

Fixes #290.

## Root cause

`DataGridRow.OnPropertyChanged` refreshed template cells after a recycled row received a new `DataContext` by calling `RefreshCellContent` with `nameof(DataGridTemplateColumn.CellTemplate)`.

That refresh reason is also used for a real template-property change. `DataGridTemplateColumn` therefore set `_forceGenerateCellFromTemplate`, discarded the existing control, and rebuilt the template. In practice, every real-to-real row recycle bypassed `ReuseCellContent`, so the optimization worked in direct `GenerateElement` tests but not through the actual row lifecycle.

## Changes

- Separate data-context refresh from template-property refresh.
- Add an internal data-context refresh path that allows the existing cell content to participate in normal reuse/recycling decisions.
- Keep explicit template changes on a forced-build path so replacing `CellTemplate` or `NewRowCellTemplate` cannot retain visuals from the old template.
- Restrict the one-shot force flag to its original edit-mode responsibility: replacing an editing control with display content when a cell exits edit mode.
- Preserve the existing placeholder-transition handling, which clears incompatible visuals before moving between a real item and the new-item placeholder.
- Add an Avalonia Headless lifecycle regression test that recycles a row between two ordinary items and verifies both control identity and template build count.

## User and performance impact

Applications opting into `ReuseCellContent` now receive the intended behavior during virtualization: ordinary row recycling retains the existing control and lets inherited `DataContext` update it. This avoids repeated template construction in scroll/update paths without changing the default behavior when reuse is disabled.

## Validation

- Template reuse, editing, and container lifecycle suites: 24 passed, 0 failed.
- Full `Avalonia.Controls.DataGrid.UnitTests` project: 2,251 passed, 0 failed.
- `git diff --check`: clean.
