### PR TITLE
Improve keyboard navigation and continuous edit mode

### DIFF
--- a/docfx/articles/keyboard-shortcuts.md
+++ b/docfx/articles/keyboard-shortcuts.md
@@ -13,7 +13,7 @@
 | MovePageDown | `PageDown` | Moves down by a viewport page. `Shift` extends selection in `SelectionMode=Extended`. |
 | MoveHome | `Home` | Moves to the first column. `Ctrl+Home` jumps to the first row. |
 | MoveEnd | `End` | Moves to the last column. `Ctrl+End` jumps to the last row. |
-| Enter | `Enter` | Commits edits and moves down one row. `Ctrl+Enter` commits without moving. |
+| Enter | `Enter` | Commits edits and moves according to `EnterKeyNavigationMode`. `Ctrl+Enter` commits without moving. |
 | CancelEdit | `Escape` | Cancels cell/row editing. |
 | BeginEdit | `F2` | Begins editing the current cell (default also honors `Alt+F2`). |
 | SelectAll | `Ctrl/Cmd+A` | Selects all rows/cells when `SelectionMode=Extended`. |
@@ -38,3 +38,27 @@ KeyboardGestureOverrides = new DataGridKeyboardGestures
     ExpandAll = new KeyGesture(Key.E)
 };
 ```
+
+## Continuous Editing
+
+`Tab` and `Shift+Tab` always commit the active cell and open the editor in the next or previous writable cell. When `CanUserAddRows="True"` and the collection view supports `AddNew`, pressing `Tab` in the last writable cell commits the row, creates a new item, and opens its first writable cell.
+
+Use the Enter navigation properties when a data-entry workflow should also keep editing after Enter:
+
+```xml
+<DataGrid ItemsSource="{Binding Items}"
+          CanUserAddRows="True"
+          EnterKeyNavigationMode="NextCell"
+          ContinueEditingOnEnter="True" />
+```
+
+`EnterKeyNavigationMode="Down"` keeps the current column and moves to the row below. `NextCell` follows the same writable-cell order as Tab and wraps to the next row. `ContinueEditingOnEnter` defaults to `False`, preserving the standard commit-and-navigate behavior.
+
+Built-in compound editors are configured as a single tab stop:
+
+- `DataGridNumericColumn` selects its text when editing begins, and Tab leaves the spinner as one editor instead of visiting its internal buttons.
+- `DataGridComboBoxColumn` supports direct text entry with `IsEditable="True"`; Tab commits the current selection or text and advances the grid.
+- `DataGridAutoCompleteColumn` is the filtering editor for suggestion lists. Configure `FilterMode`, `MinimumPrefixLength`, and `IsTextCompletionEnabled`, then use Tab to commit the completed text and advance.
+- `DataGridDatePickerColumn` focuses its editable text input, so dates can be typed directly without opening the calendar.
+
+If row creation is unavailable for the source, Tab from the last cell leaves the grid normally after the current edit is committed.

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridAutoCompleteColumnHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridAutoCompleteColumnHeadlessTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
@@ -148,6 +149,16 @@ public class DataGridAutoCompleteColumnHeadlessTests
         };
 
         Assert.Equal("Search...", column.Watermark);
+    }
+
+    [AvaloniaFact]
+    public void AutoCompleteColumn_Editor_Uses_One_Tab_Stop()
+    {
+        var column = new TestAutoCompleteColumn();
+
+        var autoComplete = column.CreateEditingElement(new DataGridCell(), new object());
+
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(autoComplete));
     }
 
     private static (Window window, DataGrid grid) CreateWindow(AutoCompleteTestViewModel vm)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnEditingHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnEditingHeadlessTests.cs
@@ -333,6 +333,48 @@ public class DataGridColumnEditingHeadlessTests
     }
 
     [AvaloniaFact]
+    public void NumericColumn_Handled_Tab_From_Text_Input_Does_Not_Advance_Continuous_Edit()
+    {
+        var vm = new EditingTestViewModel();
+        var (window, grid) = CreateWindowWithMultipleColumns(vm,
+        [
+            new DataGridTextColumn
+            {
+                Header = "Name",
+                Binding = new Binding("Name"),
+                IsReadOnly = true
+            },
+            CreateNumericColumn(),
+            CreateTextColumn()
+        ]);
+
+        window.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        SelectCellAndBeginEdit(grid, 0, 1);
+        var numericCell = GetCell(grid, "Price", 0);
+        var numericUpDown = Assert.IsType<NumericUpDown>(numericCell.Content);
+        var textBox = Assert.Single(numericUpDown.GetVisualDescendants().OfType<TextBox>());
+        textBox.KeyDown += (_, eventArgs) => eventArgs.Handled = true;
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.Tab,
+            Source = textBox,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        textBox.RaiseEvent(args);
+        grid.UpdateLayout();
+
+        Assert.True(args.Handled);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+        Assert.Equal(1, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
     public void NumericColumn_CommitEdit_Updates_Value()
     {
         var vm = new EditingTestViewModel();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnEditingHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnEditingHeadlessTests.cs
@@ -181,6 +181,28 @@ public class DataGridColumnEditingHeadlessTests
     }
 
     [AvaloniaFact]
+    public void Editable_ComboBoxColumn_Focuses_Text_Input_And_Uses_One_Tab_Stop()
+    {
+        var vm = new EditingTestViewModel();
+        var column = (DataGridComboBoxColumn)CreateComboBoxColumn();
+        column.IsEditable = true;
+        var (window, grid) = CreateWindow(vm, column);
+
+        window.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        SelectCellAndBeginEdit(grid, 0, 1);
+
+        var cell = GetCell(grid, "Choice", 0);
+        var comboBox = Assert.IsType<ComboBox>(cell.Content);
+        var textBox = Assert.Single(comboBox.GetVisualDescendants().OfType<TextBox>());
+
+        Assert.True(textBox.IsFocused || comboBox.IsFocused);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(comboBox));
+    }
+
+    [AvaloniaFact]
     public void ComboBoxColumn_Edit_Does_Not_Update_Source_Until_Commit()
     {
         var vm = new EditingTestViewModel();
@@ -246,6 +268,68 @@ public class DataGridColumnEditingHeadlessTests
 
         var cell = GetCell(grid, "Price", 0);
         Assert.IsType<NumericUpDown>(cell.Content);
+    }
+
+    [AvaloniaFact]
+    public void NumericColumn_Selects_Text_And_Uses_One_Tab_Stop()
+    {
+        var vm = new EditingTestViewModel();
+        var (window, grid) = CreateWindow(vm, CreateNumericColumn());
+
+        window.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        SelectCellAndBeginEdit(grid, 0, 1);
+
+        var cell = GetCell(grid, "Price", 0);
+        var numericUpDown = Assert.IsType<NumericUpDown>(cell.Content);
+        var textBox = Assert.Single(numericUpDown.GetVisualDescendants().OfType<TextBox>());
+
+        Assert.Equal(0, textBox.SelectionStart);
+        Assert.Equal(textBox.Text?.Length ?? 0, textBox.SelectionEnd);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(numericUpDown));
+    }
+
+    [AvaloniaFact]
+    public void NumericColumn_Tab_From_Text_Input_Advances_Continuous_Edit()
+    {
+        var vm = new EditingTestViewModel();
+        var (window, grid) = CreateWindowWithMultipleColumns(vm,
+        [
+            new DataGridTextColumn
+            {
+                Header = "Name",
+                Binding = new Binding("Name"),
+                IsReadOnly = true
+            },
+            CreateNumericColumn(),
+            CreateTextColumn()
+        ]);
+
+        window.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        SelectCellAndBeginEdit(grid, 0, 1);
+        var numericCell = GetCell(grid, "Price", 0);
+        var numericUpDown = Assert.IsType<NumericUpDown>(numericCell.Content);
+        var textBox = Assert.Single(numericUpDown.GetVisualDescendants().OfType<TextBox>());
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.Tab,
+            Source = textBox,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+
+        textBox.RaiseEvent(args);
+        grid.UpdateLayout();
+
+        Assert.True(args.Handled);
+        Assert.Equal(2, grid.CurrentColumnIndex);
+        Assert.Equal(2, grid.EditingColumnIndex);
     }
 
     [AvaloniaFact]
@@ -349,6 +433,26 @@ public class DataGridColumnEditingHeadlessTests
 
         var cell = GetCell(grid, "Date", 0);
         Assert.IsType<CalendarDatePicker>(cell.Content);
+    }
+
+    [AvaloniaFact]
+    public void DatePickerColumn_Focuses_Text_Input_And_Uses_One_Tab_Stop()
+    {
+        var vm = new EditingTestViewModel();
+        var (window, grid) = CreateWindow(vm, CreateDatePickerColumn());
+
+        window.Show();
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        SelectCellAndBeginEdit(grid, 0, 1);
+
+        var cell = GetCell(grid, "Date", 0);
+        var datePicker = Assert.IsType<CalendarDatePicker>(cell.Content);
+        var textBox = Assert.Single(datePicker.GetVisualDescendants().OfType<TextBox>());
+
+        Assert.False(textBox.IsReadOnly);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(datePicker));
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridComboBoxColumnThemeTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridComboBoxColumnThemeTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Styling;
 using Xunit;
@@ -90,6 +91,7 @@ public class DataGridComboBoxColumnThemeTests
         Assert.Equal(VerticalAlignment.Bottom, displayElement.VerticalContentAlignment);
         Assert.Equal(HorizontalAlignment.Center, editingElement.HorizontalContentAlignment);
         Assert.Equal(VerticalAlignment.Bottom, editingElement.VerticalContentAlignment);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(editingElement));
     }
 
     private class DerivedComboBoxColumn : DataGridComboBoxColumn

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDatePickerColumnHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDatePickerColumnHeadlessTests.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
@@ -100,6 +101,7 @@ public class DataGridDatePickerColumnHeadlessTests
         Assert.Equal(VerticalAlignment.Bottom, displayElement.VerticalAlignment);
         Assert.Equal(HorizontalAlignment.Right, editingElement.HorizontalContentAlignment);
         Assert.Equal(VerticalAlignment.Bottom, editingElement.VerticalContentAlignment);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(editingElement));
     }
 
     private static (Window window, DataGrid grid) CreateWindow(DatePickerTestViewModel vm)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridNumericColumnHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridNumericColumnHeadlessTests.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
@@ -99,6 +100,7 @@ public class DataGridNumericColumnHeadlessTests
 
         Assert.Equal(VerticalAlignment.Bottom, displayElement.VerticalAlignment);
         Assert.Equal(VerticalAlignment.Bottom, editingElement.VerticalContentAlignment);
+        Assert.Equal(KeyboardNavigationMode.None, KeyboardNavigation.GetTabNavigation(editingElement));
     }
 
     private static (Window window, DataGrid grid) CreateWindow(NumericTestViewModel vm, string? formatString = null)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
@@ -19,6 +19,15 @@ namespace Avalonia.Controls.DataGridTests.Input;
 public class DataGridInputNavigationTests
 {
     [AvaloniaFact]
+    public void Enter_Navigation_Defaults_Preserve_Existing_Behavior()
+    {
+        var grid = new DataGrid();
+
+        Assert.Equal(DataGridEnterKeyNavigationMode.Down, grid.EnterKeyNavigationMode);
+        Assert.False(grid.ContinueEditingOnEnter);
+    }
+
+    [AvaloniaFact]
     public void ProcessDataGridKey_Handles_All_Key_Cases()
     {
         var (grid, _) = CreateGrid();
@@ -136,6 +145,44 @@ public class DataGridInputNavigationTests
         Assert.True(handled);
         Assert.Equal(1, grid.CurrentColumnIndex);
         Assert.Equal(grid.SlotFromRowIndex(0), grid.CurrentSlot);
+    }
+
+    [AvaloniaFact]
+    public void Tab_Commits_And_Opens_Editor_In_Next_Cell()
+    {
+        var (grid, _) = CreateGrid(selectionMode: DataGridSelectionMode.Single);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        Assert.True(grid.BeginEdit());
+
+        var handled = InvokeKeyHandler(grid, "ProcessTabKey", Key.Tab, KeyModifiers.None);
+
+        Assert.True(handled);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+        Assert.Equal(1, grid.EditingColumnIndex);
+        Assert.NotNull(grid.EditingRow);
+    }
+
+    [AvaloniaFact]
+    public void Tab_From_Last_Cell_Appends_Row_And_Opens_First_Editor()
+    {
+        var (grid, items) = CreateGrid(rowCount: 2, columnCount: 2);
+        grid.CanUserAddRows = true;
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var originalCount = items.Count;
+        SetCurrentCell(grid, rowIndex: originalCount - 1, columnIndex: 1);
+        Assert.True(grid.BeginEdit());
+
+        var handled = InvokeKeyHandler(grid, "ProcessTabKey", Key.Tab, KeyModifiers.None);
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(handled);
+        Assert.Equal(originalCount + 1, items.Count);
+        Assert.Equal(0, grid.CurrentColumnIndex);
+        Assert.Equal(0, grid.EditingColumnIndex);
+        Assert.Same(items[^1], grid.EditingRow?.DataContext);
     }
 
     [AvaloniaFact]
@@ -747,6 +794,54 @@ public class DataGridInputNavigationTests
     }
 
     [AvaloniaFact]
+    public void Enter_ContinueEditing_Moves_Down_And_Opens_Editor()
+    {
+        var (grid, _) = CreateGrid(rowCount: 3);
+        grid.ContinueEditingOnEnter = true;
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 1);
+        Assert.True(grid.BeginEdit());
+
+        var handled = InvokeKeyHandler(grid, "ProcessEnterKey", Key.Enter, KeyModifiers.None);
+
+        Assert.True(handled);
+        Assert.Equal(grid.SlotFromRowIndex(1), grid.CurrentSlot);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+        Assert.Equal(1, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void Enter_NextCell_ContinueEditing_Opens_Adjacent_Editor()
+    {
+        var (grid, _) = CreateGrid(rowCount: 3);
+        grid.EnterKeyNavigationMode = DataGridEnterKeyNavigationMode.NextCell;
+        grid.ContinueEditingOnEnter = true;
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        Assert.True(grid.BeginEdit());
+
+        var handled = InvokeKeyHandler(grid, "ProcessEnterKey", Key.Enter, KeyModifiers.None);
+
+        Assert.True(handled);
+        Assert.Equal(grid.SlotFromRowIndex(0), grid.CurrentSlot);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+        Assert.Equal(1, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
+    public void Enter_NextCell_Without_Continuation_Exits_Edit_Mode()
+    {
+        var (grid, _) = CreateGrid(rowCount: 3);
+        grid.EnterKeyNavigationMode = DataGridEnterKeyNavigationMode.NextCell;
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+        Assert.True(grid.BeginEdit());
+
+        var handled = InvokeKeyHandler(grid, "ProcessEnterKey", Key.Enter, KeyModifiers.None);
+
+        Assert.True(handled);
+        Assert.Equal(1, grid.CurrentColumnIndex);
+        Assert.Equal(-1, grid.EditingColumnIndex);
+    }
+
+    [AvaloniaFact]
     public void Enter_Returns_False_When_ProcessDownKeyInternal_Fails()
     {
         var (grid, _) = CreateGrid();
@@ -1323,6 +1418,10 @@ public class DataGridInputNavigationTests
 
     private sealed class InputRow : IEditableObject
     {
+        public InputRow()
+        {
+        }
+
         public int A { get; set; }
         public int B { get; set; }
         public int C { get; set; }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -110,7 +110,14 @@ internal
             }
             var rowIndex = RowIndexFromSlot(slot);
             var dataItem = DataConnection.GetDataItem(rowIndex);
-            return ReferenceEquals(dataItem, DataGridCollectionView.NewItemPlaceholder);
+            if (ReferenceEquals(dataItem, DataGridCollectionView.NewItemPlaceholder))
+            {
+                return true;
+            }
+
+            return slot >= DisplayData.FirstScrollingSlot &&
+                   slot <= DisplayData.LastScrollingSlot &&
+                   DisplayData.GetDisplayedElement(slot) is DataGridRow { IsPlaceholder: true };
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.Keyboard.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.Keyboard.cs
@@ -170,7 +170,7 @@ namespace Avalonia.Controls
         internal bool ProcessEnterKey(KeyEventArgs e)
         {
             KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
-            return ProcessEnterKey(shift, ctrl);
+            return ProcessEnterKey(e, shift, ctrl);
         }
 
         private bool ProcessEscapeKey()

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -107,6 +107,10 @@ internal
             else if (MatchesGesture(ResolveGesture(overrides?.Enter, defaults.Enter), e, allowAdditionalModifiers: true))
             {
                 focusDataGrid = ProcessEnterKey(e);
+                if (focusDataGrid && _editingColumnIndex != -1)
+                {
+                    return true;
+                }
             }
             else if (MatchesGesture(ResolveGesture(overrides?.CancelEdit, defaults.CancelEdit), e, allowAdditionalModifiers: true))
             {
@@ -232,6 +236,11 @@ internal
 
         private bool ProcessTabKey(KeyEventArgs e, bool shift, bool ctrl, bool allowCtrl)
         {
+            return ProcessTabKey(e, shift, ctrl, allowCtrl, continueEditing: true);
+        }
+
+        private bool ProcessTabKey(KeyEventArgs e, bool shift, bool ctrl, bool allowCtrl, bool continueEditing)
+        {
             if ((!allowCtrl && ctrl) || _editingColumnIndex == -1 || IsReadOnly)
             {
                 //Go to the next/previous control on the page when
@@ -272,15 +281,42 @@ internal
             }
             neighborVisibleWritableColumnIndex = (dataGridColumn == null) ? -1 : dataGridColumn.Index;
 
-            if (neighborVisibleWritableColumnIndex == -1 && (neighborSlot == -1 || neighborSlot >= SlotCount))
+            bool shouldTryAppendRow =
+                !shift &&
+                neighborVisibleWritableColumnIndex == -1 &&
+                (neighborSlot == -1 || neighborSlot >= SlotCount || IsSlotPlaceholderRow(neighborSlot)) &&
+                CanUserAddRows;
+
+            if (!shouldTryAppendRow &&
+                neighborVisibleWritableColumnIndex == -1 &&
+                (neighborSlot == -1 || neighborSlot >= SlotCount))
             {
                 // There is no previous/next row and no previous/next writable cell on the current row
                 return false;
             }
 
-            if (WaitForLostFocus(() => ProcessTabKey(e, shift, ctrl, allowCtrl)))
+            if (WaitForLostFocus(() => ProcessTabKey(e, shift, ctrl, allowCtrl, continueEditing)))
             {
                 return true;
+            }
+
+            if (shouldTryAppendRow)
+            {
+                if (!CommitEdit(DataGridEditingUnit.Row, exitEditingMode: true))
+                {
+                    return true;
+                }
+
+                neighborSlot = GetNextVisibleSlot(CurrentSlot);
+                while (neighborSlot < SlotCount && IsGroupSlot(neighborSlot))
+                {
+                    neighborSlot = GetNextVisibleSlot(neighborSlot);
+                }
+
+                if (neighborSlot < 0 || neighborSlot >= SlotCount)
+                {
+                    return false;
+                }
             }
 
             int targetSlot = -1, targetColumnIndex = -1;
@@ -329,7 +365,7 @@ internal
                 NoSelectionChangeCount--;
             }
 
-            if (_successfullyUpdatedSelection)
+            if (_successfullyUpdatedSelection && continueEditing)
             {
                 BeginCellEdit(e);
             }
@@ -730,7 +766,13 @@ internal
 
         private bool ProcessEnterKey(bool shift, bool ctrl)
         {
+            return ProcessEnterKey(null, shift, ctrl);
+        }
+
+        private bool ProcessEnterKey(KeyEventArgs e, bool shift, bool ctrl)
+        {
             int oldCurrentSlot = CurrentSlot;
+            bool wasEditing = _editingColumnIndex != -1;
 
             if (!ctrl)
             {
@@ -742,7 +784,17 @@ internal
                     return false;
                 }
 
-                if (WaitForLostFocus(() => ProcessEnterKey(shift, ctrl)))
+                if (wasEditing && EnterKeyNavigationMode == DataGridEnterKeyNavigationMode.NextCell)
+                {
+                    return ProcessTabKey(
+                        e,
+                        shift,
+                        ctrl,
+                        allowCtrl: false,
+                        continueEditing: ContinueEditingOnEnter);
+                }
+
+                if (WaitForLostFocus(() => ProcessEnterKey(e, shift, ctrl)))
                 {
                     return true;
                 }
@@ -756,9 +808,17 @@ internal
                     }
                 }
             }
-            else if (WaitForLostFocus(() => ProcessEnterKey(shift, ctrl)))
+            else if (WaitForLostFocus(() => ProcessEnterKey(e, shift, ctrl)))
             {
                 return true;
+            }
+
+            if (wasEditing &&
+                ContinueEditingOnEnter &&
+                oldCurrentSlot != CurrentSlot &&
+                _successfullyUpdatedSelection)
+            {
+                BeginCellEdit(e);
             }
 
             // Try to commit the potential editing
@@ -923,6 +983,11 @@ internal
         {
             if (e.Handled)
             {
+                if (e is KeyEventArgs handledKeyEventArgs)
+                {
+                    ProcessHandledEditingTabKey(handledKeyEventArgs);
+                }
+
                 return;
             }
 
@@ -945,6 +1010,30 @@ internal
             }
 
             DataGrid_KeyDown(this, keyEventArgs);
+        }
+
+        private void ProcessHandledEditingTabKey(KeyEventArgs e)
+        {
+            if (_editingColumnIndex == -1 || !IsKeyEventFromThisGrid(e) || e.Source is not Visual source)
+            {
+                return;
+            }
+
+            var cell = source.GetSelfAndVisualAncestors().OfType<DataGridCell>().FirstOrDefault();
+            if (cell?.OwningGrid != this ||
+                cell.OwningRow != EditingRow ||
+                cell.ColumnIndex != _editingColumnIndex ||
+                cell.Content is not InputElement editor ||
+                KeyboardNavigation.GetTabNavigation(editor) != KeyboardNavigationMode.None)
+            {
+                return;
+            }
+
+            var tabGesture = ResolveGesture(KeyboardGestureOverrides?.Tab, GetDefaultKeyboardGestures().Tab);
+            if (MatchesGesture(tabGesture, e, allowAdditionalModifiers: true))
+            {
+                ProcessTabKey(e, allowCtrl: AllowsCtrlModifier(tabGesture));
+            }
         }
 
         private void OnKeyUpRouteFinished(RoutedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -1014,7 +1014,13 @@ internal
 
         private void ProcessHandledEditingTabKey(KeyEventArgs e)
         {
-            if (_editingColumnIndex == -1 || !IsKeyEventFromThisGrid(e) || e.Source is not Visual source)
+            // Avalonia's top-level keyboard navigation moves focus to the grid when a compound
+            // editor is configured as a single tab stop. A user handler that vetoes Tab by setting
+            // Handled leaves focus on the editor subtree, so it must not trigger this fallback.
+            if (_editingColumnIndex == -1 ||
+                !IsFocused ||
+                !IsKeyEventFromThisGrid(e) ||
+                e.Source is not Visual source)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -698,6 +698,39 @@ internal
         }
 
         /// <summary>
+        /// Identifies the <see cref="EnterKeyNavigationMode"/> property.
+        /// </summary>
+        public static readonly StyledProperty<DataGridEnterKeyNavigationMode> EnterKeyNavigationModeProperty =
+            AvaloniaProperty.Register<DataGrid, DataGridEnterKeyNavigationMode>(
+                nameof(EnterKeyNavigationMode),
+                defaultValue: DataGridEnterKeyNavigationMode.Down);
+
+        /// <summary>
+        /// Gets or sets how ENTER moves the current cell while a cell is being edited.
+        /// </summary>
+        public DataGridEnterKeyNavigationMode EnterKeyNavigationMode
+        {
+            get { return GetValue(EnterKeyNavigationModeProperty); }
+            set { SetValue(EnterKeyNavigationModeProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="ContinueEditingOnEnter"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> ContinueEditingOnEnterProperty =
+            AvaloniaProperty.Register<DataGrid, bool>(nameof(ContinueEditingOnEnter));
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether ENTER opens the editor in the destination cell
+        /// after committing the current cell.
+        /// </summary>
+        public bool ContinueEditingOnEnter
+        {
+            get { return GetValue(ContinueEditingOnEnterProperty); }
+            set { SetValue(ContinueEditingOnEnterProperty, value); }
+        }
+
+        /// <summary>
         /// Identifies the <see cref="RestrictTextInputEditToCells"/> dependency property.
         /// </summary>
         public static readonly StyledProperty<bool> RestrictTextInputEditToCellsProperty =

--- a/src/Avalonia.Controls.DataGrid/DataGridAutoCompleteColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridAutoCompleteColumn.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using Avalonia.Collections;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.DataGridEditing;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -245,6 +246,8 @@ internal
                 VerticalAlignment = VerticalAlignment.Center
             };
 
+            DataGridEditorFocus.ConfigureSingleTabStop(autoComplete);
+
             if (CellAutoCompleteTheme is { } theme)
             {
                 autoComplete.Theme = theme;
@@ -264,8 +267,7 @@ internal
             {
                 string uneditedText = autoComplete.Text ?? string.Empty;
 
-                // Select all text for easy replacement
-                autoComplete.Focus();
+                DataGridEditorFocus.FocusTextInput(autoComplete, selectAll: true);
 
                 return uneditedText;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.DataGridEditing;
 using Avalonia.Controls.Templates;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
@@ -366,6 +367,15 @@ internal
                     comboBox.IsDropDownOpen = true;
                 }
 
+                if (comboBox.IsEditable)
+                {
+                    DataGridEditorFocus.FocusTextInput(comboBox, selectAll: true);
+                }
+                else
+                {
+                    comboBox.Focus();
+                }
+
                 return originalValue;
             }
 
@@ -498,6 +508,10 @@ internal
             if (!isEditing)
             {
                 comboBox.IsTabStop = false;
+            }
+            else
+            {
+                DataGridEditorFocus.ConfigureSingleTabStop(comboBox);
             }
 
             return comboBox;

--- a/src/Avalonia.Controls.DataGrid/DataGridDatePickerColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDatePickerColumn.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Avalonia.Collections;
+using Avalonia.Controls.DataGridEditing;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -279,6 +280,8 @@ internal
                 VerticalAlignment = VerticalAlignment.Center
             };
 
+            DataGridEditorFocus.ConfigureSingleTabStop(datePicker);
+
             if (CellDatePickerTheme is { } theme)
             {
                 datePicker.Theme = theme;
@@ -298,8 +301,7 @@ internal
             {
                 var uneditedValue = datePicker.SelectedDate;
                 
-                // Focus the date picker
-                datePicker.Focus();
+                DataGridEditorFocus.FocusTextInput(datePicker, selectAll: false);
 
                 return uneditedValue;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridEnumerations.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridEnumerations.cs
@@ -84,6 +84,27 @@ internal
     }
 
     /// <summary>
+    /// Specifies how the ENTER key moves the current cell while a cell is being edited.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+    enum DataGridEnterKeyNavigationMode
+    {
+        /// <summary>
+        /// Move to the cell below in the current column.
+        /// </summary>
+        Down = 0,
+
+        /// <summary>
+        /// Move to the next writable cell, wrapping to the first writable cell in the next row.
+        /// </summary>
+        NextCell = 1
+    }
+
+    /// <summary>
     /// Determines whether the row/column headers are shown or not.
     /// </summary>
     [Flags]

--- a/src/Avalonia.Controls.DataGrid/DataGridNumericColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridNumericColumn.cs
@@ -7,13 +7,13 @@ using System;
 using System.Globalization;
 using Avalonia.Collections;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.DataGridEditing;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -330,6 +330,8 @@ internal
                 Name = "CellNumericUpDown"
             };
 
+            DataGridEditorFocus.ConfigureSingleTabStop(numericUpDown);
+
             if (CellNumericUpDownTheme is { } theme)
             {
                 numericUpDown.Theme = theme;
@@ -349,13 +351,7 @@ internal
             {
                 var uneditedValue = numericUpDown.Value;
 
-                // Select all text when editing starts
-                var textBox = numericUpDown.FindDescendantOfType<TextBox>();
-                if (textBox != null)
-                {
-                    textBox.SelectAll();
-                    textBox.Focus();
-                }
+                DataGridEditorFocus.FocusTextInput(numericUpDown, selectAll: true);
 
                 return uneditedValue;
             }

--- a/src/Avalonia.Controls.DataGrid/Editing/DataGridEditorFocus.cs
+++ b/src/Avalonia.Controls.DataGrid/Editing/DataGridEditorFocus.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Controls.DataGridEditing
+{
+    internal static class DataGridEditorFocus
+    {
+        public static void ConfigureSingleTabStop(Control editor)
+        {
+            KeyboardNavigation.SetTabNavigation(editor, KeyboardNavigationMode.None);
+        }
+
+        public static bool FocusTextInput(Control editor, bool selectAll)
+        {
+            if (TryFocusTextInput(editor, selectAll))
+            {
+                return true;
+            }
+
+            Dispatcher.UIThread.Post(
+                () =>
+                {
+                    if (editor.IsAttachedToVisualTree)
+                    {
+                        TryFocusTextInput(editor, selectAll);
+                    }
+                },
+                DispatcherPriority.Loaded);
+
+            return false;
+        }
+
+        private static bool TryFocusTextInput(Control editor, bool selectAll)
+        {
+            editor.ApplyTemplate();
+
+            var textBox = editor as TextBox ?? editor.FindDescendantOfType<TextBox>();
+            if (textBox == null)
+            {
+                return editor.Focus();
+            }
+
+            if (selectAll)
+            {
+                textBox.SelectAll();
+            }
+
+            return textBox.Focus() || editor.Focus();
+        }
+    }
+}

--- a/src/DataGridSample.UnitTests/ContinuousEditingSampleTests.cs
+++ b/src/DataGridSample.UnitTests/ContinuousEditingSampleTests.cs
@@ -1,0 +1,55 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using DataGridSample.Models;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class ContinuousEditingSampleTests
+{
+    [Fact]
+    public void ViewModel_Provides_Seed_Data_And_Editor_Choices()
+    {
+        var viewModel = new ContinuousEditingViewModel();
+
+        Assert.Equal(3, viewModel.Rows.Count);
+        Assert.Contains("Morgan", viewModel.OwnerSuggestions);
+        Assert.Contains("Critical", viewModel.Priorities);
+    }
+
+    [Fact]
+    public void Row_Raises_Notifications_For_Editable_Properties()
+    {
+        var row = new ContinuousEditingRow();
+        string? changedProperty = null;
+        row.PropertyChanged += (_, args) => changedProperty = args.PropertyName;
+
+        row.Estimate = 8;
+
+        Assert.Equal(nameof(ContinuousEditingRow.Estimate), changedProperty);
+        Assert.Equal(8, row.Estimate);
+    }
+
+    [AvaloniaFact]
+    public void Page_Configures_Continuous_Next_Cell_Editing()
+    {
+        var page = new ContinuousEditingPage();
+        var grid = page.FindControl<DataGrid>("ContinuousEditingGrid");
+        var viewModel = Assert.IsType<ContinuousEditingViewModel>(page.DataContext);
+
+        Assert.NotNull(grid);
+        Assert.Same(viewModel.Rows, grid.ItemsSource);
+        Assert.Equal(DataGridEnterKeyNavigationMode.NextCell, grid.EnterKeyNavigationMode);
+        Assert.True(grid.ContinueEditingOnEnter);
+        Assert.True(grid.CanUserAddRows);
+        Assert.Collection(
+            grid.Columns,
+            column => Assert.IsType<DataGridTextColumn>(column),
+            column => Assert.IsType<DataGridAutoCompleteColumn>(column),
+            column => Assert.IsType<DataGridComboBoxColumn>(column),
+            column => Assert.IsType<DataGridNumericColumn>(column),
+            column => Assert.IsType<DataGridDatePickerColumn>(column));
+    }
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -325,6 +325,9 @@
     <TabItem Header="Excel-like Editing">
       <pages:ExcelLikeEditingPage />
     </TabItem>
+    <TabItem Header="Continuous Editing">
+      <pages:ContinuousEditingPage />
+    </TabItem>
     <TabItem Header="Formula Engine Samples">
       <pages:FormulaEngineSamplesPage />
     </TabItem>

--- a/src/DataGridSample/Models/ContinuousEditingRow.cs
+++ b/src/DataGridSample/Models/ContinuousEditingRow.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+
+namespace DataGridSample.Models;
+
+/// <summary>
+/// Represents one editable task in the continuous editing sample.
+/// </summary>
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)]
+public sealed class ContinuousEditingRow : ReactiveObject
+{
+    private string _task = string.Empty;
+    private string _owner = string.Empty;
+    private string _priority = "Normal";
+    private decimal _estimate;
+    private DateTime? _dueDate;
+
+    /// <summary>
+    /// Gets or sets the task description.
+    /// </summary>
+    public string Task
+    {
+        get => _task;
+        set => this.RaiseAndSetIfChanged(ref _task, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the task owner.
+    /// </summary>
+    public string Owner
+    {
+        get => _owner;
+        set => this.RaiseAndSetIfChanged(ref _owner, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the task priority.
+    /// </summary>
+    public string Priority
+    {
+        get => _priority;
+        set => this.RaiseAndSetIfChanged(ref _priority, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the estimate in hours.
+    /// </summary>
+    public decimal Estimate
+    {
+        get => _estimate;
+        set => this.RaiseAndSetIfChanged(ref _estimate, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the optional due date.
+    /// </summary>
+    public DateTime? DueDate
+    {
+        get => _dueDate;
+        set => this.RaiseAndSetIfChanged(ref _dueDate, value);
+    }
+}

--- a/src/DataGridSample/Pages/ContinuousEditingPage.axaml
+++ b/src/DataGridSample/Pages/ContinuousEditingPage.axaml
@@ -1,0 +1,95 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.ContinuousEditingPage"
+             x:Name="Root"
+             x:DataType="viewModels:ContinuousEditingViewModel">
+  <UserControl.DataContext>
+    <viewModels:ContinuousEditingViewModel />
+  </UserControl.DataContext>
+
+  <Grid RowDefinitions="Auto,Auto,*"
+        RowSpacing="12"
+        Margin="12">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2">Continuous editing</TextBlock>
+      <TextBlock Text="Enter commits and opens the next writable cell. Tab and Shift+Tab keep editing active across text, autocomplete, combo, numeric, and date editors."
+                 TextWrapping="Wrap" />
+    </StackPanel>
+
+    <Border Grid.Row="1"
+            Padding="12,8"
+            CornerRadius="6"
+            Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+      <Grid ColumnDefinitions="Auto,16,Auto,16,*">
+        <StackPanel>
+          <TextBlock FontWeight="SemiBold" Text="Enter" />
+          <TextBlock Foreground="{DynamicResource ThemeForegroundLowBrush}"
+                     Text="Next cell + continue editing" />
+        </StackPanel>
+        <StackPanel Grid.Column="2">
+          <TextBlock FontWeight="SemiBold" Text="Tab / Shift+Tab" />
+          <TextBlock Foreground="{DynamicResource ThemeForegroundLowBrush}"
+                     Text="Next / previous writable cell" />
+        </StackPanel>
+        <TextBlock Grid.Column="4"
+                   VerticalAlignment="Center"
+                   TextWrapping="Wrap"
+                   Text="Tip: Tab from the final Due cell commits the row and opens the first editor in a new row." />
+      </Grid>
+    </Border>
+
+    <DataGrid x:Name="ContinuousEditingGrid"
+              Grid.Row="2"
+              ItemsSource="{Binding Rows}"
+              AutoGenerateColumns="False"
+              IsReadOnly="False"
+              CanUserAddRows="True"
+              CanUserDeleteRows="True"
+              CanUserSortColumns="False"
+              SelectionMode="Single"
+              SelectionUnit="Cell"
+              EditTriggers="CellClick,TextInput,F2"
+              EnterKeyNavigationMode="NextCell"
+              ContinueEditingOnEnter="True"
+              HeadersVisibility="All"
+              RowHeight="38">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Task"
+                            Binding="{Binding Task}"
+                            Watermark="Describe the task"
+                            Width="2*"
+                            x:DataType="models:ContinuousEditingRow" />
+        <DataGridAutoCompleteColumn Header="Owner"
+                                    Binding="{Binding Owner}"
+                                    ItemsSource="{Binding #Root.((viewModels:ContinuousEditingViewModel)DataContext).OwnerSuggestions}"
+                                    FilterMode="Contains"
+                                    MinimumPrefixLength="0"
+                                    IsTextCompletionEnabled="True"
+                                    Watermark="Choose or type"
+                                    Width="*"
+                                    x:DataType="models:ContinuousEditingRow" />
+        <DataGridComboBoxColumn Header="Priority"
+                                TextBinding="{Binding Priority}"
+                                ItemsSource="{Binding #Root.((viewModels:ContinuousEditingViewModel)DataContext).Priorities}"
+                                IsEditable="True"
+                                Width="*"
+                                x:DataType="models:ContinuousEditingRow" />
+        <DataGridNumericColumn Header="Estimate"
+                               Binding="{Binding Estimate}"
+                               Minimum="0"
+                               Maximum="100"
+                               Increment="1"
+                               FormatString="N0"
+                               Width="*"
+                               x:DataType="models:ContinuousEditingRow" />
+        <DataGridDatePickerColumn Header="Due"
+                                  Binding="{Binding DueDate}"
+                                  SelectedDateFormat="Short"
+                                  Width="140"
+                                  x:DataType="models:ContinuousEditingRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/ContinuousEditingPage.axaml.cs
+++ b/src/DataGridSample/Pages/ContinuousEditingPage.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class ContinuousEditingPage : UserControl
+{
+    public ContinuousEditingPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/ViewModels/ContinuousEditingViewModel.cs
+++ b/src/DataGridSample/ViewModels/ContinuousEditingViewModel.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using DataGridSample.Models;
+using ReactiveUI;
+
+namespace DataGridSample.ViewModels;
+
+/// <summary>
+/// Supplies editable rows and editor choices for the continuous editing sample.
+/// </summary>
+public sealed class ContinuousEditingViewModel : ReactiveObject
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContinuousEditingViewModel"/> class.
+    /// </summary>
+    public ContinuousEditingViewModel()
+    {
+        OwnerSuggestions = new[] { "Avery", "Jordan", "Morgan", "Riley", "Sam" };
+        Priorities = new[] { "Low", "Normal", "High", "Critical" };
+        Rows = new ObservableCollection<ContinuousEditingRow>
+        {
+            new()
+            {
+                Task = "Confirm release notes",
+                Owner = "Avery",
+                Priority = "High",
+                Estimate = 2,
+                DueDate = new DateTime(2026, 8, 5)
+            },
+            new()
+            {
+                Task = "Run keyboard navigation checks",
+                Owner = "Jordan",
+                Priority = "Normal",
+                Estimate = 4,
+                DueDate = new DateTime(2026, 8, 6)
+            },
+            new()
+            {
+                Task = "Prepare the sample gallery",
+                Owner = "Morgan",
+                Priority = "Critical",
+                Estimate = 3,
+                DueDate = new DateTime(2026, 8, 7)
+            }
+        };
+    }
+
+    /// <summary>
+    /// Gets the editable source rows.
+    /// </summary>
+    public ObservableCollection<ContinuousEditingRow> Rows { get; }
+
+    /// <summary>
+    /// Gets the autocomplete choices for the owner column.
+    /// </summary>
+    public IReadOnlyList<string> OwnerSuggestions { get; }
+
+    /// <summary>
+    /// Gets the choices for the editable priority column.
+    /// </summary>
+    public IReadOnlyList<string> Priorities { get; }
+}


### PR DESCRIPTION
## Summary

- preserve continuous editing when Tab or Shift+Tab moves between writable cells
- make Tab from the final writable cell commit the row, restore the add-new placeholder, and open the first writable editor for the new item
- add configurable Enter navigation with `EnterKeyNavigationMode` (`Down` or `NextCell`) and `ContinueEditingOnEnter`
- treat NumericUpDown, editable ComboBox, AutoCompleteBox, and CalendarDatePicker editors as a single tab stop and focus their actual text input
- document the continuous data-entry workflow and the existing filtering editor offered by `DataGridAutoCompleteColumn`

## Root cause

The grid already reopened the next editor for ordinary Tab navigation, but the last-row path depended on the add-new placeholder being visible while the row was still being edited. `DataGridCollectionView.CanAddNew` is temporarily false during `EditItem`, so the data connection could stop reporting that placeholder and Tab concluded that no destination existed.

Compound controls introduced a second boundary: an internal TextBox or spinner part could consume Tab before the grid's route-finished keyboard processing ran. Their edit preparation also focused the outer control inconsistently, which prevented reliable select-all and direct keyboard entry.

## Implementation

### Row navigation

- recognize a realized placeholder row even while the collection view temporarily suppresses its placeholder item
- on forward Tab at the final writable cell, commit the active row first, let the view restore its add-new state, resolve the new placeholder slot, and begin editing its first writable column
- retain normal focus traversal when the source does not support creating a new item

### Enter behavior

Two styled properties make Enter behavior explicit without changing existing defaults:

```xml
<DataGrid EnterKeyNavigationMode="NextCell"
          ContinueEditingOnEnter="True" />
```

- `Down` remains the default navigation mode
- `ContinueEditingOnEnter` defaults to `False`
- `NextCell` follows the same writable-cell ordering and row wrapping as Tab

### Editor focus and tab handling

A focused internal helper configures each compound editor as one tab stop and targets its nested TextBox when available. Numeric and editable suggestion editors select all text; date editing focuses the writable date text directly. If a configured nested editor consumes Tab, the grid recognizes that single-tab-stop contract and completes grid navigation instead of entering internal spinner or popup parts.

For typed filtering, `DataGridAutoCompleteColumn` remains the purpose-built column: callers can configure `FilterMode`, `MinimumPrefixLength`, and `IsTextCompletionEnabled` without adding reflection-based item inspection to `DataGridComboBoxColumn`.

## Tests

Added coverage for:

- default Enter property values
- Tab committing and reopening the next editor
- Tab from the final cell adding a row and opening its first editor
- Enter moving down or to the next writable cell, with and without continuous editing
- routed Tab originating in NumericUpDown's nested TextBox
- text focus/selection and single-tab-stop behavior for numeric, combo-box, autocomplete, and date-picker columns

Validation:

- focused keyboard/editor suite: **150 passed**
- complete `Avalonia.Controls.DataGrid.UnitTests` project: **2261 passed**

Fixes #291

## Review hardening

Follow-up review added a handled-event veto regression for compound editors. The grid now performs its fallback Tab navigation only when the routed event leaves focus on the DataGrid itself, preserving an inner editor's handled Tab behavior.

Current validation: **53/53** focused editing tests and **2,262/2,262** full unit tests pass. Review threads are resolved.
