### PR TITLE
Complete multi-row drag selection behavior

### DIFF
--- a/docfx/articles/drag-drop.md
+++ b/docfx/articles/drag-drop.md
@@ -127,6 +127,8 @@ Built-in `DataGridRowReorderHandler` and `DataGridHierarchicalRowReorderHandler`
 - `true` keeps click-to-select but prevents range-selection drag from taking over the intended row drag gesture.
 - `false` restores the older behavior where selection drag can begin from the same surface.
 
+With suppression enabled and extended full-row selection active, pressing an already selected row keeps the complete selection available for drag detection. Crossing the drag threshold starts one drag containing all selected rows. Releasing without starting a drag applies the normal click behavior and collapses the selection to the clicked row.
+
 ## Drop Visuals and Feedback
 
 Drag/drop exposes pseudo-classes you can style:

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputMouseSelectionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputMouseSelectionTests.cs
@@ -254,7 +254,7 @@ public class DataGridInputMouseSelectionTests
     }
 
     [AvaloniaFact]
-    public void RowDragHandle_Row_Preserves_MultiSelection_On_Selected_Row_Press_When_Suppression_Enabled()
+    public void RowDragHandle_Row_Defers_MultiSelection_Collapse_Until_Selected_Row_Release()
     {
         var (grid, items) = CreateGrid(selectionUnit: DataGridSelectionUnit.FullRow, selectionMode: DataGridSelectionMode.Extended);
         grid.CanUserReorderRows = true;
@@ -281,6 +281,69 @@ public class DataGridInputMouseSelectionTests
         Assert.Equal(2, grid.SelectedItems.Count);
         Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
         Assert.Contains(items[1], grid.SelectedItems.Cast<RowItem>());
+
+        grid.RaiseEvent(CreatePointerReleasedArgs(grid, grid, pointer, point, KeyModifiers.None));
+
+        Assert.Single(grid.SelectedItems);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
+    }
+
+    [AvaloniaFact]
+    public void RowDragHandle_Row_Canceled_Deferred_Selection_Remains_MultiSelected_On_Release()
+    {
+        var (grid, items) = CreateGrid(selectionUnit: DataGridSelectionUnit.FullRow, selectionMode: DataGridSelectionMode.Extended);
+        grid.CanUserReorderRows = true;
+        grid.RowDragHandle = DataGridRowDragHandle.Row;
+        grid.RowDragDropOptions = new DataGridRowDragDropOptions
+        {
+            SuppressSelectionDragFromDragHandle = true
+        };
+        grid.SelectedItems.Add(items[0]);
+        grid.SelectedItems.Add(items[1]);
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var slot = grid.SlotFromRowIndex(0);
+        var row = grid.DisplayData.GetDisplayedElement(slot) as DataGridRow;
+        Assert.NotNull(row);
+
+        var cell = row!.Cells[0];
+        var point = GetCenterPoint(cell, grid);
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+
+        cell.RaiseEvent(CreatePointerPressedArgs(cell, grid, pointer, point, KeyModifiers.None));
+        grid.CancelDeferredRowDragSelection(pointer.Id);
+        grid.RaiseEvent(CreatePointerReleasedArgs(grid, grid, pointer, point, KeyModifiers.None));
+
+        Assert.Equal(2, grid.SelectedItems.Count);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
+        Assert.Contains(items[1], grid.SelectedItems.Cast<RowItem>());
+    }
+
+    [AvaloniaFact]
+    public void RowDragHandle_Row_Does_Not_Defer_Selection_When_Row_Drag_Cannot_Start()
+    {
+        var (grid, items) = CreateGrid(selectionUnit: DataGridSelectionUnit.FullRow, selectionMode: DataGridSelectionMode.Extended);
+        grid.CanUserReorderRows = true;
+        grid.RowDragHandle = DataGridRowDragHandle.Row;
+        grid.IsReadOnly = true;
+        grid.SelectedItems.Add(items[0]);
+        grid.SelectedItems.Add(items[1]);
+        grid.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var slot = grid.SlotFromRowIndex(0);
+        var row = grid.DisplayData.GetDisplayedElement(slot) as DataGridRow;
+        Assert.NotNull(row);
+
+        var cell = row!.Cells[0];
+        var point = GetCenterPoint(cell, grid);
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+
+        cell.RaiseEvent(CreatePointerPressedArgs(cell, grid, pointer, point, KeyModifiers.None));
+
+        Assert.Single(grid.SelectedItems);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
 
         grid.RaiseEvent(CreatePointerReleasedArgs(grid, grid, pointer, point, KeyModifiers.None));
     }
@@ -378,7 +441,7 @@ public class DataGridInputMouseSelectionTests
     }
 
     [AvaloniaFact]
-    public void RowDragHandle_RowHeader_Preserves_MultiSelection_On_Selected_Row_Press_When_Suppression_Enabled()
+    public void RowDragHandle_RowHeader_Defers_MultiSelection_Collapse_Until_Selected_Row_Release()
     {
         var (grid, items) = CreateGrid(selectionUnit: DataGridSelectionUnit.FullRow, selectionMode: DataGridSelectionMode.Extended);
         grid.HeadersVisibility = DataGridHeadersVisibility.All;
@@ -410,6 +473,9 @@ public class DataGridInputMouseSelectionTests
         Assert.Contains(items[1], grid.SelectedItems.Cast<RowItem>());
 
         grid.RaiseEvent(CreatePointerReleasedArgs(grid, grid, pointer, point, KeyModifiers.None));
+
+        Assert.Single(grid.SelectedItems);
+        Assert.Contains(items[0], grid.SelectedItems.Cast<RowItem>());
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid/DataGrid.RowDragDrop.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.RowDragDrop.cs
@@ -13,6 +13,8 @@ namespace Avalonia.Controls
 #nullable enable
     partial class DataGrid
     {
+        private DeferredRowDragSelection? _deferredRowDragSelection;
+
         public static readonly RoutedEvent<DataGridRowDragStartingEventArgs> RowDragStartingEvent =
             RoutedEvent.Register<DataGrid, DataGridRowDragStartingEventArgs>(
                 nameof(RowDragStarting),
@@ -110,7 +112,7 @@ namespace Avalonia.Controls
 
         internal bool ShouldSuppressSelectionDragFromRowDragHandle(int columnIndex)
         {
-            if (!CanUserReorderRows)
+            if (!CanStartRowDragGesture())
             {
                 return false;
             }
@@ -131,8 +133,24 @@ namespace Avalonia.Controls
                    RowDragHandle == DataGridRowDragHandle.RowHeaderAndRow;
         }
 
-        internal bool ShouldPreserveSelectionForRowDrag(int columnIndex, int slot, bool isSelected, KeyModifiers modifiers)
+        internal bool CanStartRowDragGesture()
         {
+            return CanUserReorderRows &&
+                   !IsReadOnly &&
+                   IsEnabled &&
+                   EditingRow == null &&
+                   DataConnection?.EditableCollectionView?.IsAddingNew != true &&
+                   DataConnection?.EditableCollectionView?.IsEditingItem != true;
+        }
+
+        internal bool ShouldDeferSelectionForRowDrag(
+            int columnIndex,
+            int slot,
+            bool isSelected,
+            PointerPressedEventArgs pointerPressedEventArgs)
+        {
+            _deferredRowDragSelection = null;
+
             if (!ShouldSuppressSelectionDragFromRowDragHandle(columnIndex) ||
                 SelectionUnit != DataGridSelectionUnit.FullRow ||
                 SelectionMode != DataGridSelectionMode.Extended ||
@@ -143,8 +161,52 @@ namespace Avalonia.Controls
                 return false;
             }
 
-            KeyboardHelper.GetMetaKeyState(this, modifiers, out var ctrl, out _);
-            return !ctrl && !modifiers.HasFlag(KeyModifiers.Shift);
+            KeyboardHelper.GetMetaKeyState(this, pointerPressedEventArgs.KeyModifiers, out bool ctrl, out _);
+            if (ctrl || pointerPressedEventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                return false;
+            }
+
+            _deferredRowDragSelection = new DeferredRowDragSelection(
+                pointerPressedEventArgs.Pointer.Id,
+                columnIndex,
+                slot,
+                pointerPressedEventArgs);
+            return true;
+        }
+
+        internal void CompleteDeferredRowDragSelection(int pointerId)
+        {
+            DeferredRowDragSelection? deferred = TakeDeferredRowDragSelection(pointerId);
+            if (deferred == null ||
+                !GetRowSelection(deferred.Slot) ||
+                _selectedItems.Count <= 1)
+            {
+                return;
+            }
+
+            UpdateStateOnMouseLeftButtonDown(
+                deferred.TriggerEvent,
+                deferred.ColumnIndex,
+                deferred.Slot,
+                allowEdit: false);
+        }
+
+        internal void CancelDeferredRowDragSelection(int pointerId)
+        {
+            TakeDeferredRowDragSelection(pointerId);
+        }
+
+        private DeferredRowDragSelection? TakeDeferredRowDragSelection(int pointerId)
+        {
+            if (_deferredRowDragSelection?.PointerId != pointerId)
+            {
+                return null;
+            }
+
+            DeferredRowDragSelection deferred = _deferredRowDragSelection;
+            _deferredRowDragSelection = null;
+            return deferred;
         }
 
         private void RefreshRowDragDropController()
@@ -239,6 +301,29 @@ namespace Avalonia.Controls
 
             _rowDragDropControllerFactory = e.NewValue as IDataGridRowDragDropControllerFactory;
             RefreshRowDragDropController();
+        }
+
+        private sealed class DeferredRowDragSelection
+        {
+            public DeferredRowDragSelection(
+                int pointerId,
+                int columnIndex,
+                int slot,
+                PointerPressedEventArgs triggerEvent)
+            {
+                PointerId = pointerId;
+                ColumnIndex = columnIndex;
+                Slot = slot;
+                TriggerEvent = triggerEvent;
+            }
+
+            public int PointerId { get; }
+
+            public int ColumnIndex { get; }
+
+            public int Slot { get; }
+
+            public PointerPressedEventArgs TriggerEvent { get; }
         }
     }
 #nullable restore

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -282,11 +282,11 @@ internal
                     bool shouldHandleSelection = !e.Handled || !focusWithin || !isSelected || ctrl;
                     if (shouldHandleSelection)
                     {
-                        var preserveSelectionForRowDrag =
-                            OwningGrid.ShouldPreserveSelectionForRowDrag(ColumnIndex, OwningRow.Slot, isSelected, e.KeyModifiers);
+                        var deferSelectionForRowDrag =
+                            OwningGrid.ShouldDeferSelectionForRowDrag(ColumnIndex, OwningRow.Slot, isSelected, e);
                         bool allowEdit = !e.Handled && focusWithin && isSelected && !ctrl &&
                                          OwningGrid.ShouldBeginEditOnPointer(e);
-                        var handled = preserveSelectionForRowDrag
+                        var handled = deferSelectionForRowDrag
                             ? true
                             : OwningGrid.UpdateStateOnMouseLeftButtonDown(e, ColumnIndex, OwningRow.Slot, allowEdit);
                         if (!OwningGrid.ShouldSuppressSelectionDragFromRowDragHandle(ColumnIndex))

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -290,9 +290,9 @@ internal
                         return;
                     }
 
-                    var preserveSelectionForRowDrag =
-                        OwningGrid.ShouldPreserveSelectionForRowDrag(columnIndex: -1, Slot, OwningGrid.GetRowSelection(Slot), e.KeyModifiers);
-                    if (preserveSelectionForRowDrag)
+                    var deferSelectionForRowDrag =
+                        OwningGrid.ShouldDeferSelectionForRowDrag(columnIndex: -1, Slot, OwningGrid.GetRowSelection(Slot), e);
+                    if (deferSelectionForRowDrag)
                     {
                         e.Handled = true;
                     }

--- a/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
+++ b/src/Avalonia.Controls.DataGrid/DragDrop/DataGridRowDragDropController.cs
@@ -116,9 +116,7 @@ namespace Avalonia.Controls.DataGridDragDrop
 
         private bool ShouldHandlePointer(PointerEventArgs e)
         {
-            if (!_grid.CanUserReorderRows ||
-                _grid.IsReadOnly ||
-                !_grid.IsEnabled)
+            if (!_grid.CanStartRowDragGesture())
             {
                 return false;
             }
@@ -138,13 +136,6 @@ namespace Avalonia.Controls.DataGridDragDrop
             // Don't intercept clicks on expand/collapse toggle buttons (hierarchical expanders)
             if (IsExpanderButtonHit(e.Source) ||
                 IsExpanderButtonHit(_grid.GetVisualAt(point.Position)))
-            {
-                return false;
-            }
-
-            if (_grid.EditingRow != null ||
-                _grid.DataConnection?.EditableCollectionView?.IsAddingNew == true ||
-                _grid.DataConnection?.EditableCollectionView?.IsEditingItem == true)
             {
                 return false;
             }
@@ -431,11 +422,17 @@ namespace Avalonia.Controls.DataGridDragDrop
                 return;
             }
 
+            _grid.CompleteDeferredRowDragSelection(_pointerId.Value);
             ResetPointerState();
         }
 
         private void ResetPointerState()
         {
+            if (_pointerId.HasValue)
+            {
+                _grid.CancelDeferredRowDragSelection(_pointerId.Value);
+            }
+
             _pointerId = null;
             _pointerStart = default;
             _dragStartRow = null;
@@ -459,6 +456,11 @@ namespace Avalonia.Controls.DataGridDragDrop
             {
                 ResetPointerState();
                 return;
+            }
+
+            if (_pointerId.HasValue)
+            {
+                _grid.CancelDeferredRowDragSelection(_pointerId.Value);
             }
 
             var session = new DataGridRowDragSession(_grid, info.Items, info.Indices, info.FromSelection);


### PR DESCRIPTION
## Summary

Completes the multi-row drag gesture so selected rows remain intact while drag intent is being determined, while preserving normal click selection behavior when no drag occurs.

- defers selection collapse when pointer press starts on an already selected row in an extended full-row multi-selection
- cancels the deferred collapse as soon as the row drag crosses its threshold, allowing the existing drag-info pipeline to include every selected row
- applies the normal single-row click selection on pointer release when no drag started
- supports both whole-row and row-header drag surfaces
- centralizes row-drag eligibility so read-only, disabled, add-new, and edit states do not suppress ordinary selection when a row drag cannot start
- documents the press/threshold/release contract

## Problem analysis

The repository already had the two core pieces needed for multi-row drag:

1. `DataGridRowDragDropController.TryCreateDragInfo()` uses all selected rows when the pressed row is selected and `DragSelectedRows` is enabled.
2. The selection handler preserves a multi-selection on pointer press when `SuppressSelectionDragFromDragHandle` is enabled.

The remaining gap was pointer-release behavior. Preserving selection unconditionally on press solved drag startup, but it also meant a simple click on one selected row never performed the usual selection collapse. The issue discussion correctly identifies the required sequencing: preserve on press, decide between click and drag, then apply click selection on release only if the drag threshold was not crossed.

## Implementation

`DataGrid` now owns a small deferred row-selection record containing the pointer id, row slot, column surface, and original press event.

- row/cell press records the deferred selection only when a built-in row drag is actually eligible
- the row drag controller completes it on matching pointer release
- drag startup and every pointer-controller reset path cancel it
- completion reuses the existing pointer selection pipeline, keeping currency, edit commit, selection notifications, and bound `SelectedItems` behavior consistent

The controller and selection code share one `CanStartRowDragGesture()` predicate so gesture suppression cannot diverge from actual drag eligibility.

No view code-behind, reflection, static state, or new public API is introduced.

## Tests

Headless coverage verifies:

- whole-row press keeps the complete selection until release
- whole-row release without drag collapses to the clicked row
- canceled/deferred selection remains multi-selected, matching drag startup behavior
- row-header press/release follows the same contract
- read-only grids do not defer selection because row drag cannot start
- existing suppression-disabled behavior remains unchanged

Validation performed:

- mouse-selection + row-drag controller lane: **96 passed**
- complete unit suite: **2,252 passed**
- production build, `net8.0`: **0 errors**
- production build, `net10.0`: **0 errors**

Fixes #296
