### PR TITLE
Add column width sharing across grids

### DIFF
--- a/docfx/articles/columns-and-editing.md
+++ b/docfx/articles/columns-and-editing.md
@@ -64,6 +64,60 @@ Double-click the column header resize handle to fit the column to visible conten
           CanUserReorderColumns="True" />
 ```
 
+### Sharing widths across grids
+
+Use one `DataGridColumnWidthSharingScope` resource for every grid that should participate, then assign the same `WidthSharingGroup` to corresponding column definitions. The scope starts a group at its largest registered width and propagates later programmatic, automatic, and user-initiated width changes in either direction.
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sizing="using:Avalonia.Controls.DataGridSizing"
+             xmlns:vm="using:MyApp.ViewModels"
+             x:DataType="vm:ComparisonViewModel">
+  <UserControl.Resources>
+    <sizing:DataGridColumnWidthSharingScope x:Key="ComparisonColumnWidths" />
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="*,*">
+    <DataGrid ItemsSource="{CompiledBinding CurrentItems}"
+              ColumnDefinitionsSource="{CompiledBinding CurrentColumns}"
+              ColumnWidthSharingScope="{StaticResource ComparisonColumnWidths}"
+              AutoGenerateColumns="False" />
+    <DataGrid Grid.Row="1"
+              ItemsSource="{CompiledBinding BaselineItems}"
+              ColumnDefinitionsSource="{CompiledBinding BaselineColumns}"
+              ColumnWidthSharingScope="{StaticResource ComparisonColumnWidths}"
+              AutoGenerateColumns="False" />
+  </Grid>
+</UserControl>
+```
+
+```csharp
+public sealed class ComparisonViewModel : ReactiveObject
+{
+    public DataGridColumnDefinitionList CurrentColumns { get; } = CreateColumns();
+    public DataGridColumnDefinitionList BaselineColumns { get; } = CreateColumns();
+
+    private static DataGridColumnDefinitionList CreateColumns() => new()
+    {
+        new DataGridTextColumnDefinition
+        {
+            Header = "Name",
+            Width = DataGridLength.Auto,
+            WidthSharingGroup = "name"
+        },
+        new DataGridNumericColumnDefinition
+        {
+            Header = "Amount",
+            Width = new DataGridLength(120),
+            WidthSharingGroup = "amount"
+        }
+    };
+}
+```
+
+For columns declared directly in XAML, set `sizing:DataGridColumnWidthSharing.Group="name"` instead. Group names are case-sensitive. Pixel columns remain pixel-sized, intrinsic sizing modes such as `Auto` are preserved, and star columns become pixel columns when synchronized because an exact width must be shared across grids with potentially different available space. The scope respects the common `MinWidth`/`MaxWidth` range; if constraints do not overlap, each column is clamped to its own range. Remove the group or scope to stop synchronization. Call `Synchronize()` when you need to recompute a group from the largest current width explicitly.
+
 ## Headers, Sorting, and Filters
 
 Columns expose header content and sorting metadata:

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -315,6 +315,30 @@ public class DataGridColumnWidthSharingTests
     }
 
     [Fact]
+    public void Unmeasured_Star_Column_Does_Not_Clamp_Measured_Participant()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn measuredColumn = CreateColumn(10, "name");
+        measuredColumn.MinWidth = 0;
+        DataGridTextColumn unmeasuredStarColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star),
+            "name");
+
+        CreateGrid(scope, measuredColumn);
+        CreateGrid(scope, unmeasuredStarColumn);
+
+        Assert.Equal(10, measuredColumn.ActualWidth);
+        Assert.True(unmeasuredStarColumn.Width.IsStar);
+
+        unmeasuredStarColumn.SetWidthInternalNoCallback(
+            new DataGridLength(1, DataGridLengthUnitType.Star, 30, 30));
+        unmeasuredStarColumn.IsInitialDesiredWidthDetermined = true;
+
+        Assert.Equal(30, measuredColumn.ActualWidth);
+        Assert.Equal(30, unmeasuredStarColumn.ActualWidth);
+    }
+
+    [Fact]
     public void First_Measure_Completion_Reports_Previously_Unmeasured_Star_Columns()
     {
         var scope = new DataGridColumnWidthSharingScope();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridSizing;
+using Avalonia.Headless.XUnit;
 using Avalonia.Markup.Xaml;
 using Xunit;
 
@@ -105,6 +106,37 @@ public class DataGridColumnWidthSharingTests
 
         Assert.Equal(220, firstColumn.ActualWidth);
         Assert.Equal(160, secondColumn.ActualWidth);
+    }
+
+    [AvaloniaFact]
+    public void Reattached_Grid_Reregisters_Columns_Pruned_While_Detached()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn detachedColumn = CreateColumn(100, "name");
+        DataGridTextColumn activeColumn = CreateColumn(150, "name");
+        DataGrid detachedGrid = CreateGrid(scope, detachedColumn);
+        CreateGrid(scope, activeColumn);
+        var root = new Window { Content = detachedGrid };
+
+        try
+        {
+            root.Show();
+            root.Content = null;
+
+            activeColumn.Width = new DataGridLength(210);
+            root.Content = detachedGrid;
+            root.UpdateLayout();
+
+            Assert.Equal(210, detachedColumn.ActualWidth);
+
+            activeColumn.Width = new DataGridLength(240);
+
+            Assert.Equal(240, detachedColumn.ActualWidth);
+        }
+        finally
+        {
+            root.Close();
+        }
     }
 
     [Fact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -147,6 +147,26 @@ public class DataGridColumnWidthSharingTests
     }
 
     [Fact]
+    public void Scope_Does_Not_Convert_Unmeasured_Star_Columns_During_Registration()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star),
+            "name");
+        DataGridTextColumn secondColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star),
+            "name");
+
+        CreateGrid(scope, firstColumn);
+        Assert.True(firstColumn.Width.IsStar);
+
+        CreateGrid(scope, secondColumn);
+
+        Assert.True(firstColumn.Width.IsStar);
+        Assert.True(secondColumn.Width.IsStar);
+    }
+
+    [Fact]
     public void Inherited_Grid_ColumnWidth_Changes_Are_Shared()
     {
         var scope = new DataGridColumnWidthSharingScope();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridSizing;
+using Avalonia.Markup.Xaml;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Sizing;
+
+public class DataGridColumnWidthSharingTests
+{
+    [Fact]
+    public void Scope_Uses_Largest_Initial_Width_And_Propagates_Later_Changes()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(100, "name");
+        DataGridTextColumn secondColumn = CreateColumn(180, "name");
+
+        DataGrid firstGrid = CreateGrid(scope, firstColumn);
+        DataGrid secondGrid = CreateGrid(scope, secondColumn);
+
+        Assert.Equal(180, firstColumn.ActualWidth);
+        Assert.Equal(180, secondColumn.ActualWidth);
+
+        firstColumn.Resize(firstColumn.Width, new DataGridLength(240), userInitiated: true);
+
+        Assert.Equal(240, firstColumn.ActualWidth);
+        Assert.Equal(240, secondColumn.ActualWidth);
+
+        secondColumn.Width = new DataGridLength(80);
+
+        Assert.Equal(80, firstColumn.ActualWidth);
+        Assert.Equal(80, secondColumn.ActualWidth);
+        Assert.Same(scope, firstGrid.ColumnWidthSharingScope);
+        Assert.Same(scope, secondGrid.ColumnWidthSharingScope);
+    }
+
+    [Fact]
+    public void Scope_Keeps_Different_Groups_Independent()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn nameColumn = CreateColumn(100, "name");
+        DataGridTextColumn amountColumn = CreateColumn(160, "amount");
+        CreateGrid(scope, nameColumn);
+        CreateGrid(scope, amountColumn);
+
+        nameColumn.Width = new DataGridLength(225);
+
+        Assert.Equal(225, nameColumn.ActualWidth);
+        Assert.Equal(160, amountColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Removed_Column_Is_No_Longer_Synchronized()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(100, "name");
+        DataGridTextColumn removedColumn = CreateColumn(140, "name");
+        CreateGrid(scope, firstColumn);
+        DataGrid secondGrid = CreateGrid(scope, removedColumn);
+
+        secondGrid.Columns.Remove(removedColumn);
+        var independentGrid = new DataGrid();
+        independentGrid.Columns.Add(removedColumn);
+        firstColumn.Width = new DataGridLength(260);
+
+        Assert.Equal(260, firstColumn.ActualWidth);
+        Assert.Equal(140, removedColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Changing_Group_Updates_Registration()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(100, "name");
+        DataGridTextColumn secondColumn = CreateColumn(160, "name");
+        CreateGrid(scope, firstColumn);
+        CreateGrid(scope, secondColumn);
+
+        DataGridColumnWidthSharing.SetGroup(secondColumn, "other");
+        firstColumn.Width = new DataGridLength(210);
+
+        Assert.Equal(210, firstColumn.ActualWidth);
+        Assert.Equal(160, secondColumn.ActualWidth);
+
+        DataGridColumnWidthSharing.SetGroup(secondColumn, "name");
+
+        Assert.Equal(210, secondColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Changing_Grid_Scope_Unregisters_Columns_From_The_Old_Scope()
+    {
+        var oldScope = new DataGridColumnWidthSharingScope();
+        var newScope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(100, "name");
+        DataGridTextColumn secondColumn = CreateColumn(160, "name");
+        CreateGrid(oldScope, firstColumn);
+        DataGrid secondGrid = CreateGrid(oldScope, secondColumn);
+
+        secondGrid.ColumnWidthSharingScope = newScope;
+        firstColumn.Width = new DataGridLength(220);
+
+        Assert.Equal(220, firstColumn.ActualWidth);
+        Assert.Equal(160, secondColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Scope_Uses_Common_Constraints_And_Preserves_Auto_Sizing_Mode()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn constrainedColumn = CreateColumn(100, "name");
+        constrainedColumn.MaxWidth = 150;
+        DataGridTextColumn autoColumn = CreateColumn(DataGridLength.Auto, "name");
+        CreateGrid(scope, constrainedColumn);
+        CreateGrid(scope, autoColumn);
+
+        autoColumn.Width = new DataGridLength(220);
+
+        Assert.Equal(150, constrainedColumn.ActualWidth);
+        Assert.Equal(150, autoColumn.ActualWidth);
+
+        autoColumn.Width = DataGridLength.Auto;
+        scope.Synchronize();
+
+        Assert.True(autoColumn.Width.IsAuto);
+        Assert.Equal(constrainedColumn.ActualWidth, autoColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Column_Definitions_Apply_And_Update_Width_Sharing_Group()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        var firstDefinition = new DataGridTextColumnDefinition
+        {
+            Width = new DataGridLength(100),
+            WidthSharingGroup = "name"
+        };
+        var secondDefinition = new DataGridTextColumnDefinition
+        {
+            Width = new DataGridLength(175),
+            WidthSharingGroup = "name"
+        };
+        DataGrid firstGrid = CreateGrid(scope, firstDefinition);
+        DataGrid secondGrid = CreateGrid(scope, secondDefinition);
+        DataGridColumn firstColumn = firstGrid.Columns[0];
+        DataGridColumn secondColumn = secondGrid.Columns[0];
+
+        Assert.Equal("name", DataGridColumnWidthSharing.GetGroup(firstColumn));
+        Assert.Equal(175, firstColumn.ActualWidth);
+        Assert.Equal(175, secondColumn.ActualWidth);
+
+        secondDefinition.WidthSharingGroup = "other";
+        firstColumn.Width = new DataGridLength(230);
+
+        Assert.Equal("other", DataGridColumnWidthSharing.GetGroup(secondColumn));
+        Assert.Equal(230, firstColumn.ActualWidth);
+        Assert.Equal(175, secondColumn.ActualWidth);
+    }
+
+    [Fact]
+    public void Scope_And_Attached_Group_Can_Be_Configured_In_Xaml()
+    {
+        const string xaml = """
+                            <StackPanel xmlns="https://github.com/avaloniaui"
+                                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                        xmlns:sizing="using:Avalonia.Controls.DataGridSizing">
+                              <StackPanel.Resources>
+                                <sizing:DataGridColumnWidthSharingScope x:Key="SharedWidths" />
+                              </StackPanel.Resources>
+                              <DataGrid ColumnWidthSharingScope="{StaticResource SharedWidths}">
+                                <DataGrid.Columns>
+                                  <DataGridTextColumn Width="100"
+                                                      sizing:DataGridColumnWidthSharing.Group="name" />
+                                </DataGrid.Columns>
+                              </DataGrid>
+                              <DataGrid ColumnWidthSharingScope="{StaticResource SharedWidths}">
+                                <DataGrid.Columns>
+                                  <DataGridTextColumn Width="180"
+                                                      sizing:DataGridColumnWidthSharing.Group="name" />
+                                </DataGrid.Columns>
+                              </DataGrid>
+                            </StackPanel>
+                            """;
+
+        StackPanel panel = AvaloniaRuntimeXamlLoader.Parse<StackPanel>(xaml, typeof(DataGrid).Assembly);
+        DataGrid firstGrid = Assert.IsType<DataGrid>(panel.Children[0]);
+        DataGrid secondGrid = Assert.IsType<DataGrid>(panel.Children[1]);
+
+        Assert.Same(firstGrid.ColumnWidthSharingScope, secondGrid.ColumnWidthSharingScope);
+        Assert.Equal(180, firstGrid.Columns[0].ActualWidth);
+        Assert.Equal(180, secondGrid.Columns[0].ActualWidth);
+    }
+
+    private static DataGridTextColumn CreateColumn(double width, string group)
+    {
+        return CreateColumn(new DataGridLength(width), group);
+    }
+
+    private static DataGridTextColumn CreateColumn(DataGridLength width, string group)
+    {
+        var column = new DataGridTextColumn
+        {
+            Width = width
+        };
+        DataGridColumnWidthSharing.SetGroup(column, group);
+        return column;
+    }
+
+    private static DataGrid CreateGrid(
+        DataGridColumnWidthSharingScope scope,
+        DataGridColumn column)
+    {
+        var grid = new DataGrid
+        {
+            ColumnWidthSharingScope = scope
+        };
+        grid.Columns.Add(column);
+        return grid;
+    }
+
+    private static DataGrid CreateGrid(
+        DataGridColumnWidthSharingScope scope,
+        DataGridColumnDefinition definition)
+    {
+        return new DataGrid
+        {
+            ColumnWidthSharingScope = scope,
+            ColumnDefinitionsSource = new ObservableCollection<DataGridColumnDefinition> { definition }
+        };
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -139,6 +139,43 @@ public class DataGridColumnWidthSharingTests
         }
     }
 
+    [AvaloniaFact]
+    public void Detached_Grid_Scope_Change_Removes_Old_Scope_Registration()
+    {
+        var oldScope = new DataGridColumnWidthSharingScope();
+        var newScope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn oldScopeColumn = CreateColumn(100, "name");
+        DataGridTextColumn movedColumn = CreateColumn(150, "name");
+        DataGridTextColumn newScopeColumn = CreateColumn(175, "name");
+        CreateGrid(oldScope, oldScopeColumn);
+        DataGrid movedGrid = CreateGrid(oldScope, movedColumn);
+        CreateGrid(newScope, newScopeColumn);
+        var root = new Window { Content = movedGrid };
+
+        try
+        {
+            root.Show();
+            root.Content = null;
+            movedGrid.ColumnWidthSharingScope = newScope;
+            root.Content = movedGrid;
+            root.UpdateLayout();
+
+            Assert.Equal(175, movedColumn.ActualWidth);
+
+            oldScopeColumn.Width = new DataGridLength(220);
+
+            Assert.Equal(175, movedColumn.ActualWidth);
+
+            newScopeColumn.Width = new DataGridLength(240);
+
+            Assert.Equal(240, movedColumn.ActualWidth);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
     [Fact]
     public void Scope_Uses_Common_Constraints_And_Preserves_Auto_Sizing_Mode()
     {
@@ -196,6 +233,32 @@ public class DataGridColumnWidthSharingTests
 
         Assert.True(firstColumn.Width.IsStar);
         Assert.True(secondColumn.Width.IsStar);
+    }
+
+    [Fact]
+    public void First_Measure_Completion_Reports_Previously_Unmeasured_Star_Columns()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn firstColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star),
+            "name");
+        DataGridTextColumn secondColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star),
+            "name");
+        CreateGrid(scope, firstColumn);
+        CreateGrid(scope, secondColumn);
+
+        firstColumn.SetWidthInternalNoCallback(
+            new DataGridLength(1, DataGridLengthUnitType.Star, 100, 100));
+        firstColumn.IsInitialDesiredWidthDetermined = true;
+        secondColumn.SetWidthInternalNoCallback(
+            new DataGridLength(1, DataGridLengthUnitType.Star, 180, 180));
+        secondColumn.IsInitialDesiredWidthDetermined = true;
+
+        Assert.True(firstColumn.Width.IsAbsolute);
+        Assert.True(secondColumn.Width.IsAbsolute);
+        Assert.Equal(180, firstColumn.ActualWidth);
+        Assert.Equal(firstColumn.ActualWidth, secondColumn.ActualWidth);
     }
 
     [Fact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -140,6 +140,85 @@ public class DataGridColumnWidthSharingTests
     }
 
     [AvaloniaFact]
+    public void Reattached_Grid_Adopts_Active_Group_Width_Instead_Of_Stale_Width()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn detachedColumn = CreateColumn(200, "name");
+        DataGridTextColumn activeColumn = CreateColumn(100, "name");
+        DataGrid detachedGrid = CreateGrid(scope, detachedColumn);
+        CreateGrid(scope, activeColumn);
+        var root = new Window { Content = detachedGrid };
+
+        try
+        {
+            root.Show();
+            root.Content = null;
+
+            activeColumn.Width = new DataGridLength(100);
+            Assert.Equal(100, activeColumn.ActualWidth);
+            detachedColumn.Width = new DataGridLength(200);
+
+            root.Content = detachedGrid;
+            root.UpdateLayout();
+
+            Assert.Equal(100, detachedColumn.ActualWidth);
+            Assert.Equal(100, activeColumn.ActualWidth);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Width_Adjustment_Side_Effects_Are_Reported_To_Shared_Participants()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn leadingColumn = CreateColumn(100, group: null);
+        DataGridTextColumn adjustedColumn = CreateColumn(160, "name");
+        DataGridTextColumn peerColumn = CreateColumn(160, "name");
+        DataGrid firstGrid = CreateGrid(scope, leadingColumn);
+        firstGrid.Columns.Add(adjustedColumn);
+        DataGrid secondGrid = CreateGrid(scope, peerColumn);
+        firstGrid.CanUserResizeColumns = true;
+        firstGrid.Height = 120;
+        secondGrid.Height = 120;
+        var root = new Window
+        {
+            Width = 500,
+            Height = 300,
+            Content = new StackPanel
+            {
+                Children =
+                {
+                    firstGrid,
+                    secondGrid
+                }
+            }
+        };
+
+        try
+        {
+            root.Show();
+            root.UpdateLayout();
+
+            double startingWidth = adjustedColumn.ActualWidth;
+            double remaining = firstGrid.DecreaseColumnWidths(
+                adjustedColumn.DisplayIndex,
+                amount: -40,
+                userInitiated: false);
+
+            Assert.Equal(0, remaining);
+            Assert.Equal(startingWidth - 40, adjustedColumn.ActualWidth);
+            Assert.Equal(adjustedColumn.ActualWidth, peerColumn.ActualWidth);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Detached_Grid_Scope_Change_Removes_Old_Scope_Registration()
     {
         var oldScope = new DataGridColumnWidthSharingScope();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -147,6 +147,31 @@ public class DataGridColumnWidthSharingTests
     }
 
     [Fact]
+    public void Inherited_Grid_ColumnWidth_Changes_Are_Shared()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        var firstColumn = new DataGridTextColumn();
+        var secondColumn = new DataGridTextColumn();
+        DataGridColumnWidthSharing.SetGroup(firstColumn, "name");
+        DataGridColumnWidthSharing.SetGroup(secondColumn, "name");
+        DataGrid firstGrid = CreateGrid(scope, firstColumn);
+        DataGrid secondGrid = CreateGrid(scope, secondColumn);
+
+        Assert.True(firstColumn.InheritsWidth);
+        Assert.True(secondColumn.InheritsWidth);
+
+        firstGrid.ColumnWidth = new DataGridLength(165);
+
+        Assert.Equal(165, firstColumn.ActualWidth);
+        Assert.Equal(165, secondColumn.ActualWidth);
+
+        secondGrid.ColumnWidth = new DataGridLength(210);
+
+        Assert.Equal(210, firstColumn.ActualWidth);
+        Assert.Equal(210, secondColumn.ActualWidth);
+    }
+
+    [Fact]
     public void Column_Definitions_Apply_And_Update_Width_Sharing_Group()
     {
         var scope = new DataGridColumnWidthSharingScope();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sizing/DataGridColumnWidthSharingTests.cs
@@ -130,6 +130,23 @@ public class DataGridColumnWidthSharingTests
     }
 
     [Fact]
+    public void Scope_Converts_Equal_Width_Star_Column_To_Synchronized_Pixels()
+    {
+        var scope = new DataGridColumnWidthSharingScope();
+        DataGridTextColumn pixelColumn = CreateColumn(100, "name");
+        DataGridTextColumn starColumn = CreateColumn(
+            new DataGridLength(1, DataGridLengthUnitType.Star, 100, 100),
+            "name");
+
+        CreateGrid(scope, pixelColumn);
+        CreateGrid(scope, starColumn);
+
+        Assert.True(starColumn.Width.IsAbsolute);
+        Assert.Equal(100, starColumn.ActualWidth);
+        Assert.Equal(pixelColumn.ActualWidth, starColumn.ActualWidth);
+    }
+
+    [Fact]
     public void Column_Definitions_Apply_And_Update_Width_Sharing_Group()
     {
         var scope = new DataGridColumnWidthSharingScope();

--- a/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnDefinition.cs
+++ b/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnDefinition.cs
@@ -13,6 +13,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Utilities;
 using Avalonia.Controls.DataGridSearching;
 using Avalonia.Controls.DataGridSorting;
+using Avalonia.Controls.DataGridSizing;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Styling;
@@ -90,6 +91,7 @@ namespace Avalonia.Controls
         private string _sortMemberPath;
         private object _tag;
         private object _columnKey;
+        private string _widthSharingGroup;
         private System.Collections.IComparer _customSortComparer;
         private IDataGridColumnValueAccessor _valueAccessor;
         private Type _valueType;
@@ -273,6 +275,15 @@ namespace Avalonia.Controls
             set => SetProperty(ref _columnKey, value);
         }
 
+        /// <summary>
+        /// Gets or sets the name of the column width-sharing group.
+        /// </summary>
+        public string WidthSharingGroup
+        {
+            get => _widthSharingGroup;
+            set => SetProperty(ref _widthSharingGroup, value);
+        }
+
         public System.Collections.IComparer CustomSortComparer
         {
             get => _customSortComparer;
@@ -397,6 +408,7 @@ namespace Avalonia.Controls
         {
             column.Header = Header;
             column.ColumnKey = ColumnKey;
+            DataGridColumnWidthSharing.SetGroup(column, WidthSharingGroup);
             column.SortMemberPath = SortMemberPath;
             column.Tag = Tag;
             column.CustomSortComparer = CustomSortComparer;
@@ -608,6 +620,9 @@ namespace Avalonia.Controls
                     return true;
                 case nameof(Tag):
                     column.Tag = Tag;
+                    return true;
+                case nameof(WidthSharingGroup):
+                    DataGridColumnWidthSharing.SetGroup(column, WidthSharingGroup);
                     return true;
                 case nameof(CustomSortComparer):
                     column.CustomSortComparer = CustomSortComparer;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
@@ -40,5 +40,17 @@ namespace Avalonia.Controls
         {
             ColumnWidthSharingScope?.UnregisterColumn(column);
         }
+
+        internal void RefreshColumnWidthSharingRegistration()
+        {
+            DataGridColumnWidthSharingScope scope = ColumnWidthSharingScope;
+            if (scope == null)
+            {
+                return;
+            }
+
+            scope.UnregisterGrid(this);
+            scope.RegisterGrid(this);
+        }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
@@ -41,6 +41,11 @@ namespace Avalonia.Controls
             ColumnWidthSharingScope?.UnregisterColumn(column);
         }
 
+        internal void OnColumnWidthSharingColumnMeasured(DataGridColumn column)
+        {
+            ColumnWidthSharingScope?.ReportWidth(column);
+        }
+
         internal void RefreshColumnWidthSharingRegistration()
         {
             DataGridColumnWidthSharingScope scope = ColumnWidthSharingScope;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
@@ -46,6 +46,11 @@ namespace Avalonia.Controls
             ColumnWidthSharingScope?.ReportWidth(column);
         }
 
+        internal void OnColumnWidthSharingSideEffect(DataGridColumn column)
+        {
+            ColumnWidthSharingScope?.ReportWidth(column);
+        }
+
         internal void RefreshColumnWidthSharingRegistration()
         {
             DataGridColumnWidthSharingScope scope = ColumnWidthSharingScope;
@@ -55,7 +60,7 @@ namespace Avalonia.Controls
             }
 
             scope.UnregisterGrid(this);
-            scope.RegisterGrid(this);
+            scope.RegisterGrid(this, adoptExistingWidths: true);
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.ColumnWidthSharing.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia.Controls.DataGridSizing;
+
+namespace Avalonia.Controls
+{
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    partial class DataGrid
+    {
+        private void OnColumnWidthSharingScopeChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            DataGridColumnWidthSharingScope oldScope = e.OldValue as DataGridColumnWidthSharingScope;
+            DataGridColumnWidthSharingScope newScope = e.NewValue as DataGridColumnWidthSharingScope;
+
+            oldScope?.UnregisterGrid(this);
+            newScope?.RegisterGrid(this);
+        }
+
+        internal void OnColumnWidthSharingGroupChanged(
+            DataGridColumn column,
+            string oldGroup,
+            string newGroup)
+        {
+            ColumnWidthSharingScope?.ChangeColumnGroup(column, oldGroup, newGroup);
+        }
+
+        internal void OnColumnWidthSharingColumnAttached(DataGridColumn column)
+        {
+            ColumnWidthSharingScope?.RegisterColumn(column);
+        }
+
+        internal void OnColumnWidthSharingColumnDetached(DataGridColumn column)
+        {
+            ColumnWidthSharingScope?.UnregisterColumn(column);
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.Width.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.Width.cs
@@ -42,6 +42,7 @@ namespace Avalonia.Controls
             Math.Max(targetWidth - column.Width.DisplayValue, amount));
 
             column.SetWidthDisplayValue(column.Width.DisplayValue + adjustment);
+            column.OwningGrid?.OnColumnWidthSharingSideEffect(column);
             return amount - adjustment;
         }
 
@@ -109,6 +110,7 @@ namespace Avalonia.Controls
             Math.Min(targetWidth - column.Width.DisplayValue, amount));
 
             column.SetWidthDisplayValue(column.Width.DisplayValue + adjustment);
+            column.OwningGrid?.OnColumnWidthSharingSideEffect(column);
             return amount - adjustment;
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -604,6 +604,8 @@ internal
                 EnsureHorizontalLayout();
                 UpdateSummaryRowLayout();
             }
+
+            ColumnWidthSharingScope?.ReportWidth(updatedColumn);
         }
 
         internal void OnFillerColumnWidthNeeded(double finalWidth)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -1399,7 +1399,8 @@ internal
             {
                 if (column.InheritsWidth)
                 {
-                    column.SetWidthInternalNoCallback(value);
+                    column.SetWidthInternalNoCallback(value, preserveInheritance: true);
+                    ColumnWidthSharingScope?.ReportWidth(column);
                 }
             }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -1019,6 +1019,7 @@ internal
                 var expected = totalStarColumnsWidth * column.Width.Value / totalStarWeights;
                 column.SetWidthDesiredValue(expected);
                 column.SetWidthDisplayValue(expected);
+                OnColumnWidthSharingSideEffect(column);
             }
         }
 
@@ -1080,6 +1081,7 @@ internal
                 remainingAdjustment -= adjustment;
                 totalStarWeights -= starColumnPair.Key.Width.Value;
                 starColumnPair.Key.SetWidthDisplayValue(Math.Max(DataGrid.DATAGRID_minimumStarColumnWidth, starColumnPair.Key.Width.DisplayValue + adjustment));
+                OnColumnWidthSharingSideEffect(starColumnPair.Key);
             }
 
             return remainingAdjustment;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -11,6 +11,7 @@ using Avalonia.Controls.Selection;
 using Avalonia.Controls.DataGridSorting;
 using Avalonia.Controls.DataGridSearching;
 using Avalonia.Controls.DataGridFilling;
+using Avalonia.Controls.DataGridSizing;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Media;
@@ -463,6 +464,21 @@ internal
         {
             get { return GetValue(ColumnWidthProperty); }
             set { SetValue(ColumnWidthProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="ColumnWidthSharingScope"/> dependency property.
+        /// </summary>
+        public static readonly StyledProperty<DataGridColumnWidthSharingScope> ColumnWidthSharingScopeProperty =
+            AvaloniaProperty.Register<DataGrid, DataGridColumnWidthSharingScope>(nameof(ColumnWidthSharingScope));
+
+        /// <summary>
+        /// Gets or sets the scope that synchronizes columns with matching width-sharing group names.
+        /// </summary>
+        public DataGridColumnWidthSharingScope ColumnWidthSharingScope
+        {
+            get { return GetValue(ColumnWidthSharingScopeProperty); }
+            set { SetValue(ColumnWidthSharingScopeProperty, value); }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Template.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Template.cs
@@ -164,6 +164,7 @@ internal
                 }
             }
             NormalizeColumnDisplayIndexesAfterDetachedMutations();
+            RefreshColumnWidthSharingRegistration();
             if (_columnHeadersPresenter != null && _columnHeadersPresenter.OwningGrid == null)
             {
                 _columnHeadersPresenter.OwningGrid = this;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -517,6 +517,7 @@ internal
             ItemsSourceProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnItemsSourcePropertyChanged(e));
             CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnCanUserResizeColumnsChanged(e));
             ColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnColumnWidthChanged(e));
+            ColumnWidthSharingScopeProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnColumnWidthSharingScopeChanged(e));
             FrozenColumnCountProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnFrozenColumnCountChanged(e));
             FrozenColumnCountRightProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnFrozenColumnCountRightChanged(e));
             GridLinesVisibilityProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnGridLinesVisibilityChanged(e));

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.Width.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.Width.cs
@@ -126,7 +126,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal void EnsureWidth()
         {
-            SetWidthInternalNoCallback(CoerceWidth(this, Width));
+            SetWidthInternalNoCallback(CoerceWidth(this, Width), preserveInheritance: InheritsWidth);
         }
 
         /// <summary>
@@ -255,17 +255,21 @@ namespace Avalonia.Controls
         /// Sets the column's Width directly, without any callback effects.
         /// </summary>
         /// <param name="width">The new Width.</param>
-        internal void SetWidthInternalNoCallback(DataGridLength width)
+        /// <param name="preserveInheritance">Whether the internal update should retain grid-level width inheritance.</param>
+        internal void SetWidthInternalNoCallback(DataGridLength width, bool preserveInheritance = false)
         {
-            var originalValue = _setWidthInternalNoCallback;
+            bool originalNoCallback = _setWidthInternalNoCallback;
+            bool originalInternal = _settingWidthInternally;
             _setWidthInternalNoCallback = true;
+            _settingWidthInternally |= preserveInheritance;
             try
             {
                 SetCurrentValue(WidthProperty, width);
             }
             finally
             {
-                _setWidthInternalNoCallback = originalValue;
+                _setWidthInternalNoCallback = originalNoCallback;
+                _settingWidthInternally = originalInternal;
             }
 
         }

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -235,9 +235,23 @@ internal
         /// </summary>
         internal bool IsInitialDesiredWidthDetermined
         {
-            get;
-            set;
+            get => _isInitialDesiredWidthDetermined;
+            set
+            {
+                if (_isInitialDesiredWidthDetermined == value)
+                {
+                    return;
+                }
+
+                _isInitialDesiredWidthDetermined = value;
+                if (value)
+                {
+                    OwningGrid?.OnColumnWidthSharingColumnMeasured(this);
+                }
+            }
         }
+
+        private bool _isInitialDesiredWidthDetermined;
 
         internal double LayoutRoundedWidth
         {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
@@ -163,6 +163,7 @@ namespace Avalonia.Controls
                     for (int columnIndex = 0; columnIndex < ItemsInternal.Count; columnIndex++)
                     {
                         // Detach the column...
+                        _owningGrid.OnColumnWidthSharingColumnDetached(ItemsInternal[columnIndex]);
                         ItemsInternal[columnIndex].OwningGrid = null;
                         ItemsInternal[columnIndex].ClearElementCache();
                     }
@@ -209,6 +210,7 @@ namespace Avalonia.Controls
                 ItemsInternal.Insert(columnIndexWithFiller, dataGridColumn);
                 dataGridColumn.Index = columnIndexWithFiller;
                 dataGridColumn.OwningGrid = _owningGrid;
+                _owningGrid.OnColumnWidthSharingColumnAttached(dataGridColumn);
                 dataGridColumn.RemoveEditingElement();
                 if (dataGridColumn != RowGroupSpacerColumn && dataGridColumn != FillerColumn)
                 {
@@ -612,6 +614,7 @@ namespace Avalonia.Controls
                     VisibleEdgedColumnsWidth -= dataGridColumn.ActualWidth;
                 }
                 // continue with the base remove
+                _owningGrid.OnColumnWidthSharingColumnDetached(dataGridColumn);
                 dataGridColumn.OwningGrid = null;
                 _owningGrid.OnRemovedColumn_PreNotification(dataGridColumn, headerCell);
                 _owningGrid.OnColumnCollectionChanged_PreNotification(false /*columnsGrew*/);

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharing.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharing.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Avalonia.Controls.DataGridSizing
+{
+    /// <summary>
+    /// Provides the attached column group used by <see cref="DataGridColumnWidthSharingScope"/>.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    static class DataGridColumnWidthSharing
+    {
+        /// <summary>
+        /// Identifies the Group attached property.
+        /// </summary>
+        public static readonly AttachedProperty<string> GroupProperty =
+            AvaloniaProperty.RegisterAttached<DataGridColumn, string>(
+                "Group",
+                typeof(DataGridColumnWidthSharing));
+
+        static DataGridColumnWidthSharing()
+        {
+            GroupProperty.Changed.AddClassHandler<DataGridColumn>(
+                (column, args) => column.OwningGrid?.OnColumnWidthSharingGroupChanged(
+                    column,
+                    args.OldValue as string,
+                    args.NewValue as string));
+        }
+
+        /// <summary>
+        /// Gets the width-sharing group assigned to a column.
+        /// </summary>
+        /// <param name="target">The target column.</param>
+        /// <returns>The group name, or <see langword="null"/> when sharing is disabled.</returns>
+        public static string GetGroup(AvaloniaObject target)
+        {
+            return target.GetValue(GroupProperty);
+        }
+
+        /// <summary>
+        /// Sets the width-sharing group assigned to a column.
+        /// </summary>
+        /// <param name="target">The target column.</param>
+        /// <param name="value">The group name, or <see langword="null"/> to disable sharing.</param>
+        public static void SetGroup(AvaloniaObject target, string value)
+        {
+            target.SetValue(GroupProperty, value);
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -209,7 +209,7 @@ namespace Avalonia.Controls.DataGridSizing
                     DataGridLength synchronized = current.IsAbsolute || current.IsStar
                         ? new DataGridLength(width)
                         : new DataGridLength(current.Value, current.UnitType, width, width);
-                    column.SetWidthInternalNoCallback(synchronized);
+                    column.SetWidthInternalNoCallback(synchronized, preserveInheritance: column.InheritsWidth);
                     column.OwningGrid.OnColumnWidthChanged(column);
                 }
             }

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -67,7 +67,10 @@ namespace Avalonia.Controls.DataGridSizing
 
             foreach (string group in new List<string>(_groups.Keys))
             {
-                RemoveMatching(group, column => column.OwningGrid == grid);
+                RemoveMatching(
+                    group,
+                    column => column.OwningGrid == grid ||
+                        grid.ColumnsInternal.ItemsInternal.Contains(column));
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Controls.DataGridSizing
             }
         }
 
-        internal void RegisterGrid(DataGrid grid)
+        internal void RegisterGrid(DataGrid grid, bool adoptExistingWidths = false)
         {
             if (grid == null)
             {
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.DataGridSizing
 
             foreach (DataGridColumn column in grid.ColumnsInternal.ItemsInternal)
             {
-                RegisterColumn(column);
+                RegisterColumn(column, adoptExistingWidths);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Avalonia.Controls.DataGridSizing
             }
         }
 
-        internal void RegisterColumn(DataGridColumn column)
+        internal void RegisterColumn(DataGridColumn column, bool adoptExistingWidth = false)
         {
             if (column?.OwningGrid == null)
             {
@@ -89,6 +89,9 @@ namespace Avalonia.Controls.DataGridSizing
 
             List<WeakReference<DataGridColumn>> participants = GetOrCreateGroup(group);
             Prune(participants);
+            double existingWidth = adoptExistingWidth
+                ? GetLargestMeasuredWidth(participants)
+                : 0;
             foreach (WeakReference<DataGridColumn> reference in participants)
             {
                 if (reference.TryGetTarget(out DataGridColumn existing) && ReferenceEquals(existing, column))
@@ -98,7 +101,14 @@ namespace Avalonia.Controls.DataGridSizing
             }
 
             participants.Add(new WeakReference<DataGridColumn>(column));
-            SynchronizeLargestWidth(group);
+            if (existingWidth > 0)
+            {
+                ApplyWidth(participants, existingWidth);
+            }
+            else
+            {
+                SynchronizeLargestWidth(group);
+            }
         }
 
         internal void UnregisterColumn(DataGridColumn column, string group = null)
@@ -138,6 +148,24 @@ namespace Avalonia.Controls.DataGridSizing
                 return;
             }
 
+            Prune(participants);
+            bool isRegistered = false;
+            foreach (WeakReference<DataGridColumn> reference in participants)
+            {
+                if (reference.TryGetTarget(out DataGridColumn column) &&
+                    ReferenceEquals(column, source))
+                {
+                    isRegistered = true;
+                    break;
+                }
+            }
+
+            if (!isRegistered)
+            {
+                RemoveGroupIfEmpty(group, participants);
+                return;
+            }
+
             ApplyWidth(participants, source.ActualWidth);
             RemoveGroupIfEmpty(group, participants);
         }
@@ -150,6 +178,19 @@ namespace Avalonia.Controls.DataGridSizing
             }
 
             Prune(participants);
+            double width = GetLargestMeasuredWidth(participants);
+
+            if (width > 0)
+            {
+                ApplyWidth(participants, width);
+            }
+
+            RemoveGroupIfEmpty(group, participants);
+        }
+
+        private static double GetLargestMeasuredWidth(
+            List<WeakReference<DataGridColumn>> participants)
+        {
             double width = 0;
             foreach (WeakReference<DataGridColumn> reference in participants)
             {
@@ -159,12 +200,7 @@ namespace Avalonia.Controls.DataGridSizing
                 }
             }
 
-            if (width > 0)
-            {
-                ApplyWidth(participants, width);
-            }
-
-            RemoveGroupIfEmpty(group, participants);
+            return width;
         }
 
         private void ApplyWidth(List<WeakReference<DataGridColumn>> participants, double requestedWidth)

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -215,7 +215,8 @@ namespace Avalonia.Controls.DataGridSizing
             double maximum = double.PositiveInfinity;
             foreach (WeakReference<DataGridColumn> reference in participants)
             {
-                if (reference.TryGetTarget(out DataGridColumn column))
+                if (reference.TryGetTarget(out DataGridColumn column) &&
+                    !IsUnmeasuredStar(column))
                 {
                     minimum = Math.Max(minimum, column.ActualMinWidth);
                     maximum = Math.Min(maximum, column.ActualMaxWidth);

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -200,12 +200,12 @@ namespace Avalonia.Controls.DataGridSizing
                     double width = minimum <= maximum
                         ? sharedWidth
                         : Math.Clamp(sharedWidth, column.ActualMinWidth, column.ActualMaxWidth);
-                    if (Math.Abs(column.ActualWidth - width) <= 0.001)
+                    DataGridLength current = column.Width;
+                    if (Math.Abs(column.ActualWidth - width) <= 0.001 && !current.IsStar)
                     {
                         continue;
                     }
 
-                    DataGridLength current = column.Width;
                     DataGridLength synchronized = current.IsAbsolute || current.IsStar
                         ? new DataGridLength(width)
                         : new DataGridLength(current.Value, current.UnitType, width, width);

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Controls.DataGridSizing
+{
+    /// <summary>
+    /// Synchronizes the display widths of columns that share the same group name across DataGrid controls.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridColumnWidthSharingScope
+    {
+        private readonly Dictionary<string, List<WeakReference<DataGridColumn>>> _groups =
+            new(StringComparer.Ordinal);
+        private bool _isSynchronizing;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataGridColumnWidthSharingScope"/> class.
+        /// </summary>
+        public DataGridColumnWidthSharingScope()
+        {
+        }
+
+        /// <summary>
+        /// Recomputes every registered group using its largest current column width.
+        /// </summary>
+        public void Synchronize()
+        {
+            if (_isSynchronizing)
+            {
+                return;
+            }
+
+            foreach (string group in new List<string>(_groups.Keys))
+            {
+                SynchronizeLargestWidth(group);
+            }
+        }
+
+        internal void RegisterGrid(DataGrid grid)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            foreach (DataGridColumn column in grid.ColumnsInternal.ItemsInternal)
+            {
+                RegisterColumn(column);
+            }
+        }
+
+        internal void UnregisterGrid(DataGrid grid)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            foreach (string group in new List<string>(_groups.Keys))
+            {
+                RemoveMatching(group, column => column.OwningGrid == grid);
+            }
+        }
+
+        internal void RegisterColumn(DataGridColumn column)
+        {
+            if (column?.OwningGrid == null)
+            {
+                return;
+            }
+
+            string group = DataGridColumnWidthSharing.GetGroup(column);
+            if (string.IsNullOrWhiteSpace(group))
+            {
+                return;
+            }
+
+            List<WeakReference<DataGridColumn>> participants = GetOrCreateGroup(group);
+            Prune(participants);
+            foreach (WeakReference<DataGridColumn> reference in participants)
+            {
+                if (reference.TryGetTarget(out DataGridColumn existing) && ReferenceEquals(existing, column))
+                {
+                    return;
+                }
+            }
+
+            participants.Add(new WeakReference<DataGridColumn>(column));
+            SynchronizeLargestWidth(group);
+        }
+
+        internal void UnregisterColumn(DataGridColumn column, string group = null)
+        {
+            if (column == null)
+            {
+                return;
+            }
+
+            group ??= DataGridColumnWidthSharing.GetGroup(column);
+            if (!string.IsNullOrWhiteSpace(group))
+            {
+                RemoveMatching(group, candidate => ReferenceEquals(candidate, column));
+            }
+        }
+
+        internal void ChangeColumnGroup(DataGridColumn column, string oldGroup, string newGroup)
+        {
+            UnregisterColumn(column, oldGroup);
+            if (!string.IsNullOrWhiteSpace(newGroup))
+            {
+                RegisterColumn(column);
+            }
+        }
+
+        internal void ReportWidth(DataGridColumn source)
+        {
+            if (_isSynchronizing || source?.OwningGrid == null)
+            {
+                return;
+            }
+
+            string group = DataGridColumnWidthSharing.GetGroup(source);
+            if (string.IsNullOrWhiteSpace(group) ||
+                !_groups.TryGetValue(group, out List<WeakReference<DataGridColumn>> participants))
+            {
+                return;
+            }
+
+            ApplyWidth(participants, source.ActualWidth);
+            RemoveGroupIfEmpty(group, participants);
+        }
+
+        private void SynchronizeLargestWidth(string group)
+        {
+            if (!_groups.TryGetValue(group, out List<WeakReference<DataGridColumn>> participants))
+            {
+                return;
+            }
+
+            Prune(participants);
+            double width = 0;
+            foreach (WeakReference<DataGridColumn> reference in participants)
+            {
+                if (reference.TryGetTarget(out DataGridColumn column))
+                {
+                    width = Math.Max(width, column.ActualWidth);
+                }
+            }
+
+            if (width > 0)
+            {
+                ApplyWidth(participants, width);
+            }
+
+            RemoveGroupIfEmpty(group, participants);
+        }
+
+        private void ApplyWidth(List<WeakReference<DataGridColumn>> participants, double requestedWidth)
+        {
+            if (_isSynchronizing || double.IsNaN(requestedWidth) || double.IsInfinity(requestedWidth))
+            {
+                return;
+            }
+
+            Prune(participants);
+            double minimum = 0;
+            double maximum = double.PositiveInfinity;
+            foreach (WeakReference<DataGridColumn> reference in participants)
+            {
+                if (reference.TryGetTarget(out DataGridColumn column))
+                {
+                    minimum = Math.Max(minimum, column.ActualMinWidth);
+                    maximum = Math.Min(maximum, column.ActualMaxWidth);
+                }
+            }
+
+            double sharedWidth = minimum <= maximum
+                ? Math.Clamp(requestedWidth, minimum, maximum)
+                : requestedWidth;
+
+            _isSynchronizing = true;
+            try
+            {
+                foreach (WeakReference<DataGridColumn> reference in participants)
+                {
+                    if (!reference.TryGetTarget(out DataGridColumn column) || column.OwningGrid == null)
+                    {
+                        continue;
+                    }
+
+                    double width = minimum <= maximum
+                        ? sharedWidth
+                        : Math.Clamp(sharedWidth, column.ActualMinWidth, column.ActualMaxWidth);
+                    if (Math.Abs(column.ActualWidth - width) <= 0.001)
+                    {
+                        continue;
+                    }
+
+                    DataGridLength current = column.Width;
+                    DataGridLength synchronized = current.IsAbsolute || current.IsStar
+                        ? new DataGridLength(width)
+                        : new DataGridLength(current.Value, current.UnitType, width, width);
+                    column.SetWidthInternalNoCallback(synchronized);
+                    column.OwningGrid.OnColumnWidthChanged(column);
+                }
+            }
+            finally
+            {
+                _isSynchronizing = false;
+            }
+        }
+
+        private List<WeakReference<DataGridColumn>> GetOrCreateGroup(string group)
+        {
+            if (!_groups.TryGetValue(group, out List<WeakReference<DataGridColumn>> participants))
+            {
+                participants = new List<WeakReference<DataGridColumn>>();
+                _groups.Add(group, participants);
+            }
+
+            return participants;
+        }
+
+        private void RemoveMatching(string group, Predicate<DataGridColumn> predicate)
+        {
+            if (!_groups.TryGetValue(group, out List<WeakReference<DataGridColumn>> participants))
+            {
+                return;
+            }
+
+            for (int index = participants.Count - 1; index >= 0; index--)
+            {
+                if (!participants[index].TryGetTarget(out DataGridColumn column) || predicate(column))
+                {
+                    participants.RemoveAt(index);
+                }
+            }
+
+            RemoveGroupIfEmpty(group, participants);
+        }
+
+        private static void Prune(List<WeakReference<DataGridColumn>> participants)
+        {
+            for (int index = participants.Count - 1; index >= 0; index--)
+            {
+                if (!participants[index].TryGetTarget(out DataGridColumn column) || column.OwningGrid == null)
+                {
+                    participants.RemoveAt(index);
+                }
+            }
+        }
+
+        private void RemoveGroupIfEmpty(string group, List<WeakReference<DataGridColumn>> participants)
+        {
+            if (participants.Count == 0)
+            {
+                _groups.Remove(group);
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
+++ b/src/Avalonia.Controls.DataGrid/Sizing/DataGridColumnWidthSharingScope.cs
@@ -123,7 +123,7 @@ namespace Avalonia.Controls.DataGridSizing
 
         internal void ReportWidth(DataGridColumn source)
         {
-            if (_isSynchronizing || source?.OwningGrid == null)
+            if (_isSynchronizing || source?.OwningGrid == null || IsUnmeasuredStar(source))
             {
                 return;
             }
@@ -150,7 +150,7 @@ namespace Avalonia.Controls.DataGridSizing
             double width = 0;
             foreach (WeakReference<DataGridColumn> reference in participants)
             {
-                if (reference.TryGetTarget(out DataGridColumn column))
+                if (reference.TryGetTarget(out DataGridColumn column) && !IsUnmeasuredStar(column))
                 {
                     width = Math.Max(width, column.ActualWidth);
                 }
@@ -192,7 +192,9 @@ namespace Avalonia.Controls.DataGridSizing
             {
                 foreach (WeakReference<DataGridColumn> reference in participants)
                 {
-                    if (!reference.TryGetTarget(out DataGridColumn column) || column.OwningGrid == null)
+                    if (!reference.TryGetTarget(out DataGridColumn column) ||
+                        column.OwningGrid == null ||
+                        IsUnmeasuredStar(column))
                     {
                         continue;
                     }
@@ -217,6 +219,17 @@ namespace Avalonia.Controls.DataGridSizing
             {
                 _isSynchronizing = false;
             }
+        }
+
+        private static bool IsUnmeasuredStar(DataGridColumn column)
+        {
+            if (!column.Width.IsStar || column.IsInitialDesiredWidthDetermined)
+            {
+                return false;
+            }
+
+            return double.IsNaN(column.Width.DisplayValue) ||
+                column.Width.DisplayValue <= column.ActualMinWidth + 0.001;
         }
 
         private List<WeakReference<DataGridColumn>> GetOrCreateGroup(string group)

--- a/src/DataGridSample.UnitTests/ColumnWidthSharingPageTests.cs
+++ b/src/DataGridSample.UnitTests/ColumnWidthSharingPageTests.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridSizing;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class ColumnWidthSharingPageTests
+{
+    [AvaloniaFact]
+    public void Xaml_And_Definition_Columns_Share_Widths()
+    {
+        var page = new ColumnWidthSharingPage
+        {
+            DataContext = new ColumnWidthSharingViewModel()
+        };
+        var window = new Window
+        {
+            Width = 1100,
+            Height = 720,
+            Content = page
+        };
+        window.ApplySampleTheme();
+
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            DataGrid? xamlGrid = page.FindControl<DataGrid>("XamlColumnsGrid");
+            DataGrid? definitionGrid = page.FindControl<DataGrid>("DefinitionColumnsGrid");
+            Assert.NotNull(xamlGrid);
+            Assert.NotNull(definitionGrid);
+            Assert.Same(xamlGrid.ColumnWidthSharingScope, definitionGrid.ColumnWidthSharingScope);
+            Assert.Equal("owner", DataGridColumnWidthSharing.GetGroup(xamlGrid.Columns[1]));
+            Assert.Equal("owner", DataGridColumnWidthSharing.GetGroup(definitionGrid.Columns[1]));
+            Assert.Equal(xamlGrid.Columns[1].ActualWidth, definitionGrid.Columns[1].ActualWidth);
+
+            xamlGrid.Columns[1].Width = new DataGridLength(260);
+            PumpLayout(window);
+
+            Assert.Equal(260, xamlGrid.Columns[1].ActualWidth);
+            Assert.Equal(260, definitionGrid.Columns[1].ActualWidth);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void PumpLayout(Control control)
+    {
+        Dispatcher.UIThread.RunJobs();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/src/DataGridSample.UnitTests/SamplePageCatalog.cs
+++ b/src/DataGridSample.UnitTests/SamplePageCatalog.cs
@@ -51,6 +51,7 @@ internal static class SamplePageCatalog
             ("DataGridSample.Pages.ColumnSearchPage", static () => new global::DataGridSample.Pages.ColumnSearchPage()),
             ("DataGridSample.Pages.ColumnThemesPage", static () => new global::DataGridSample.Pages.ColumnThemesPage()),
             ("DataGridSample.Pages.ColumnTypesPage", static () => new global::DataGridSample.Pages.ColumnTypesPage()),
+            ("DataGridSample.Pages.ColumnWidthSharingPage", static () => new global::DataGridSample.Pages.ColumnWidthSharingPage()),
             ("DataGridSample.Pages.ComboHyperlinkColumnsPage", static () => new global::DataGridSample.Pages.ComboHyperlinkColumnsPage()),
             ("DataGridSample.Pages.ConditionalFormattingPage", static () => new global::DataGridSample.Pages.ConditionalFormattingPage()),
             ("DataGridSample.Pages.ContainerLifecyclePage", static () => new global::DataGridSample.Pages.ContainerLifecyclePage()),

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:DataGridSample"
         xmlns:pages="clr-namespace:DataGridSample.Pages"
+        xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
         x:Class="DataGridSample.MainWindow"
         Title="ProDataGrid for Avalonia"
         Width="1000"
@@ -438,6 +439,13 @@
     </TabItem>
     <TabItem Header="Column Chooser (Definitions)">
       <pages:ColumnChooserDefinitionsPage />
+    </TabItem>
+    <TabItem Header="Shared Column Widths">
+      <pages:ColumnWidthSharingPage>
+        <pages:ColumnWidthSharingPage.DataContext>
+          <viewModels:ColumnWidthSharingViewModel />
+        </pages:ColumnWidthSharingPage.DataContext>
+      </pages:ColumnWidthSharingPage>
     </TabItem>
     <TabItem Header="Column Definitions">
       <pages:ColumnDefinitionsPage />

--- a/src/DataGridSample/Pages/ColumnWidthSharingPage.axaml
+++ b/src/DataGridSample/Pages/ColumnWidthSharingPage.axaml
@@ -1,0 +1,100 @@
+<!--
+  Copyright (c) Wieslaw Soltes. All rights reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for details.
+-->
+<UserControl
+    x:Class="DataGridSample.Pages.ColumnWidthSharingPage"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:sizing="clr-namespace:Avalonia.Controls.DataGridSizing;assembly=Avalonia.Controls.DataGrid"
+    xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+    x:DataType="viewModels:ColumnWidthSharingViewModel"
+    d:DesignHeight="720"
+    d:DesignWidth="1100"
+    mc:Ignorable="d">
+
+  <UserControl.Resources>
+    <sizing:DataGridColumnWidthSharingScope x:Key="ComparisonColumnWidths" />
+  </UserControl.Resources>
+
+  <Grid Margin="12"
+        RowDefinitions="Auto,*,*"
+        RowSpacing="10">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2" Text="Shared Column Widths" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Resize a column in either grid. The matching column follows immediately, even though the first grid declares groups in XAML and the second uses MVVM column definitions." />
+    </StackPanel>
+
+    <Border Grid.Row="1"
+            Padding="10"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1"
+            CornerRadius="6">
+      <Grid RowDefinitions="Auto,*"
+            RowSpacing="6">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <TextBlock FontWeight="SemiBold" Text="Current plan" />
+          <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                     Text="XAML columns · Group attached property" />
+        </StackPanel>
+
+        <DataGrid x:Name="XamlColumnsGrid"
+                  Grid.Row="1"
+                  ItemsSource="{Binding CurrentItems}"
+                  ColumnWidthSharingScope="{StaticResource ComparisonColumnWidths}"
+                  AutoGenerateColumns="False"
+                  CanUserResizeColumns="True"
+                  GridLinesVisibility="Horizontal"
+                  HeadersVisibility="All"
+                  IsReadOnly="True">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Work item"
+                                Binding="{Binding WorkItem}"
+                                Width="Auto"
+                                sizing:DataGridColumnWidthSharing.Group="work-item"
+                                x:DataType="viewModels:ColumnWidthSharingViewModel+ComparisonRow" />
+            <DataGridTextColumn Header="Owner"
+                                Binding="{Binding Owner}"
+                                Width="130"
+                                sizing:DataGridColumnWidthSharing.Group="owner"
+                                x:DataType="viewModels:ColumnWidthSharingViewModel+ComparisonRow" />
+            <DataGridTextColumn Header="Status"
+                                Binding="{Binding Status}"
+                                Width="*"
+                                sizing:DataGridColumnWidthSharing.Group="status"
+                                x:DataType="viewModels:ColumnWidthSharingViewModel+ComparisonRow" />
+          </DataGrid.Columns>
+        </DataGrid>
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="2"
+            Padding="10"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1"
+            CornerRadius="6">
+      <Grid RowDefinitions="Auto,*"
+            RowSpacing="6">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <TextBlock FontWeight="SemiBold" Text="Baseline plan" />
+          <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                     Text="ColumnDefinitionsSource · WidthSharingGroup" />
+        </StackPanel>
+
+        <DataGrid x:Name="DefinitionColumnsGrid"
+                  Grid.Row="1"
+                  ItemsSource="{Binding BaselineItems}"
+                  ColumnDefinitionsSource="{Binding BaselineColumns}"
+                  ColumnWidthSharingScope="{StaticResource ComparisonColumnWidths}"
+                  AutoGenerateColumns="False"
+                  CanUserResizeColumns="True"
+                  GridLinesVisibility="Horizontal"
+                  HeadersVisibility="All"
+                  IsReadOnly="True" />
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/ColumnWidthSharingPage.axaml.cs
+++ b/src/DataGridSample/Pages/ColumnWidthSharingPage.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public sealed partial class ColumnWidthSharingPage : UserControl
+{
+    public ColumnWidthSharingPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/ViewModels/ColumnWidthSharingViewModel.cs
+++ b/src/DataGridSample/ViewModels/ColumnWidthSharingViewModel.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Data.Core;
+using ReactiveUI;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class ColumnWidthSharingViewModel : ReactiveObject
+{
+    public ColumnWidthSharingViewModel()
+    {
+        CurrentItems =
+        [
+            new ComparisonRow("Refresh customer dashboard", "Ava", "In progress"),
+            new ComparisonRow("Review export accessibility", "Marek", "Ready"),
+            new ComparisonRow("Publish release notes", "Noah", "Blocked")
+        ];
+
+        BaselineItems =
+        [
+            new ComparisonRow("Dashboard", "Ava Kowalska", "Complete"),
+            new ComparisonRow("Accessibility audit", "Marek", "In review"),
+            new ComparisonRow("Release notes", "Noah", "Complete")
+        ];
+
+        BaselineColumns =
+        [
+            new DataGridTextColumnDefinition
+            {
+                Header = "Work item",
+                Binding = CreateBinding(nameof(ComparisonRow.WorkItem), static row => row.WorkItem),
+                Width = DataGridLength.Auto,
+                WidthSharingGroup = "work-item"
+            },
+            new DataGridTextColumnDefinition
+            {
+                Header = "Owner",
+                Binding = CreateBinding(nameof(ComparisonRow.Owner), static row => row.Owner),
+                Width = new DataGridLength(210),
+                WidthSharingGroup = "owner"
+            },
+            new DataGridTextColumnDefinition
+            {
+                Header = "Status",
+                Binding = CreateBinding(nameof(ComparisonRow.Status), static row => row.Status),
+                Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                WidthSharingGroup = "status"
+            }
+        ];
+    }
+
+    public IReadOnlyList<ComparisonRow> CurrentItems { get; }
+
+    public IReadOnlyList<ComparisonRow> BaselineItems { get; }
+
+    public DataGridColumnDefinitionList BaselineColumns { get; }
+
+    private static DataGridBindingDefinition CreateBinding(
+        string propertyName,
+        Func<ComparisonRow, string> getter)
+    {
+        var propertyInfo = new ClrPropertyInfo(
+            propertyName,
+            target => target is ComparisonRow row ? getter(row) : null,
+            setter: null,
+            typeof(string));
+
+        return DataGridBindingDefinition.Create<ComparisonRow, string>(propertyInfo, getter);
+    }
+
+    public sealed record ComparisonRow(string WorkItem, string Owner, string Status);
+}


### PR DESCRIPTION
## Summary

Adds first-class DataGrid column-width sharing across multiple grids, analogous to `Grid.SharedSizeGroup`/scope usage.

- introduces an explicit weak-reference `DataGridColumnWidthSharingScope`
- introduces `DataGridColumnWidthSharing.Group` for direct XAML columns
- adds `DataGrid.ColumnWidthSharingScope` and `DataGridColumnDefinition.WidthSharingGroup`
- synchronizes initial widths and propagates automatic, programmatic, user, inherited, and redistribution changes
- tracks collection, group, scope, measurement, and visual-attachment lifecycle transitions
- documents compiled-binding/MVVM and direct XAML usage

## Design

The implementation is instance-scoped with no global registry. A reentrancy guard prevents recursive broadcasts while widths are applied through the existing no-callback API.

Sizing behavior is explicit:

- pixel columns remain pixel columns;
- intrinsic auto modes retain their mode while sharing desired/display width;
- measured star results normalize to pixels because different grids cannot reliably share one star result;
- unresolved stars are deferred entirely—including their provisional constraints—until measurement completes;
- overlapping constraints produce a common clamped width, while incompatible constraints clamp each participant independently.

Definition changes use the live materialization pipeline, so group updates do not rebuild the grid.

## Review hardening

Follow-up fixes cover:

- inherited width preservation;
- registration refresh and identity-safe scope migration while detached;
- active-width adoption on reattach, preventing stale detached widths from winning;
- rejection of reports from pruned/nonparticipants;
- first-measure reporting for deferred stars;
- indirect non-star/star redistribution, normalization, and min/max side-effect reports;
- consistent exclusion of unresolved stars from both target assignment and common constraint aggregation.

## Validation

- Focused width-sharing suite: **17 passed, 0 failed**.
- Full `Avalonia.Controls.DataGrid.UnitTests`: **2,267 passed, 0 failed**.
- Release leak suite: **34 passed, 0 failed**.
- `git diff --check`: clean.
- All review threads resolved.

Fixes #295
