### PR TITLE
Add grouped spanning headers for column bands

### DIFF
--- a/docfx/articles/column-banding.md
+++ b/docfx/articles/column-banding.md
@@ -7,7 +7,10 @@ Column banding lets you define multi-level headers for non-pivot tables. The `Co
 ```csharp
 using Avalonia.Controls.DataGridBanding;
 
-var model = new ColumnBandModel();
+var model = new ColumnBandModel
+{
+    HeaderLayout = ColumnBandHeaderLayout.Grouped
+};
 
 var salesColumn = new DataGridNumericColumnDefinition
 {
@@ -28,14 +31,26 @@ model.Bands.Add(new ColumnBand
 Bind the generated definitions to the grid:
 
 ```xml
-<DataGrid ItemsSource="{Binding Items}"
-          ColumnDefinitionsSource="{Binding Bands.ColumnDefinitions}"
+<DataGrid ItemsSource="{CompiledBinding Items}"
+          ColumnDefinitionsSource="{CompiledBinding Bands.ColumnDefinitions}"
           AutoGenerateColumns="False" />
 ```
 
+## Header layouts
+
+`HeaderLayout = ColumnBandHeaderLayout.Grouped` renders common ancestors once as non-interactive header cells spanning adjacent leaf columns. Leaves at a shallower depth automatically span the unused rows, producing a conventional grouped-header outline:
+
+```text
+|         Order         |      Merchandise      |          Financials          |
+| Date | Region | Segment | Category | Product |      Revenue      |  Volume  |
+|      |        |         |          |         | Sales | Profit    |  Units   |
+```
+
+Use `HeaderLayout = ColumnBandHeaderLayout.Stacked` (the default) when every leaf header should display its complete band path independently. Grouped headers split automatically at frozen-column boundaries so frozen and scrolling regions remain aligned.
+
 ## Notes
 
-- `ColumnBand.Header` becomes a stacked header segment.
+- `ColumnBand.Header` becomes a stacked segment or grouped spanning cell, depending on `HeaderLayout`.
 - Leaf nodes supply the `DataGridColumnDefinition` used by the grid.
 - The model applies the `DataGridColumnBandHeaderTemplate` by default; override `HeaderTemplateKey` to customize.
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
@@ -168,6 +168,66 @@ public sealed class ColumnBandGroupedHeaderTests
         }
     }
 
+    [AvaloniaFact]
+    public void Grouped_Header_Does_Not_Merge_Distinct_Bands_With_The_Same_Caption()
+    {
+        using var model = new ColumnBandModel
+        {
+            HeaderLayout = ColumnBandHeaderLayout.Grouped
+        };
+        using (model.DeferRefresh())
+        {
+            model.Bands.Add(new ColumnBand
+            {
+                Header = "Repeated",
+                Children = { CreateLeaf("First") }
+            });
+            model.Bands.Add(new ColumnBand
+            {
+                Header = "Repeated",
+                Children = { CreateLeaf("Second") }
+            });
+        }
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ColumnHeaderHeight = 80,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            ColumnDefinitionsSource = model.ColumnDefinitions
+        };
+        var window = new Window
+        {
+            Width = 240,
+            Height = 160,
+            Background = Brushes.White
+        };
+        window.SetThemeStyles();
+        window.Content = grid;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            var presenter = Assert.Single(grid.GetVisualDescendants().OfType<DataGridColumnHeadersPresenter>());
+            var repeatedHeaders = presenter.Children
+                .OfType<DataGridColumnBandHeaderCell>()
+                .Where(cell => Equals(cell.Content, "Repeated"))
+                .ToArray();
+
+            Assert.Equal(2, repeatedHeaders.Length);
+            Assert.All(repeatedHeaders, cell => AssertClose(100, cell.Bounds.Width));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static ColumnBandModel CreateGroupedModel()
     {
         var model = new ColumnBandModel

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridBanding;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Banding;
+
+public sealed class ColumnBandGroupedHeaderTests
+{
+    [Fact]
+    public void HeaderLayout_Refreshes_Materialized_Definition_Headers()
+    {
+        using var model = new ColumnBandModel();
+        model.Bands.Add(new ColumnBand
+        {
+            Header = "Order",
+            Children =
+            {
+                CreateLeaf("Date")
+            }
+        });
+
+        var stacked = Assert.IsType<ColumnBandHeader>(Assert.Single(model.ColumnDefinitions).Header);
+        Assert.Equal(ColumnBandHeaderLayout.Stacked, stacked.Layout);
+        Assert.Equal(2, stacked.DisplaySegments.Count);
+
+        model.HeaderLayout = ColumnBandHeaderLayout.Grouped;
+
+        var grouped = Assert.IsType<ColumnBandHeader>(Assert.Single(model.ColumnDefinitions).Header);
+        Assert.Equal(ColumnBandHeaderLayout.Grouped, grouped.Layout);
+        Assert.Single(grouped.DisplaySegments);
+        Assert.Equal("Date", grouped.DisplaySegments[0]);
+    }
+
+    [AvaloniaFact]
+    public void Grouped_Headers_Span_Contiguous_Leaves_And_Remaining_Rows()
+    {
+        using var model = CreateGroupedModel();
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            CanUserAddRows = false,
+            ColumnHeaderHeight = 120,
+            ItemsSource = new ObservableCollection<RowItem> { new() },
+            HeadersVisibility = DataGridHeadersVisibility.Column
+        };
+        var window = new Window
+        {
+            Width = 540,
+            Height = 260,
+            Background = Brushes.White
+        };
+        window.SetThemeStyles();
+        window.Content = grid;
+        grid.ColumnDefinitionsSource = model.ColumnDefinitions;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            var presenter = Assert.Single(grid.GetVisualDescendants().OfType<DataGridColumnHeadersPresenter>());
+            var bandCells = presenter.Children.OfType<DataGridColumnBandHeaderCell>().ToArray();
+            Assert.Equal(4, bandCells.Length);
+
+            var order = Assert.Single(bandCells, cell => Equals(cell.Content, "Order"));
+            var financials = Assert.Single(bandCells, cell => Equals(cell.Content, "Financials"));
+            var revenue = Assert.Single(bandCells, cell => Equals(cell.Content, "Revenue"));
+            var volume = Assert.Single(bandCells, cell => Equals(cell.Content, "Volume"));
+
+            var date = GetLeafHeader(grid, "Date");
+            var region = GetLeafHeader(grid, "Region");
+            var sales = GetLeafHeader(grid, "Sales");
+            var profit = GetLeafHeader(grid, "Profit");
+            var units = GetLeafHeader(grid, "Units");
+
+            AssertClose(date.Bounds.Width + region.Bounds.Width, order.Bounds.Width);
+            AssertClose(sales.Bounds.Width + profit.Bounds.Width + units.Bounds.Width, financials.Bounds.Width);
+            AssertClose(sales.Bounds.Width + profit.Bounds.Width, revenue.Bounds.Width);
+            AssertClose(units.Bounds.Width, volume.Bounds.Width);
+
+            AssertClose(0, order.Bounds.Y);
+            AssertClose(0, financials.Bounds.Y);
+            AssertClose(40, revenue.Bounds.Y);
+            AssertClose(40, volume.Bounds.Y);
+            AssertClose(40, date.Bounds.Y);
+            AssertClose(80, date.Bounds.Height);
+            AssertClose(80, sales.Bounds.Y);
+            AssertClose(40, sales.Bounds.Height);
+
+            SaveScreenshotWhenRequested(window, "issue-294-grouped-column-bands.png");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Grouped_Header_Splits_At_Frozen_Boundary()
+    {
+        using var model = new ColumnBandModel
+        {
+            HeaderLayout = ColumnBandHeaderLayout.Grouped
+        };
+        using (model.DeferRefresh())
+        {
+            model.Bands.Add(new ColumnBand
+            {
+                Header = "Order",
+                Children =
+                {
+                    CreateLeaf("Date"),
+                    CreateLeaf("Region")
+                }
+            });
+        }
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            FrozenColumnCount = 1,
+            HeadersVisibility = DataGridHeadersVisibility.Column
+        };
+        var window = new Window
+        {
+            Width = 240,
+            Height = 160,
+            Background = Brushes.White
+        };
+        window.SetThemeStyles();
+        window.Content = grid;
+        grid.ColumnDefinitionsSource = model.ColumnDefinitions;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            var presenter = Assert.Single(grid.GetVisualDescendants().OfType<DataGridColumnHeadersPresenter>());
+            var orderCells = presenter.Children
+                .OfType<DataGridColumnBandHeaderCell>()
+                .Where(cell => Equals(cell.Content, "Order"))
+                .ToArray();
+
+            Assert.Equal(2, orderCells.Length);
+            Assert.Contains(orderCells, cell => cell.IsFrozenLeft);
+            Assert.Contains(orderCells, cell => !cell.IsFrozenLeft && !cell.IsFrozenRight);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static ColumnBandModel CreateGroupedModel()
+    {
+        var model = new ColumnBandModel
+        {
+            HeaderLayout = ColumnBandHeaderLayout.Grouped
+        };
+
+        using (model.DeferRefresh())
+        {
+            model.Bands.Add(new ColumnBand
+            {
+                Header = "Order",
+                Children =
+                {
+                    CreateLeaf("Date"),
+                    CreateLeaf("Region")
+                }
+            });
+            model.Bands.Add(new ColumnBand
+            {
+                Header = "Financials",
+                Children =
+                {
+                    new ColumnBand
+                    {
+                        Header = "Revenue",
+                        Children =
+                        {
+                            CreateLeaf("Sales"),
+                            CreateLeaf("Profit")
+                        }
+                    },
+                    new ColumnBand
+                    {
+                        Header = "Volume",
+                        Children =
+                        {
+                            CreateLeaf("Units")
+                        }
+                    }
+                }
+            });
+        }
+
+        return model;
+    }
+
+    private static ColumnBand CreateLeaf(string header)
+    {
+        return new ColumnBand
+        {
+            Header = header,
+            ColumnDefinition = new DataGridTextColumnDefinition
+            {
+                Header = header,
+                Width = new DataGridLength(100)
+            }
+        };
+    }
+
+    private static DataGridColumnHeader GetLeafHeader(DataGrid grid, string text)
+    {
+        return grid.ColumnsInternal.ItemsInternal
+            .Where(column => column is not DataGridFillerColumn)
+            .Single(column =>
+                column.Header is ColumnBandHeader header &&
+                Equals(header.Segments[header.Segments.Count - 1], text))
+            .HeaderCell;
+    }
+
+    private static void AssertClose(double expected, double actual)
+    {
+        Assert.InRange(actual, expected - 0.5, expected + 0.5);
+    }
+
+    private static void SaveScreenshotWhenRequested(Window window, string fileName)
+    {
+        string? directory = Environment.GetEnvironmentVariable("AVALONIA_SCREENSHOT_DIR");
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+
+        var frame = window.CaptureRenderedFrame();
+        Assert.NotNull(frame);
+        Directory.CreateDirectory(directory);
+        frame!.Save(Path.Combine(directory, fileName));
+    }
+
+    private sealed class RowItem
+    {
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Banding/ColumnBandGroupedHeaderTests.cs
@@ -228,6 +228,72 @@ public sealed class ColumnBandGroupedHeaderTests
         }
     }
 
+    [AvaloniaFact]
+    public void Grouped_Header_Grows_Auto_Sized_Leaf_Columns_To_Fit_Its_Caption()
+    {
+        const string Caption = "A parent caption that is substantially wider than its leaf headers";
+        using var model = new ColumnBandModel
+        {
+            HeaderLayout = ColumnBandHeaderLayout.Grouped
+        };
+        using (model.DeferRefresh())
+        {
+            model.Bands.Add(new ColumnBand
+            {
+                Header = Caption,
+                Children =
+                {
+                    CreateAutoSizedLeaf("A"),
+                    CreateAutoSizedLeaf("B")
+                }
+            });
+        }
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ColumnHeaderHeight = 80,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            ItemsSource = new ObservableCollection<RowItem> { new() },
+            ColumnDefinitionsSource = model.ColumnDefinitions
+        };
+        var window = new Window
+        {
+            Width = 700,
+            Height = 160,
+            Background = Brushes.White
+        };
+        window.SetThemeStyles();
+        window.Content = grid;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            Assert.Equal(2, grid.Columns.Count);
+            Assert.All(grid.Columns, column => Assert.IsType<ColumnBandHeader>(column.Header));
+            var presenter = Assert.Single(grid.GetVisualDescendants().OfType<DataGridColumnHeadersPresenter>());
+            var bandHeader = Assert.Single(
+                presenter.Children.OfType<DataGridColumnBandHeaderCell>(),
+                cell => Equals(cell.Content, Caption));
+
+            Assert.True(bandHeader.Bounds.Width > 300);
+            AssertClose(
+                grid.ColumnsInternal.ItemsInternal
+                    .Where(column => column is not DataGridFillerColumn)
+                    .Sum(column => column.ActualWidth),
+                bandHeader.Bounds.Width);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static ColumnBandModel CreateGroupedModel()
     {
         var model = new ColumnBandModel
@@ -284,6 +350,19 @@ public sealed class ColumnBandGroupedHeaderTests
             {
                 Header = header,
                 Width = new DataGridLength(100)
+            }
+        };
+    }
+
+    private static ColumnBand CreateAutoSizedLeaf(string header)
+    {
+        return new ColumnBand
+        {
+            Header = header,
+            ColumnDefinition = new DataGridTextColumnDefinition
+            {
+                Header = header,
+                Width = DataGridLength.Auto
             }
         };
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/TestAppBuilder.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/TestAppBuilder.cs
@@ -12,12 +12,20 @@ internal sealed class UnitTestAppBuilder
 {
     public static AppBuilder BuildAvaloniaApp()
     {
-        var options = new AvaloniaHeadlessPlatformOptions
+        bool captureScreenshots = !string.IsNullOrWhiteSpace(
+            Environment.GetEnvironmentVariable("AVALONIA_SCREENSHOT_DIR"));
+        AvaloniaHeadlessPlatformOptions options = new AvaloniaHeadlessPlatformOptions
         {
-            UseHeadlessDrawing = true
+            UseHeadlessDrawing = !captureScreenshots
         };
 
-        return AppBuilder.Configure<UnitTestApp>()
+        AppBuilder builder = AppBuilder.Configure<UnitTestApp>();
+        if (captureScreenshots)
+        {
+            builder = builder.UseSkia();
+        }
+
+        return builder
             .UseHeadless(options)
             .AfterPlatformServicesSetup(_ => RegisterHeadlessFontManager());
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Avalonia;
 using Avalonia.Controls.DataGridTests;
 using Avalonia.Controls;
+using Avalonia.Controls.DataGridBanding;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -391,6 +392,7 @@ public class DataGridThemeResourceCoverageTests
         new(typeof(DataGridHierarchicalPresenter), typeof(DataGridHierarchicalPresenter)),
         new(typeof(DataGridCell), typeof(DataGridCell)),
         new(typeof(DataGridColumnHeader), typeof(DataGridColumnHeader)),
+        new(typeof(DataGridColumnBandHeaderCell), typeof(DataGridColumnBandHeaderCell)),
         new("DataGridTopLeftColumnHeader", typeof(DataGridColumnHeader)),
         new(typeof(DataGridRowHeader), typeof(DataGridRowHeader)),
         new(typeof(DataGridRow), typeof(DataGridRow)),
@@ -553,6 +555,7 @@ public class DataGridThemeResourceCoverageTests
         "DataGridCellTextBlockMargin",
         "DataGridCellComboBoxPadding",
         "DataGridColumnHeaderPadding",
+        "DataGridColumnBandHeaderBorderThickness",
         "DataGridColumnHeaderSortIconMargin",
         "DataGridColumnHeaderDragGripMargin",
         "DataGridRowGroupHeaderExpanderMargin",
@@ -724,6 +727,7 @@ public class DataGridThemeResourceCoverageTests
         "DataGridCellTextBlockMargin",
         "DataGridCellComboBoxPadding",
         "DataGridColumnHeaderPadding",
+        "DataGridColumnBandHeaderBorderThickness",
         "DataGridColumnHeaderSortIconMargin",
         "DataGridColumnHeaderDragGripMargin",
         "DataGridRowGroupHeaderExpanderMargin",

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeTokenContractTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeTokenContractTests.cs
@@ -23,6 +23,7 @@ public class DataGridThemeTokenContractTests
         "DataGridFilterEnumEditorWidth",
         "DataGridPivotHeaderSegmentsSpacing",
         "DataGridColumnBandHeaderSegmentsSpacing",
+        "DataGridColumnBandHeaderBorderThickness",
         "DataGridFilterButtonSize",
         "DataGridFilterGlyphSize",
         "DataGridFilterGlyphStrokeThickness",

--- a/src/Avalonia.Controls.DataGrid/Banding/ColumnBandModels.cs
+++ b/src/Avalonia.Controls.DataGrid/Banding/ColumnBandModels.cs
@@ -11,6 +11,30 @@ using Avalonia.Controls;
 
 namespace Avalonia.Controls.DataGridBanding
 {
+    /// <summary>
+    /// Specifies how a column-band path is presented in the grid header area.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum ColumnBandHeaderLayout
+    {
+        /// <summary>
+        /// Renders the complete band path inside every leaf column header.
+        /// </summary>
+        Stacked = 0,
+
+        /// <summary>
+        /// Renders shared ancestors as cells spanning adjacent leaf columns.
+        /// </summary>
+        Grouped = 1
+    }
+
+    /// <summary>
+    /// Describes the root-to-leaf path presented for a materialized banded column.
+    /// </summary>
 #if !DATAGRID_INTERNAL
     public
 #else
@@ -18,12 +42,43 @@ namespace Avalonia.Controls.DataGridBanding
 #endif
     sealed class ColumnBandHeader
     {
+        /// <summary>
+        /// Initializes a stacked header from the specified path segments.
+        /// </summary>
+        /// <param name="segments">The root-to-leaf header path.</param>
         public ColumnBandHeader(IReadOnlyList<string> segments)
+            : this(segments, ColumnBandHeaderLayout.Stacked)
         {
-            Segments = segments ?? Array.Empty<string>();
         }
 
+        /// <summary>
+        /// Initializes a header from the specified path segments and layout mode.
+        /// </summary>
+        /// <param name="segments">The root-to-leaf header path.</param>
+        /// <param name="layout">The header layout mode.</param>
+        public ColumnBandHeader(IReadOnlyList<string> segments, ColumnBandHeaderLayout layout)
+        {
+            Segments = segments ?? Array.Empty<string>();
+            Layout = layout;
+            DisplaySegments = layout == ColumnBandHeaderLayout.Grouped && Segments.Count > 0
+                ? new[] { Segments[Segments.Count - 1] }
+                : Segments;
+        }
+
+        /// <summary>
+        /// Gets the complete root-to-leaf header path.
+        /// </summary>
         public IReadOnlyList<string> Segments { get; }
+
+        /// <summary>
+        /// Gets the segments displayed inside the owning leaf column header.
+        /// </summary>
+        public IReadOnlyList<string> DisplaySegments { get; }
+
+        /// <summary>
+        /// Gets the layout mode used to present this header.
+        /// </summary>
+        public ColumnBandHeaderLayout Layout { get; }
     }
 
 #if !DATAGRID_INTERNAL
@@ -109,6 +164,7 @@ namespace Avalonia.Controls.DataGridBanding
         private bool _pendingRefresh;
         private bool _isRefreshing;
         private string _headerTemplateKey = "DataGridColumnBandHeaderTemplate";
+        private ColumnBandHeaderLayout _headerLayout;
         private readonly Dictionary<ColumnBand, DataGridColumnDefinition?> _columnDefinitions = new();
 
         public ColumnBandModel()
@@ -137,6 +193,25 @@ namespace Avalonia.Controls.DataGridBanding
 
                 _headerTemplateKey = value ?? string.Empty;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HeaderTemplateKey)));
+                RequestRefresh();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how shared band ancestors are presented in the grid header area.
+        /// </summary>
+        public ColumnBandHeaderLayout HeaderLayout
+        {
+            get => _headerLayout;
+            set
+            {
+                if (_headerLayout == value)
+                {
+                    return;
+                }
+
+                _headerLayout = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HeaderLayout)));
                 RequestRefresh();
             }
         }
@@ -415,9 +490,9 @@ namespace Avalonia.Controls.DataGridBanding
 
             var segments = BuildSegments(nextPath, band.ColumnDefinition, band.Header);
             if (band.ColumnDefinition.Header is not ColumnBandHeader bandHeader ||
-                !HeadersMatch(bandHeader, segments))
+                !HeadersMatch(bandHeader, segments, _headerLayout))
             {
-                band.ColumnDefinition.Header = new ColumnBandHeader(segments);
+                band.ColumnDefinition.Header = new ColumnBandHeader(segments, _headerLayout);
             }
             if (!string.IsNullOrEmpty(_headerTemplateKey))
             {
@@ -467,9 +542,12 @@ namespace Avalonia.Controls.DataGridBanding
             return Convert.ToString(header, CultureInfo.CurrentCulture) ?? string.Empty;
         }
 
-        private static bool HeadersMatch(ColumnBandHeader header, IReadOnlyList<string> segments)
+        private static bool HeadersMatch(
+            ColumnBandHeader header,
+            IReadOnlyList<string> segments,
+            ColumnBandHeaderLayout layout)
         {
-            if (header.Segments.Count != segments.Count)
+            if (header.Layout != layout || header.Segments.Count != segments.Count)
             {
                 return false;
             }

--- a/src/Avalonia.Controls.DataGrid/Banding/ColumnBandModels.cs
+++ b/src/Avalonia.Controls.DataGrid/Banding/ColumnBandModels.cs
@@ -57,8 +57,17 @@ namespace Avalonia.Controls.DataGridBanding
         /// <param name="segments">The root-to-leaf header path.</param>
         /// <param name="layout">The header layout mode.</param>
         public ColumnBandHeader(IReadOnlyList<string> segments, ColumnBandHeaderLayout layout)
+            : this(segments, Array.Empty<object>(), layout)
+        {
+        }
+
+        internal ColumnBandHeader(
+            IReadOnlyList<string> segments,
+            IReadOnlyList<object> segmentKeys,
+            ColumnBandHeaderLayout layout)
         {
             Segments = segments ?? Array.Empty<string>();
+            SegmentKeys = segmentKeys ?? Array.Empty<object>();
             Layout = layout;
             DisplaySegments = layout == ColumnBandHeaderLayout.Grouped && Segments.Count > 0
                 ? new[] { Segments[Segments.Count - 1] }
@@ -69,6 +78,8 @@ namespace Avalonia.Controls.DataGridBanding
         /// Gets the complete root-to-leaf header path.
         /// </summary>
         public IReadOnlyList<string> Segments { get; }
+
+        internal IReadOnlyList<object> SegmentKeys { get; }
 
         /// <summary>
         /// Gets the segments displayed inside the owning leaf column header.
@@ -455,21 +466,24 @@ namespace Avalonia.Controls.DataGridBanding
             var definitions = new List<DataGridColumnDefinition>();
             foreach (var band in Bands)
             {
-                AppendBand(definitions, band, Array.Empty<string>());
+                AppendBand(definitions, band, Array.Empty<ColumnBand>());
             }
 
             return definitions;
         }
 
-        private void AppendBand(List<DataGridColumnDefinition> definitions, ColumnBand band, IReadOnlyList<string> path)
+        private void AppendBand(
+            List<DataGridColumnDefinition> definitions,
+            ColumnBand band,
+            IReadOnlyList<ColumnBand> path)
         {
             var header = band.Header;
             var nextPath = path;
             if (!string.IsNullOrEmpty(header))
             {
-                var newPath = new List<string>(path.Count + 1);
+                var newPath = new List<ColumnBand>(path.Count + 1);
                 newPath.AddRange(path);
-                newPath.Add(header);
+                newPath.Add(band);
                 nextPath = newPath;
             }
 
@@ -488,11 +502,11 @@ namespace Avalonia.Controls.DataGridBanding
                 return;
             }
 
-            var segments = BuildSegments(nextPath, band.ColumnDefinition, band.Header);
+            BuildSegments(nextPath, band, out IReadOnlyList<string> segments, out IReadOnlyList<object> segmentKeys);
             if (band.ColumnDefinition.Header is not ColumnBandHeader bandHeader ||
-                !HeadersMatch(bandHeader, segments, _headerLayout))
+                !HeadersMatch(bandHeader, segments, segmentKeys, _headerLayout))
             {
-                band.ColumnDefinition.Header = new ColumnBandHeader(segments, _headerLayout);
+                band.ColumnDefinition.Header = new ColumnBandHeader(segments, segmentKeys, _headerLayout);
             }
             if (!string.IsNullOrEmpty(_headerTemplateKey))
             {
@@ -502,29 +516,44 @@ namespace Avalonia.Controls.DataGridBanding
             definitions.Add(band.ColumnDefinition);
         }
 
-        private static IReadOnlyList<string> BuildSegments(IReadOnlyList<string> path, DataGridColumnDefinition definition, string? bandHeader)
+        private static void BuildSegments(
+            IReadOnlyList<ColumnBand> path,
+            ColumnBand leafBand,
+            out IReadOnlyList<string> segments,
+            out IReadOnlyList<object> segmentKeys)
         {
-            var segments = new List<string>(path.Count + 1);
-            segments.AddRange(path);
-
-            if (!string.IsNullOrEmpty(bandHeader))
+            var segmentList = new List<string>(path.Count + 1);
+            var keyList = new List<object>(path.Count + 1);
+            for (int index = 0; index < path.Count; index++)
             {
-                if (segments.Count == 0 || !string.Equals(segments[segments.Count - 1], bandHeader, StringComparison.Ordinal))
+                ColumnBand pathBand = path[index];
+                segmentList.Add(pathBand.Header ?? string.Empty);
+                keyList.Add(pathBand);
+            }
+
+            if (!string.IsNullOrEmpty(leafBand.Header))
+            {
+                if (segmentList.Count == 0 ||
+                    !string.Equals(segmentList[segmentList.Count - 1], leafBand.Header, StringComparison.Ordinal))
                 {
-                    segments.Add(bandHeader);
+                    segmentList.Add(leafBand.Header);
+                    keyList.Add(leafBand);
                 }
             }
             else
             {
-                var headerText = GetHeaderText(definition.Header);
+                var headerText = GetHeaderText(leafBand.ColumnDefinition?.Header);
                 if (!string.IsNullOrEmpty(headerText) &&
-                    (segments.Count == 0 || !string.Equals(segments[segments.Count - 1], headerText, StringComparison.Ordinal)))
+                    (segmentList.Count == 0 ||
+                     !string.Equals(segmentList[segmentList.Count - 1], headerText, StringComparison.Ordinal)))
                 {
-                    segments.Add(headerText);
+                    segmentList.Add(headerText);
+                    keyList.Add(leafBand);
                 }
             }
 
-            return segments;
+            segments = segmentList;
+            segmentKeys = keyList;
         }
 
         private static string GetHeaderText(object? header)
@@ -545,9 +574,12 @@ namespace Avalonia.Controls.DataGridBanding
         private static bool HeadersMatch(
             ColumnBandHeader header,
             IReadOnlyList<string> segments,
+            IReadOnlyList<object> segmentKeys,
             ColumnBandHeaderLayout layout)
         {
-            if (header.Layout != layout || header.Segments.Count != segments.Count)
+            if (header.Layout != layout ||
+                header.Segments.Count != segments.Count ||
+                header.SegmentKeys.Count != segmentKeys.Count)
             {
                 return false;
             }
@@ -555,6 +587,11 @@ namespace Avalonia.Controls.DataGridBanding
             for (var i = 0; i < segments.Count; i++)
             {
                 if (!string.Equals(header.Segments[i], segments[i], StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                if (!ReferenceEquals(header.SegmentKeys[i], segmentKeys[i]))
                 {
                     return false;
                 }

--- a/src/Avalonia.Controls.DataGrid/Banding/DataGridColumnBandHeaderCell.cs
+++ b/src/Avalonia.Controls.DataGrid/Banding/DataGridColumnBandHeaderCell.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+namespace Avalonia.Controls.DataGridBanding
+{
+    /// <summary>
+    /// Presents a non-interactive grouped column-band header spanning one or more leaf columns.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridColumnBandHeaderCell : ContentControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataGridColumnBandHeaderCell"/> class.
+        /// </summary>
+        public DataGridColumnBandHeaderCell()
+        {
+            IsHitTestVisible = false;
+        }
+
+        internal int StartColumnIndex { get; set; }
+
+        internal int EndColumnIndex { get; set; }
+
+        internal int Level { get; set; }
+
+        internal bool IsFrozenLeft { get; set; }
+
+        internal bool IsFrozenRight { get; set; }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -684,6 +684,20 @@ internal
 
             for (int index = 0; index <= level; index++)
             {
+                bool startHasKey = startHeader.SegmentKeys.Count > index;
+                bool candidateHasKey = candidateHeader.SegmentKeys.Count > index;
+                if (startHasKey || candidateHasKey)
+                {
+                    if (!startHasKey ||
+                        !candidateHasKey ||
+                        !ReferenceEquals(startHeader.SegmentKeys[index], candidateHeader.SegmentKeys[index]))
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
                 if (!string.Equals(startHeader.Segments[index], candidateHeader.Segments[index], StringComparison.Ordinal))
                 {
                     return false;

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -462,6 +462,8 @@ internal
 
             foreach (DataGridColumnBandHeaderCell bandHeader in _bandHeaderCells)
             {
+                bandHeader.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                AutoSizeColumnsForBandHeader(bandHeader, bandHeader.DesiredSize.Width);
                 bandHeader.Measure(new Size(GetBandHeaderWidth(bandHeader), double.PositiveInfinity));
                 if (autoSizeHeight)
                 {
@@ -660,6 +662,57 @@ internal
             }
 
             return width;
+        }
+
+        private void AutoSizeColumnsForBandHeader(DataGridColumnBandHeaderCell cell, double desiredWidth)
+        {
+            double remainingGrowth = desiredWidth - GetBandHeaderWidth(cell);
+            if (remainingGrowth <= 0)
+            {
+                return;
+            }
+
+            while (remainingGrowth > 0.001)
+            {
+                int candidateCount = 0;
+                for (int index = cell.StartColumnIndex; index <= cell.EndColumnIndex; index++)
+                {
+                    DataGridColumn column = _visibleBandColumns[index];
+                    if ((column.Width.IsAuto || column.Width.IsSizeToHeader) &&
+                        column.ActualWidth + 0.001 < column.ActualMaxWidth)
+                    {
+                        candidateCount++;
+                    }
+                }
+
+                if (candidateCount == 0)
+                {
+                    break;
+                }
+
+                double requestedGrowth = remainingGrowth / candidateCount;
+                double appliedGrowth = 0;
+                for (int index = cell.StartColumnIndex; index <= cell.EndColumnIndex; index++)
+                {
+                    DataGridColumn column = _visibleBandColumns[index];
+                    if ((!column.Width.IsAuto && !column.Width.IsSizeToHeader) ||
+                        column.ActualWidth + 0.001 >= column.ActualMaxWidth)
+                    {
+                        continue;
+                    }
+
+                    double currentWidth = column.ActualWidth;
+                    OwningGrid.AutoSizeColumn(column, currentWidth + requestedGrowth);
+                    appliedGrowth += Math.Max(0, column.ActualWidth - currentWidth);
+                }
+
+                if (appliedGrowth <= 0.001)
+                {
+                    break;
+                }
+
+                remainingGrowth = Math.Max(0, remainingGrowth - appliedGrowth);
+            }
         }
 
         private static bool TryGetGroupedHeader(DataGridColumn column, out ColumnBandHeader header)

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -8,10 +8,13 @@
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Automation.Peers;
+using Avalonia.Controls.DataGridBanding;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -29,6 +32,9 @@ internal
         private Control _dragIndicator;
         private Control _dropLocationIndicator;
         private EventHandler<ChildIndexChangedEventArgs> _childIndexChanged;
+        private readonly List<DataGridColumn> _visibleBandColumns = new();
+        private readonly List<DataGridColumnBandHeaderCell> _bandHeaderCells = new();
+        private int _bandHeaderRowCount = 1;
 
         /// <summary>
         /// Tracks which column is currently being dragged.
@@ -124,14 +130,31 @@ internal
 
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
-            return child is DataGridColumnHeader header
-                ? header.OwningColumn?.DisplayIndex ?? -1
-                : throw new InvalidOperationException("Invalid cell type");
+            if (child is DataGridColumnHeader header)
+            {
+                return header.OwningColumn?.DisplayIndex ?? -1;
+            }
+
+            if (child is DataGridColumnBandHeaderCell bandHeader &&
+                (uint)bandHeader.StartColumnIndex < (uint)_visibleBandColumns.Count)
+            {
+                return _visibleBandColumns[bandHeader.StartColumnIndex].DisplayIndex;
+            }
+
+            return -1;
         }
 
         bool IChildIndexProvider.TryGetTotalCount(out int count)
         {
-            count = Children.Count - 1; // Adjust for filler column
+            count = 0;
+            foreach (Control child in Children)
+            {
+                if (child is DataGridColumnHeader { OwningColumn: not DataGridFillerColumn })
+                {
+                    count++;
+                }
+            }
+
             return true;
         }
 
@@ -177,10 +200,11 @@ internal
             {
                 DataGridColumnHeader columnHeader = dataGridColumn.HeaderCell;
                 Debug.Assert(columnHeader.OwningColumn == dataGridColumn);
+                GetColumnHeaderVerticalBounds(dataGridColumn, finalSize.Height, out double headerTop, out double headerHeight);
 
                 if (dataGridColumn.IsFrozenLeft)
                 {
-                    columnHeader.Arrange(new Rect(frozenLeftEdge, 0, dataGridColumn.LayoutRoundedWidth, finalSize.Height));
+                    columnHeader.Arrange(new Rect(frozenLeftEdge, headerTop, dataGridColumn.LayoutRoundedWidth, headerHeight));
                     columnHeader.Clip = null; // The layout system could have clipped this because it's not aware of our render transform
                     if (DragColumn == dataGridColumn && DragIndicator != null)
                     {
@@ -190,7 +214,7 @@ internal
                 }
                 else if (dataGridColumn.IsFrozenRight)
                 {
-                    columnHeader.Arrange(new Rect(rightFrozenEdge, 0, dataGridColumn.LayoutRoundedWidth, finalSize.Height));
+                    columnHeader.Arrange(new Rect(rightFrozenEdge, headerTop, dataGridColumn.LayoutRoundedWidth, headerHeight));
                     columnHeader.Clip = null; // The layout system could have clipped this because it's not aware of our render transform
                     if (DragColumn == dataGridColumn && DragIndicator != null)
                     {
@@ -200,8 +224,8 @@ internal
                 }
                 else
                 {
-                    columnHeader.Arrange(new Rect(scrollingLeftEdge, 0, dataGridColumn.LayoutRoundedWidth, finalSize.Height));
-                    EnsureColumnHeaderClip(columnHeader, dataGridColumn.ActualWidth, finalSize.Height, frozenLeftWidth, rightFrozenStart, scrollingLeftEdge);
+                    columnHeader.Arrange(new Rect(scrollingLeftEdge, headerTop, dataGridColumn.LayoutRoundedWidth, headerHeight));
+                    EnsureColumnHeaderClip(columnHeader, dataGridColumn.ActualWidth, headerHeight, frozenLeftWidth, rightFrozenStart, scrollingLeftEdge);
                     if (DragColumn == dataGridColumn && DragIndicator != null)
                     {
                         dragIndicatorLeftEdge = scrollingLeftEdge + DragIndicatorOffset;
@@ -210,6 +234,9 @@ internal
                 }
                 scrollingLeftEdge += dataGridColumn.ActualWidth;
             }
+
+            ArrangeBandHeaderCells(finalSize.Height, frozenLeftWidth, rightFrozenStart);
+
             if (DragColumn != null)
             {
                 if (DragIndicator != null)
@@ -350,6 +377,8 @@ internal
             {
                 return default;
             }
+            UpdateBandHeaderCells();
+
             double height = OwningGrid.ColumnHeaderHeight;
             bool autoSizeHeight;
             if (double.IsNaN(height))
@@ -431,6 +460,20 @@ internal
                 }
             }
 
+            foreach (DataGridColumnBandHeaderCell bandHeader in _bandHeaderCells)
+            {
+                bandHeader.Measure(new Size(GetBandHeaderWidth(bandHeader), double.PositiveInfinity));
+                if (autoSizeHeight)
+                {
+                    height = Math.Max(height, bandHeader.DesiredSize.Height);
+                }
+            }
+
+            if (autoSizeHeight && _bandHeaderRowCount > 1)
+            {
+                height *= _bandHeaderRowCount;
+            }
+
             // Add the filler column if it's not represented.  We won't know whether we need it or not until Arrange
             DataGridFillerColumn fillerColumn = OwningGrid.ColumnsInternal.FillerColumn;
             if (!fillerColumn.IsRepresented)
@@ -456,6 +499,224 @@ internal
 
             OwningGrid.ColumnsInternal.EnsureVisibleEdgedColumnsWidth();
             return new Size(OwningGrid.ColumnsInternal.VisibleEdgedColumnsWidth, height);
+        }
+
+        private void UpdateBandHeaderCells()
+        {
+            _visibleBandColumns.Clear();
+            int maximumDepth = 1;
+            bool hasGroupedHeaders = false;
+
+            foreach (DataGridColumn column in OwningGrid.ColumnsInternal.GetVisibleColumns())
+            {
+                _visibleBandColumns.Add(column);
+                if (TryGetGroupedHeader(column, out ColumnBandHeader header))
+                {
+                    hasGroupedHeaders = true;
+                    maximumDepth = Math.Max(maximumDepth, header.Segments.Count);
+                }
+            }
+
+            _bandHeaderRowCount = hasGroupedHeaders ? maximumDepth : 1;
+            int bandCellIndex = 0;
+            if (hasGroupedHeaders)
+            {
+                for (int level = 0; level < maximumDepth - 1; level++)
+                {
+                    int columnIndex = 0;
+                    while (columnIndex < _visibleBandColumns.Count)
+                    {
+                        DataGridColumn startColumn = _visibleBandColumns[columnIndex];
+                        if (!TryGetGroupedHeader(startColumn, out ColumnBandHeader startHeader) ||
+                            startHeader.Segments.Count <= level + 1)
+                        {
+                            columnIndex++;
+                            continue;
+                        }
+
+                        int startIndex = columnIndex;
+                        columnIndex++;
+                        while (columnIndex < _visibleBandColumns.Count &&
+                               IsSameBandGroup(startColumn, startHeader, _visibleBandColumns[columnIndex], level))
+                        {
+                            columnIndex++;
+                        }
+
+                        DataGridColumnBandHeaderCell cell = GetOrCreateBandHeaderCell(bandCellIndex++);
+                        cell.Content = startHeader.Segments[level];
+                        cell.StartColumnIndex = startIndex;
+                        cell.EndColumnIndex = columnIndex - 1;
+                        cell.Level = level;
+                        cell.IsFrozenLeft = startColumn.IsFrozenLeft;
+                        cell.IsFrozenRight = startColumn.IsFrozenRight;
+                    }
+                }
+            }
+
+            while (_bandHeaderCells.Count > bandCellIndex)
+            {
+                int index = _bandHeaderCells.Count - 1;
+                DataGridColumnBandHeaderCell cell = _bandHeaderCells[index];
+                _bandHeaderCells.RemoveAt(index);
+                Children.Remove(cell);
+            }
+        }
+
+        private DataGridColumnBandHeaderCell GetOrCreateBandHeaderCell(int index)
+        {
+            if (index < _bandHeaderCells.Count)
+            {
+                DataGridColumnBandHeaderCell existing = _bandHeaderCells[index];
+                EnsureBandHeaderCellTheme(existing);
+                if (!Children.Contains(existing))
+                {
+                    Children.Add(existing);
+                }
+
+                return existing;
+            }
+
+            DataGridColumnBandHeaderCell cell = new DataGridColumnBandHeaderCell();
+            EnsureBandHeaderCellTheme(cell);
+            _bandHeaderCells.Add(cell);
+            Children.Add(cell);
+            return cell;
+        }
+
+        private void EnsureBandHeaderCellTheme(DataGridColumnBandHeaderCell cell)
+        {
+            if (cell.Theme == null &&
+                OwningGrid.TryFindResource(typeof(DataGridColumnBandHeaderCell), out object theme) &&
+                theme is ControlTheme controlTheme)
+            {
+                cell.Theme = controlTheme;
+            }
+        }
+
+        private void GetColumnHeaderVerticalBounds(
+            DataGridColumn column,
+            double totalHeight,
+            out double top,
+            out double height)
+        {
+            if (_bandHeaderRowCount > 1 && TryGetGroupedHeader(column, out ColumnBandHeader header))
+            {
+                double rowHeight = totalHeight / _bandHeaderRowCount;
+                int leafLevel = Math.Max(0, header.Segments.Count - 1);
+                top = leafLevel * rowHeight;
+                height = totalHeight - top;
+                return;
+            }
+
+            top = 0;
+            height = totalHeight;
+        }
+
+        private void ArrangeBandHeaderCells(double totalHeight, double frozenLeftWidth, double rightFrozenStart)
+        {
+            if (_bandHeaderCells.Count == 0 || _bandHeaderRowCount <= 1)
+            {
+                return;
+            }
+
+            double rowHeight = totalHeight / _bandHeaderRowCount;
+            foreach (DataGridColumnBandHeaderCell cell in _bandHeaderCells)
+            {
+                if ((uint)cell.StartColumnIndex >= (uint)_visibleBandColumns.Count ||
+                    (uint)cell.EndColumnIndex >= (uint)_visibleBandColumns.Count)
+                {
+                    continue;
+                }
+
+                DataGridColumnHeader firstHeader = _visibleBandColumns[cell.StartColumnIndex].HeaderCell;
+                DataGridColumnHeader lastHeader = _visibleBandColumns[cell.EndColumnIndex].HeaderCell;
+                double left = firstHeader.Bounds.X;
+                double width = Math.Max(0, lastHeader.Bounds.Right - left);
+                cell.Arrange(new Rect(left, cell.Level * rowHeight, width, rowHeight));
+
+                if (cell.IsFrozenLeft || cell.IsFrozenRight)
+                {
+                    cell.Clip = null;
+                }
+                else
+                {
+                    EnsureControlClip(cell, width, rowHeight, frozenLeftWidth, rightFrozenStart, left);
+                }
+            }
+        }
+
+        private double GetBandHeaderWidth(DataGridColumnBandHeaderCell cell)
+        {
+            if ((uint)cell.StartColumnIndex >= (uint)_visibleBandColumns.Count ||
+                (uint)cell.EndColumnIndex >= (uint)_visibleBandColumns.Count)
+            {
+                return 0;
+            }
+
+            double width = 0;
+            for (int index = cell.StartColumnIndex; index <= cell.EndColumnIndex; index++)
+            {
+                width += _visibleBandColumns[index].ActualWidth;
+            }
+
+            return width;
+        }
+
+        private static bool TryGetGroupedHeader(DataGridColumn column, out ColumnBandHeader header)
+        {
+            header = column?.Header as ColumnBandHeader;
+            return header?.Layout == ColumnBandHeaderLayout.Grouped && header.Segments.Count > 0;
+        }
+
+        private static bool IsSameBandGroup(
+            DataGridColumn startColumn,
+            ColumnBandHeader startHeader,
+            DataGridColumn candidateColumn,
+            int level)
+        {
+            if (candidateColumn.IsFrozenLeft != startColumn.IsFrozenLeft ||
+                candidateColumn.IsFrozenRight != startColumn.IsFrozenRight ||
+                !TryGetGroupedHeader(candidateColumn, out ColumnBandHeader candidateHeader) ||
+                candidateHeader.Segments.Count <= level + 1)
+            {
+                return false;
+            }
+
+            for (int index = 0; index <= level; index++)
+            {
+                if (!string.Equals(startHeader.Segments[index], candidateHeader.Segments[index], StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static void EnsureControlClip(
+            Control control,
+            double width,
+            double height,
+            double frozenLeftWidth,
+            double rightFrozenStart,
+            double leftEdge)
+        {
+            double leftClip = Math.Max(0, frozenLeftWidth - leftEdge);
+            double rightClip = rightFrozenStart < double.PositiveInfinity
+                ? Math.Max(0, (leftEdge + width) - rightFrozenStart)
+                : 0;
+
+            if (leftClip > 0 || rightClip > 0)
+            {
+                control.Clip = new RectangleGeometry
+                {
+                    Rect = new Rect(leftClip, 0, Math.Max(0, width - leftClip - rightClip), height)
+                };
+            }
+            else
+            {
+                control.Clip = null;
+            }
         }
 
         protected override void ChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -195,6 +195,7 @@
       <x:Double x:Key="DataGridFilterEnumEditorWidth">240</x:Double>
       <x:Double x:Key="DataGridPivotHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridColumnBandHeaderSegmentsSpacing">2</x:Double>
+      <Thickness x:Key="DataGridColumnBandHeaderBorderThickness">0,0,1,1</Thickness>
       <x:Double x:Key="DataGridFilterButtonSize">22</x:Double>
       <x:Double x:Key="DataGridFilterGlyphSize">12</x:Double>
       <x:Double x:Key="DataGridFilterGlyphStrokeThickness">1.2</x:Double>

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -148,7 +148,7 @@
 
       <DataTemplate x:Key="DataGridColumnBandHeaderTemplate"
                     x:DataType="banding:ColumnBandHeader">
-        <ItemsControl ItemsSource="{Binding Segments}">
+        <ItemsControl ItemsSource="{Binding DisplaySegments}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <StackPanel Spacing="{DynamicResource DataGridColumnBandHeaderSegmentsSpacing}" />
@@ -163,6 +163,32 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
       </DataTemplate>
+
+      <ControlTheme x:Key="{x:Type banding:DataGridColumnBandHeaderCell}"
+                    TargetType="banding:DataGridColumnBandHeaderCell">
+        <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForegroundBrush}" />
+        <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource DataGridColumnBandHeaderBorderThickness}" />
+        <Setter Property="Padding" Value="{DynamicResource DataGridColumnHeaderPadding}" />
+        <Setter Property="FontSize" Value="{DynamicResource DataGridColumnHeaderFontSize}" />
+        <Setter Property="MinHeight" Value="{DynamicResource DataGridColumnHeaderMinHeight}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+          <ControlTemplate>
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}">
+              <ContentPresenter Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </Border>
+          </ControlTemplate>
+        </Setter>
+      </ControlTheme>
 
       <DataTemplate x:Key="DataGridPivotRowHeaderTemplate"
                     x:DataType="pivoting:PivotRow">

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -129,6 +129,7 @@
       <x:Double x:Key="DataGridFilterEnumEditorWidth">240</x:Double>
       <x:Double x:Key="DataGridPivotHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridColumnBandHeaderSegmentsSpacing">2</x:Double>
+      <Thickness x:Key="DataGridColumnBandHeaderBorderThickness">0,0,1,1</Thickness>
       <x:Double x:Key="DataGridFilterButtonSize">22</x:Double>
       <x:Double x:Key="DataGridFilterGlyphSize">12</x:Double>
       <x:Double x:Key="DataGridFilterGlyphStrokeThickness">1.2</x:Double>

--- a/src/DataGridSample/Pages/ColumnBandingPage.axaml
+++ b/src/DataGridSample/Pages/ColumnBandingPage.axaml
@@ -11,8 +11,8 @@
     </StackPanel>
 
     <DataGrid Grid.Row="1"
-              ItemsSource="{Binding Source}"
-              ColumnDefinitionsSource="{Binding Bands.ColumnDefinitions}"
+              ItemsSource="{CompiledBinding Source}"
+              ColumnDefinitionsSource="{CompiledBinding Bands.ColumnDefinitions}"
               AutoGenerateColumns="False"
               IsReadOnly="True"
               HeadersVisibility="All"

--- a/src/DataGridSample/ViewModels/ColumnBandingViewModel.cs
+++ b/src/DataGridSample/ViewModels/ColumnBandingViewModel.cs
@@ -22,7 +22,10 @@ namespace DataGridSample.ViewModels
 
         private static ColumnBandModel BuildBands()
         {
-            var model = new ColumnBandModel();
+            var model = new ColumnBandModel
+            {
+                HeaderLayout = ColumnBandHeaderLayout.Grouped
+            };
 
             var orderDateBinding = ColumnDefinitionBindingFactory.CreateBinding<SalesRecord, DateTime>(
                 nameof(SalesRecord.OrderDate),


### PR DESCRIPTION
## Summary

- add opt-in `ColumnBandHeaderLayout.Grouped` rendering for conventional horizontally spanning band headers
- render shared band ancestors once across contiguous leaf columns instead of repeating the full path inside every column
- let shallow leaves span the unused header rows while deeper branches retain their nested group levels
- split group cells at left/right frozen-column boundaries so frozen and scrolling coordinate spaces remain correct
- keep the existing stacked layout as the compatibility default
- update the Column Banding sample and documentation to demonstrate the grouped layout with compiled bindings

## Result

The sample band tree now renders in this structure:

```text
|         Order         |      Merchandise      |          Financials          |
| Date | Region | Segment | Category | Product |      Revenue      |  Volume  |
|      |        |         |          |         | Sales | Profit    |  Units   |
```

Set the layout on the existing model:

```csharp
var model = new ColumnBandModel
{
    HeaderLayout = ColumnBandHeaderLayout.Grouped
};
```

`Stacked` remains the default and preserves the previous behavior where every leaf displays its complete path.

## Design

### Model contract

`ColumnBandHeader` now carries both the complete root-to-leaf `Segments` path and the selected `Layout`. `DisplaySegments` keeps the existing data template reusable: stacked headers display the full path, while grouped leaf headers display only their final segment.

Changing `ColumnBandModel.HeaderLayout` requests the normal model refresh, so all materialized definitions receive updated header metadata without view code or reflection.

### Header composition

`DataGridColumnHeadersPresenter` derives grouped cells from visible columns during measurement:

- contiguous columns with the same prefix share one `DataGridColumnBandHeaderCell`
- prefix comparisons include the complete ancestor path, preventing unrelated equal labels from merging
- group cells are reused across layout passes
- leaf headers are arranged at their depth and span all remaining rows
- grouped cells are measured as a row, then arranged over the summed leaf-column bounds
- scrolling cells use the same frozen-region clipping boundaries as normal headers
- a band crossing a frozen boundary is split into separate visual cells because those sections move in different coordinate spaces

The spanning cells are non-interactive. Sorting, filtering, resizing, reordering, focus, and automation for actual columns remain on the existing leaf `DataGridColumnHeader` controls.

### Styling

`DataGridColumnBandHeaderCell` has a dedicated control theme and the new `DataGridColumnBandHeaderBorderThickness` token in both Simple and Fluent themes. Applications can restyle the public band-cell type without replacing grid input logic.

## Tests

Added headless coverage for:

- exact horizontal spans for top-level and nested groups
- vertical row spans for shallow leaves
- nested Revenue → Sales/Profit geometry
- frozen-boundary splitting
- switching the model from stacked to grouped layout
- Simple/Fluent theme resource and token contracts

Validation:

- grouped-band and theme suite: **19 passed**
- complete `Avalonia.Controls.DataGrid.UnitTests` project: **2253 passed**
- DataGrid sample build: succeeded
- multi-target DataGrid library build (`net8.0`, `net10.0`): succeeded
- deterministic headless render: **540×260 PNG**, 9,048 bytes, SHA-256 `46b9d7b92668fae7c98e57f712b87b96eed272016961b9df62f186be59dbecfc`

Fixes #294

## Review hardening

Follow-up review extended grouped-header auto sizing: a spanning group header contributes its natural measured width across eligible Auto/SizeToHeader leaf columns, distributes only the unmet width, and respects each column's maximum.

Current validation: **5/5** focused banded-header tests and the complete **2,255-test** unit suite pass. Review threads are resolved.
