### PR TITLE
Support sharing column definitions across DataGrids

### DIFF
--- a/docfx/articles/column-definitions.md
+++ b/docfx/articles/column-definitions.md
@@ -49,6 +49,30 @@ public DataGridColumnDefinitionList ColumnDefinitions { get; } = new()
 };
 ```
 
+## Share definitions across multiple grids
+
+`DataGridColumn` objects are controls and can belong to only one `DataGrid`. Do not bind the same `Columns` collection to multiple grids. Bind the same definition collection to `ColumnDefinitionsSource` instead:
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:MyApp.ViewModels"
+             x:DataType="vm:ComparisonViewModel">
+  <Grid ColumnDefinitions="*,*">
+    <DataGrid Grid.Column="0"
+              ItemsSource="{CompiledBinding CurrentItems}"
+              ColumnDefinitionsSource="{CompiledBinding ColumnDefinitions}"
+              AutoGenerateColumns="False" />
+    <DataGrid Grid.Column="1"
+              ItemsSource="{CompiledBinding ComparisonItems}"
+              ColumnDefinitionsSource="{CompiledBinding ColumnDefinitions}"
+              AutoGenerateColumns="False" />
+  </Grid>
+</UserControl>
+```
+
+Each grid creates and owns a distinct `DataGridColumn` for every shared definition. Collection changes and `DataGridColumnDefinition` property changes are applied to every connected grid, while no column control instance is reused or reparented.
+
 ## Typed builder
 
 If you prefer a strongly typed builder, use `DataGridColumnDefinitionBuilder`:

--- a/docfx/articles/columns-and-editing.md
+++ b/docfx/articles/columns-and-editing.md
@@ -99,7 +99,7 @@ Bind `Columns` to an `ObservableCollection<DataGridColumn>` to drive columns fro
 
 ## MVVM Column Definitions
 
-`ColumnDefinitionsSource` lets you define columns in view-models without creating Avalonia controls. Bind an `IList<DataGridColumnDefinition>` and the grid materializes the corresponding built-in columns. Use `DataGridColumnDefinitionList` when you want `AddRange` and `SuspendNotifications()` for batch updates.
+`ColumnDefinitionsSource` lets you define columns in view-models without creating Avalonia controls. Bind an `IList<DataGridColumnDefinition>` and the grid materializes the corresponding built-in columns. Unlike `DataGridColumn` controls, one definition list can be shared by multiple grids because each grid materializes its own column instances. Use `DataGridColumnDefinitionList` when you want `AddRange` and `SuspendNotifications()` for batch updates.
 
 For a full walkthrough, see [Column Definitions](column-definitions.md) and [Column Definitions: AOT-Friendly Bindings](column-definitions-aot.md).
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/BindableColumnsHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/BindableColumnsHeadlessTests.cs
@@ -130,6 +130,30 @@ public class BindableColumnsHeadlessTests
         }
     }
 
+    [AvaloniaFact]
+    public void Columns_Binding_Shared_Control_Instances_Explains_ColumnDefinitionsSource()
+    {
+        var columns = new ObservableCollection<DataGridColumn>
+        {
+            new DataGridTextColumn { Header = "Name" }
+        };
+        var firstGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            Columns = columns
+        };
+        var secondGrid = new DataGrid
+        {
+            AutoGenerateColumns = false
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => secondGrid.Columns = columns);
+
+        Assert.Contains("DataGridColumnDefinition", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(DataGrid.ColumnDefinitionsSource), exception.Message, StringComparison.Ordinal);
+        Assert.Same(firstGrid, columns[0].OwningGrid);
+    }
+
     private static DataGridColumn[] GetNonFillerColumns(DataGrid grid)
     {
         return grid.ColumnsInternal.ItemsInternal

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnDefinitionsTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnDefinitionsTests.cs
@@ -329,6 +329,58 @@ public class DataGridColumnDefinitionsTests
     }
 
     [AvaloniaFact]
+    public void ColumnDefinitionsSource_Can_Be_Shared_By_Multiple_Grids()
+    {
+        var nameDefinition = new DataGridTextColumnDefinition
+        {
+            Header = "Name",
+            Binding = DataGridBindingDefinition.Create<Person, string>(p => p.Name)
+        };
+        var definitions = new ObservableCollection<DataGridColumnDefinition>
+        {
+            nameDefinition
+        };
+
+        var firstGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ColumnDefinitionsSource = definitions
+        };
+        var secondGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ColumnDefinitionsSource = definitions
+        };
+
+        var firstColumn = Assert.Single(GetNonFillerColumns(firstGrid));
+        var secondColumn = Assert.Single(GetNonFillerColumns(secondGrid));
+
+        Assert.NotSame(firstColumn, secondColumn);
+        Assert.Same(firstGrid, firstColumn.OwningGrid);
+        Assert.Same(secondGrid, secondColumn.OwningGrid);
+
+        nameDefinition.Header = "Display Name";
+
+        Assert.Equal("Display Name", firstColumn.Header);
+        Assert.Equal("Display Name", secondColumn.Header);
+
+        definitions.Add(new DataGridTextColumnDefinition
+        {
+            Header = "Age",
+            Binding = DataGridBindingDefinition.Create<Person, int>(p => p.Age)
+        });
+
+        Assert.Equal(2, GetNonFillerColumns(firstGrid).Count);
+        Assert.Equal(2, GetNonFillerColumns(secondGrid).Count);
+
+        firstGrid.ColumnDefinitionsSource = null;
+        nameDefinition.Header = "Full Name";
+
+        Assert.Empty(GetNonFillerColumns(firstGrid));
+        Assert.Equal("Full Name", GetNonFillerColumns(secondGrid)[0].Header);
+    }
+
+    [AvaloniaFact]
     public void ColumnDefinition_Applies_SummaryCell_Alignment()
     {
         var definitions = new ObservableCollection<DataGridColumnDefinition>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.Binding.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.Binding.cs
@@ -495,7 +495,10 @@ internal
 
             if (column.OwningGrid != null && column.OwningGrid != this)
             {
-                throw new InvalidOperationException("Column already belongs to another DataGrid. Detach it before binding.");
+                throw new InvalidOperationException(
+                    "DataGridColumn instances cannot be shared by multiple DataGrid controls. " +
+                    "Bind a shared DataGridColumnDefinition collection to ColumnDefinitionsSource so each grid " +
+                    "materializes its own columns, or detach the column before binding it here.");
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -708,7 +708,8 @@ internal
         }
 
         /// <summary>
-        /// Gets or sets the bound column definitions source (IList + INotifyCollectionChanged enables live updates).
+        /// Gets or sets the bound column definitions source. Definitions may be shared by multiple grids;
+        /// each grid materializes its own column instances. IList + INotifyCollectionChanged enables live updates.
         /// </summary>
 #if !DATAGRID_INTERNAL
         public


### PR DESCRIPTION
## Summary

- document `ColumnDefinitionsSource` as the supported way to share one MVVM column model between multiple grids
- add regression coverage proving that two grids materialize independent `DataGridColumn` controls from the same definition list
- verify that definition property changes and collection changes propagate to both grids, and detaching one grid leaves the other subscribed
- replace the generic shared-column ownership failure with an actionable diagnostic that points callers to `DataGridColumnDefinition` and `ColumnDefinitionsSource`

## Analysis

`DataGridColumn` is a control-layer object with an `OwningGrid`; reusing one instance across two grids would violate its ownership, layout, editing, theme, and event-subscription invariants. Cloning arbitrary columns would also be incomplete for custom columns, templates, bindings, attached metadata, and future properties.

The repository already has an MVVM-safe abstraction for this scenario: `DataGridColumnDefinition`. A definition is model metadata rather than a control. Each `DataGrid` independently calls the definition factory and owns the resulting column, while definition collection and property notifications remain shared.

This change makes that capability explicit and protects it with end-to-end tests instead of introducing a partial control clone API.

## Supported usage

Both grids bind the same view-model collection:

```xml
<DataGrid ItemsSource="{CompiledBinding CurrentItems}"
          ColumnDefinitionsSource="{CompiledBinding ColumnDefinitions}"
          AutoGenerateColumns="False" />

<DataGrid ItemsSource="{CompiledBinding ComparisonItems}"
          ColumnDefinitionsSource="{CompiledBinding ColumnDefinitions}"
          AutoGenerateColumns="False" />
```

The view model exposes `IList<DataGridColumnDefinition>` or `DataGridColumnDefinitionList`; it does not construct or retain Avalonia control instances.

## Behavior covered

- the same definition creates different column instances for grid A and grid B
- each materialized column has the correct owning grid
- changing a definition updates both materialized columns
- adding to the shared observable definition list updates both grids
- clearing `ColumnDefinitionsSource` on one grid does not unsubscribe the other grid
- attempting to bind the same `DataGridColumn` controls to another grid explains the supported definition-based alternative

## Documentation

- added a complete compiled-binding two-grid example with `x:DataType`
- clarified the difference between exclusive `Columns` controls and reusable `ColumnDefinitionsSource` models in both column guides
- expanded the public property documentation to state the sharing/materialization contract

## Validation

- focused column definition/binding suite: **78 passed**
- complete `Avalonia.Controls.DataGrid.UnitTests` project: **2252 passed**

Fixes #293
