### PR TITLE
Add Excel/DataGrip-style distinct-value column filtering

### DIFF
--- a/docfx/articles/column-header-menus-and-filters.md
+++ b/docfx/articles/column-header-menus-and-filters.md
@@ -4,6 +4,8 @@ This guide covers header context menus, programmatic filter flyout display, and 
 
 For complete `FilteringModel` wiring (descriptors, column ids, flyout templates, and adapter behavior), see [Filtering Model: End-to-End Usage](filtering-model-end-to-end.md).
 
+For the built-in searchable checkbox/value/count popup, see [Distinct-Value Column Filtering](distinct-value-column-filtering.md).
+
 ## UX Reference (Common Grids)
 
 In mature grid controls, column headers typically support:
@@ -23,6 +25,7 @@ ProDataGrid now follows the same UX patterns using Avalonia concepts such as `Co
 - `DataGrid.ClearFilter(DataGridColumn column)`: clear the active filter for a column.
 - `DataGridColumn.ClearFilter()`: clear the active filter for the column instance.
 - `DataGridColumnDefinition.FilterFlyout` / `FilterFlyoutKey`: configure per-column flyouts when using `ColumnDefinitionsSource`.
+- `DataGridDistinctValueFilterFlyout`: generate distinct values and counts through a typed accessor and update the central filtering model with `In` descriptors.
 
 ## Context Menu with Filter Actions
 

--- a/docfx/articles/data-operations.md
+++ b/docfx/articles/data-operations.md
@@ -125,6 +125,7 @@ For a full end-to-end walkthrough (ViewModel + XAML + flyouts + troubleshooting)
 - Use stable column ids (`ColumnKey`, definition instance, or definition `ColumnKey`) and include `propertyPath` when you are not using a custom predicate.
 - Adapter guarantees: descriptor to predicate for string/between/in/custom cases, duplicate guards, observer-mode reconciliation, and selection stability are covered by unit tests.
 - The filter button glyphs and default editor templates (text/number/date/enum) live in `Themes/Generic.xaml` and can be reused across themes and samples.
+- `DataGridDistinctValueFilterFlyout` adds a built-in searchable checkbox/value/count popup that writes `FilteringOperator.In` descriptors through the same model. See [Distinct-Value Column Filtering](distinct-value-column-filtering.md).
 
 `FilteringModelFactory` and `FilteringAdapterFactory` are CLR properties; set them in code before the grid is loaded if you need custom creation.
 
@@ -184,6 +185,16 @@ Columns expose `FilterFlyout` and `ShowFilterButton` so you can plug in custom e
 ```
 
 Use `ShowFilterButton="True"` if you want a filter glyph without a flyout (for example, to open an external panel).
+
+For an Excel/DataGrip-style popup backed by a typed value accessor:
+
+```xml
+<DataGridTextColumn.FilterFlyout>
+  <filtering:DataGridDistinctValueFilterFlyout />
+</DataGridTextColumn.FilterFlyout>
+```
+
+The popup provides substring search and distinct values with row counts; checking values immediately creates an `In` descriptor, while clearing all checks removes the descriptor. See [Distinct-Value Column Filtering](distinct-value-column-filtering.md) for the reflection-free accessor setup.
 
 ### DynamicData Integration (Filtering)
 

--- a/docfx/articles/distinct-value-column-filtering.md
+++ b/docfx/articles/distinct-value-column-filtering.md
@@ -1,0 +1,98 @@
+# Distinct-Value Column Filtering
+
+`DataGridDistinctValueFilterFlyout` provides an Excel/DataGrip-style filter surface for a column. The popup contains a substring search box and a `ListBox`; each row shows a checkbox, the formatted value, and its source-row count.
+
+Selections update the grid's central `IFilteringModel` immediately:
+
+- No checked values means no descriptor and therefore no filter.
+- One or more checked values produce a `FilteringOperator.In` descriptor.
+- Unchecking the final selected value removes that column's descriptor.
+- Searching changes only the visible options. Selections hidden by the search remain selected.
+- Reopening the popup rebuilds counts from the collection view's underlying `SourceCollection`, so values do not disappear merely because the current column is already filtered.
+
+## Configure a typed column definition
+
+The distinct-value popup reads values through `IDataGridColumnValueAccessor`. Typed column definitions create this accessor as part of their binding, so they are the recommended reflection-free setup.
+
+Declare the reusable flyout in XAML:
+
+```xml
+<UserControl
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:filtering="clr-namespace:Avalonia.Controls.DataGridFiltering;assembly=Avalonia.Controls.DataGrid">
+  <UserControl.Resources>
+    <filtering:DataGridDistinctValueFilterFlyout
+        x:Key="StatusDistinctValueFilter"
+        Placement="Bottom" />
+  </UserControl.Resources>
+
+  <DataGrid ItemsSource="{Binding View}"
+            FilteringModel="{Binding FilteringModel}"
+            ColumnDefinitionsSource="{Binding ColumnDefinitions}" />
+</UserControl>
+```
+
+Point the typed definition at that resource key:
+
+```csharp
+var statusColumn = new DataGridTextColumnDefinition
+{
+    ColumnKey = "Status",
+    Header = "Status",
+    Binding = DataGridBindingDefinition.Create<Order, string>(order => order.Status),
+    FilterFlyoutKey = "StatusDistinctValueFilter"
+};
+```
+
+The definition owns no view object; it only carries a stable resource key. The view resolves the flyout while materializing the column.
+
+## Configure an existing column
+
+If a column was not produced from a typed definition, register a value accessor explicitly in the composition layer:
+
+```csharp
+DataGridColumnFilter.SetValueAccessor(
+    statusColumn,
+    new DataGridColumnValueAccessor<Order, string>(order => order.Status));
+```
+
+Then assign the flyout in XAML:
+
+```xml
+<DataGridTextColumn Header="Status"
+                    ColumnKey="Status"
+                    Binding="{Binding Status}"
+                    SortMemberPath="Status">
+  <DataGridTextColumn.FilterFlyout>
+    <filtering:DataGridDistinctValueFilterFlyout />
+  </DataGridTextColumn.FilterFlyout>
+</DataGridTextColumn>
+```
+
+The flyout deliberately does not reflect over `SortMemberPath` or the binding path to read values. If no typed accessor is available, opening is canceled and `LastError` explains the missing requirement.
+
+## Formatting and equality
+
+Use `DisplayFormatter` to customize visible text. Null values display as `(Empty)` by default. Use `ValueComparer` when grouping and membership should use custom equality, such as case-insensitive string equality:
+
+```csharp
+var flyout = new DataGridDistinctValueFilterFlyout
+{
+    ValueComparer = StringComparer.OrdinalIgnoreCase,
+    DisplayFormatter = value => value?.ToString() ?? "(No value)"
+};
+```
+
+When a custom comparer is supplied, the generated descriptor carries a typed predicate so the popup's grouping semantics and the actual row filter remain consistent.
+
+## Custom presentation
+
+The default compiled-binding template is `DataGridFilterDistinctValuesEditorTemplate` in `Themes/Generic.xaml`. It consumes the small `IFilterDistinctValuesContext` and `IFilterDistinctValueOption` contracts. Applications can replace `ContentTemplate` on the flyout while retaining the built-in counting, searching, selection, and filtering behavior.
+
+The standard template uses these theme tokens:
+
+- `DataGridFilterDistinctValuesEditorWidth`
+- `DataGridFilterDistinctValuesListMaxHeight`
+- `DataGridFilterEditorSpacing`
+- `DataGridFilterEditorActionSpacing`

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -24,6 +24,8 @@
     href: sorting-model-end-to-end.md
   - name: Filtering Model (End-to-End)
     href: filtering-model-end-to-end.md
+  - name: Distinct-Value Column Filtering
+    href: distinct-value-column-filtering.md
   - name: Search Model (End-to-End)
     href: search-model-end-to-end.md
   - name: Search Model (High-Performance Mode)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridFilterFlyoutTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridFilterFlyoutTests.cs
@@ -194,6 +194,178 @@ public class DataGridFilterFlyoutTests
         }
     }
 
+    [AvaloniaFact]
+    public void Distinct_Value_Flyout_Counts_Searches_And_Filters_Through_Central_Model()
+    {
+        var flyout = new DataGridDistinctValueFilterFlyout();
+        var items = new ObservableCollection<Item>
+        {
+            new("Ada"),
+            new("Ada"),
+            new("Grace")
+        };
+        var (grid, root, column) = CreateGrid(flyout, items);
+
+        try
+        {
+            column.ColumnKey = "Name";
+            DataGridColumnFilter.SetValueAccessor(
+                column,
+                new DataGridColumnValueAccessor<Item, string>(item => item.Name));
+
+            Assert.True(column.TryShowFilterFlyout());
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(flyout.IsOpen);
+            Assert.Null(flyout.LastError);
+            Assert.NotNull(flyout.ContentTemplate);
+            DataGridDistinctValueFilterContext context = Assert.IsType<DataGridDistinctValueFilterContext>(flyout.Content);
+            Assert.Same(context, flyout.Context);
+            Assert.Collection(
+                context.Options,
+                option =>
+                {
+                    Assert.Equal("Ada", option.Display);
+                    Assert.Equal(2, option.Count);
+                    Assert.False(option.IsSelected);
+                },
+                option =>
+                {
+                    Assert.Equal("Grace", option.Display);
+                    Assert.Equal(1, option.Count);
+                    Assert.False(option.IsSelected);
+                });
+
+            IFilterDistinctValueOption ada = context.Options.Single(option => option.Display == "Ada");
+            ada.IsSelected = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(2, grid.DataConnection.Count);
+            FilteringDescriptor descriptor = Assert.Single(grid.FilteringModel.Descriptors);
+            Assert.Equal(FilteringOperator.In, descriptor.Operator);
+            Assert.Equal("Ada", Assert.Single(descriptor.Values));
+
+            context.SearchText = "rac";
+            IFilterDistinctValueOption visible = Assert.Single(context.Options);
+            Assert.Equal("Grace", visible.Display);
+
+            ada.IsSelected = false;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(grid.FilteringModel.Descriptors);
+            Assert.Equal(3, grid.DataConnection.Count);
+        }
+        finally
+        {
+            flyout.Hide();
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Distinct_Value_Flyout_Overrides_Accessor_Comparer_And_Formatter()
+    {
+        var flyout = new DataGridDistinctValueFilterFlyout
+        {
+            ValueAccessor = new DataGridColumnValueAccessor<Item, string>(item => item.Name),
+            ValueComparer = System.StringComparer.OrdinalIgnoreCase,
+            DisplayFormatter = value => value?.ToString()?.ToUpperInvariant() ?? "EMPTY"
+        };
+        var items = new ObservableCollection<Item>
+        {
+            new("Ada"),
+            new("ADA"),
+            new("Grace")
+        };
+        var (grid, root, column) = CreateGrid(flyout, items);
+
+        try
+        {
+            column.ColumnKey = "Name";
+
+            Assert.True(column.TryShowFilterFlyout());
+            Dispatcher.UIThread.RunJobs();
+
+            DataGridDistinctValueFilterContext context = Assert.IsType<DataGridDistinctValueFilterContext>(flyout.Content);
+            IFilterDistinctValueOption ada = context.Options.Single(option => option.Display == "ADA");
+            Assert.Equal(2, ada.Count);
+            Assert.Equal("GRACE", context.Options.Single(option => option.Display == "GRACE").Display);
+
+            ada.IsSelected = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(2, grid.DataConnection.Count);
+        }
+        finally
+        {
+            flyout.Hide();
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Distinct_Value_Flyout_Uses_Unfiltered_Source_When_Reopened()
+    {
+        var flyout = new DataGridDistinctValueFilterFlyout();
+        var items = new ObservableCollection<Item>
+        {
+            new("Ada"),
+            new("Ada"),
+            new("Grace")
+        };
+        var (grid, root, column) = CreateGrid(flyout, items);
+
+        try
+        {
+            column.ColumnKey = "Name";
+            DataGridColumnFilter.SetValueAccessor(
+                column,
+                new DataGridColumnValueAccessor<Item, string>(item => item.Name));
+
+            Assert.True(column.TryShowFilterFlyout());
+            Dispatcher.UIThread.RunJobs();
+            DataGridDistinctValueFilterContext firstContext = Assert.IsType<DataGridDistinctValueFilterContext>(flyout.Content);
+            firstContext.Options.Single(option => option.Display == "Grace").IsSelected = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(1, grid.DataConnection.Count);
+
+            flyout.Hide();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(column.TryShowFilterFlyout());
+            Dispatcher.UIThread.RunJobs();
+
+            DataGridDistinctValueFilterContext reopened = Assert.IsType<DataGridDistinctValueFilterContext>(flyout.Content);
+            Assert.Equal(2, reopened.Options.Count);
+            Assert.Equal(2, reopened.Options.Single(option => option.Display == "Ada").Count);
+            Assert.True(reopened.Options.Single(option => option.Display == "Grace").IsSelected);
+        }
+        finally
+        {
+            flyout.Hide();
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Distinct_Value_Flyout_Cancels_Open_When_Accessor_Is_Missing()
+    {
+        var flyout = new DataGridDistinctValueFilterFlyout();
+        var (grid, root, column) = CreateGrid(flyout);
+
+        try
+        {
+            Assert.True(column.TryShowFilterFlyout());
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(flyout.IsOpen);
+            Assert.Contains("IDataGridColumnValueAccessor", flyout.LastError);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
     private static (DataGrid grid, Window root, DataGridTextColumn column) CreateGrid(Flyout? flyout)
     {
         var items = new ObservableCollection<Item>
@@ -202,6 +374,13 @@ public class DataGridFilterFlyoutTests
             new("Grace")
         };
 
+        return CreateGrid(flyout, items);
+    }
+
+    private static (DataGrid grid, Window root, DataGridTextColumn column) CreateGrid(
+        Flyout? flyout,
+        ObservableCollection<Item> items)
+    {
         var root = new Window
         {
             Width = 400,

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Avalonia.Controls.DataGridFiltering;
 using Xunit;
@@ -110,6 +111,34 @@ public class DataGridDistinctValueFilterContextTests
     }
 
     [Fact]
+    public void Refresh_Prefers_Exact_Column_Descriptor_When_Property_Path_Is_Shared()
+    {
+        IFilteringModel model = new ReadOnlyFilteringModel(new[]
+        {
+            new FilteringDescriptor(
+                "FirstNameColumn",
+                FilteringOperator.In,
+                nameof(Item.Name),
+                values: new object[] { "Alpha" }),
+            new FilteringDescriptor(
+                "Name",
+                FilteringOperator.In,
+                nameof(Item.Name),
+                values: new object[] { "Beta" })
+        });
+        var context = CreateContext(model);
+
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta")
+        });
+
+        Assert.False(context.Options.Single(option => option.Display == "Alpha").IsSelected);
+        Assert.True(context.Options.Single(option => option.Display == "Beta").IsSelected);
+    }
+
+    [Fact]
     public void Custom_Comparer_Groups_And_Filters_Values_Consistently()
     {
         var model = new FilteringModel();
@@ -139,7 +168,7 @@ public class DataGridDistinctValueFilterContextTests
         Assert.False(descriptor.Predicate(new Item("Beta")));
     }
 
-    private static DataGridDistinctValueFilterContext CreateContext(FilteringModel model)
+    private static DataGridDistinctValueFilterContext CreateContext(IFilteringModel model)
     {
         return new DataGridDistinctValueFilterContext(
             model,
@@ -161,4 +190,50 @@ public class DataGridDistinctValueFilterContextTests
     }
 
     private sealed record Item(string? Name);
+
+    private sealed class ReadOnlyFilteringModel : IFilteringModel
+    {
+        public ReadOnlyFilteringModel(IReadOnlyList<FilteringDescriptor> descriptors)
+        {
+            Descriptors = descriptors;
+        }
+
+        public IReadOnlyList<FilteringDescriptor> Descriptors { get; }
+
+        public bool OwnsViewFilter { get; set; }
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<FilteringChangedEventArgs>? FilteringChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<FilteringChangingEventArgs>? FilteringChanging
+        {
+            add { }
+            remove { }
+        }
+
+        public void SetOrUpdate(FilteringDescriptor descriptor) => throw new NotSupportedException();
+
+        public void Apply(IEnumerable<FilteringDescriptor> descriptors) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Remove(object columnId) => throw new NotSupportedException();
+
+        public bool Move(object columnId, int newIndex) => throw new NotSupportedException();
+
+        public void BeginUpdate() => throw new NotSupportedException();
+
+        public void EndUpdate() => throw new NotSupportedException();
+
+        public IDisposable DeferRefresh() => throw new NotSupportedException();
+    }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
@@ -111,6 +111,33 @@ public class DataGridDistinctValueFilterContextTests
     }
 
     [Fact]
+    public void Refresh_Retains_Selected_Value_Missing_From_Source_With_Zero_Count()
+    {
+        var model = new FilteringModel();
+        model.SetOrUpdate(new FilteringDescriptor(
+            "Name",
+            FilteringOperator.In,
+            nameof(Item.Name),
+            values: new object[] { "Beta", "Persisted" }));
+        var context = CreateContext(model);
+
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta")
+        });
+
+        IFilterDistinctValueOption persisted = context.Options.Single(option => option.Display == "Persisted");
+        Assert.True(persisted.IsSelected);
+        Assert.Equal(0, persisted.Count);
+
+        persisted.IsSelected = false;
+
+        FilteringDescriptor descriptor = Assert.Single(model.Descriptors);
+        Assert.Equal("Beta", Assert.Single(descriptor.Values));
+    }
+
+    [Fact]
     public void Refresh_Prefers_Exact_Column_Descriptor_When_Property_Path_Is_Shared()
     {
         IFilteringModel model = new ReadOnlyFilteringModel(new[]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls.DataGridFiltering;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Filtering;
+
+public class DataGridDistinctValueFilterContextTests
+{
+    [Fact]
+    public void Refresh_Builds_Sorted_Distinct_Values_With_Counts_Unchecked()
+    {
+        var model = new FilteringModel();
+        var context = CreateContext(model);
+
+        context.Refresh(new[]
+        {
+            new Item("Beta"),
+            new Item("Alpha"),
+            new Item("Beta"),
+            new Item(null)
+        });
+
+        Assert.Collection(
+            context.Options,
+            option => AssertOption(option, "(Empty)", 1, false),
+            option => AssertOption(option, "Alpha", 1, false),
+            option => AssertOption(option, "Beta", 2, false));
+        Assert.Empty(model.Descriptors);
+    }
+
+    [Fact]
+    public void Search_Filters_Display_Options_By_Substring_Without_Changing_Selection()
+    {
+        var model = new FilteringModel();
+        var context = CreateContext(model);
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta"),
+            new Item("Alphabet")
+        });
+
+        context.Options.Single(option => option.Display == "Beta").IsSelected = true;
+        context.SearchText = "ALP";
+
+        Assert.Equal(new[] { "Alpha", "Alphabet" }, context.Options.Select(option => option.Display));
+        FilteringDescriptor descriptor = Assert.Single(model.Descriptors);
+        Assert.Equal(FilteringOperator.In, descriptor.Operator);
+        Assert.Equal("Beta", Assert.Single(descriptor.Values));
+    }
+
+    [Fact]
+    public void Selecting_Values_Creates_In_Descriptor_And_Unchecking_All_Removes_It()
+    {
+        var model = new FilteringModel();
+        var context = CreateContext(model);
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta"),
+            new Item("Gamma")
+        });
+
+        IFilterDistinctValueOption alpha = context.Options.Single(option => option.Display == "Alpha");
+        IFilterDistinctValueOption gamma = context.Options.Single(option => option.Display == "Gamma");
+        alpha.IsSelected = true;
+        gamma.IsSelected = true;
+
+        FilteringDescriptor descriptor = Assert.Single(model.Descriptors);
+        Assert.Equal("Name", descriptor.ColumnId);
+        Assert.Equal(nameof(Item.Name), descriptor.PropertyPath);
+        Assert.Equal(FilteringOperator.In, descriptor.Operator);
+        Assert.Equal(new object[] { "Alpha", "Gamma" }, descriptor.Values);
+
+        alpha.IsSelected = false;
+        gamma.IsSelected = false;
+
+        Assert.Empty(model.Descriptors);
+        Assert.All(context.Options, option => Assert.False(option.IsSelected));
+    }
+
+    [Fact]
+    public void Refresh_Restores_Selected_Values_From_Active_Descriptor()
+    {
+        var model = new FilteringModel();
+        model.SetOrUpdate(new FilteringDescriptor(
+            "Name",
+            FilteringOperator.In,
+            nameof(Item.Name),
+            values: new object[] { "Beta" }));
+        var context = CreateContext(model);
+
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta"),
+            new Item("Beta")
+        });
+
+        Assert.False(context.Options.Single(option => option.Display == "Alpha").IsSelected);
+        IFilterDistinctValueOption beta = context.Options.Single(option => option.Display == "Beta");
+        Assert.True(beta.IsSelected);
+        Assert.Equal(2, beta.Count);
+        Assert.Single(model.Descriptors);
+    }
+
+    [Fact]
+    public void Custom_Comparer_Groups_And_Filters_Values_Consistently()
+    {
+        var model = new FilteringModel();
+        var context = new DataGridDistinctValueFilterContext(
+            model,
+            "Name",
+            new DataGridColumnValueAccessor<Item, string?>(item => item.Name),
+            "Name",
+            nameof(Item.Name),
+            StringComparer.OrdinalIgnoreCase);
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("ALPHA"),
+            new Item("Beta")
+        });
+
+        DataGridDistinctValueFilterOption alpha = Assert.IsType<DataGridDistinctValueFilterOption>(
+            context.Options.Single(option => option.Display == "Alpha"));
+        Assert.Equal(2, alpha.Count);
+        Assert.Equal("Alpha", alpha.Value);
+        alpha.IsSelected = true;
+
+        FilteringDescriptor descriptor = Assert.Single(model.Descriptors);
+        Assert.NotNull(descriptor.Predicate);
+        Assert.True(descriptor.Predicate(new Item("alpha")));
+        Assert.False(descriptor.Predicate(new Item("Beta")));
+    }
+
+    private static DataGridDistinctValueFilterContext CreateContext(FilteringModel model)
+    {
+        return new DataGridDistinctValueFilterContext(
+            model,
+            "Name",
+            new DataGridColumnValueAccessor<Item, string?>(item => item.Name),
+            "Name",
+            nameof(Item.Name));
+    }
+
+    private static void AssertOption(
+        IFilterDistinctValueOption option,
+        string display,
+        int count,
+        bool isSelected)
+    {
+        Assert.Equal(display, option.Display);
+        Assert.Equal(count, option.Count);
+        Assert.Equal(isSelected, option.IsSelected);
+    }
+
+    private sealed record Item(string? Name);
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridDistinctValueFilterContextTests.cs
@@ -139,6 +139,39 @@ public class DataGridDistinctValueFilterContextTests
     }
 
     [Fact]
+    public void Property_Path_Fallback_Updates_And_Removes_The_Matched_Descriptor_Identity()
+    {
+        var model = new FilteringModel();
+        model.SetOrUpdate(new FilteringDescriptor(
+            "LegacyNameColumn",
+            FilteringOperator.In,
+            nameof(Item.Name),
+            values: new object[] { "Beta" }));
+        var context = CreateContext(model);
+
+        context.Refresh(new[]
+        {
+            new Item("Alpha"),
+            new Item("Beta")
+        });
+
+        IFilterDistinctValueOption alpha = context.Options.Single(option => option.Display == "Alpha");
+        IFilterDistinctValueOption beta = context.Options.Single(option => option.Display == "Beta");
+        Assert.True(beta.IsSelected);
+
+        alpha.IsSelected = true;
+
+        FilteringDescriptor descriptor = Assert.Single(model.Descriptors);
+        Assert.Equal("LegacyNameColumn", descriptor.ColumnId);
+        Assert.Equal(new object[] { "Alpha", "Beta" }, descriptor.Values);
+
+        alpha.IsSelected = false;
+        beta.IsSelected = false;
+
+        Assert.Empty(model.Descriptors);
+    }
+
+    [Fact]
     public void Custom_Comparer_Groups_And_Filters_Values_Consistently()
     {
         var model = new FilteringModel();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
@@ -409,6 +409,7 @@ public class DataGridThemeResourceCoverageTests
         new("DataGridFilterNumberEditorTemplate", typeof(IDataTemplate)),
         new("DataGridFilterDateEditorTemplate", typeof(IDataTemplate)),
         new("DataGridFilterEnumEditorTemplate", typeof(IDataTemplate)),
+        new("DataGridFilterDistinctValuesEditorTemplate", typeof(IDataTemplate)),
         new("DataGridColumnChooserItemTemplate", typeof(IDataTemplate)),
         new("DataGridHierarchicalCellTemplate", typeof(IDataTemplate))
     };
@@ -504,6 +505,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridFilterDateEditorWidth",
         "DataGridFilterDateEditorFieldSpacing",
         "DataGridFilterEnumEditorWidth",
+        "DataGridFilterDistinctValuesEditorWidth",
+        "DataGridFilterDistinctValuesListMaxHeight",
         "DataGridPivotHeaderSegmentsSpacing",
         "DataGridColumnBandHeaderSegmentsSpacing",
         "DataGridFilterButtonSize",
@@ -675,6 +678,8 @@ public class DataGridThemeResourceCoverageTests
         "DataGridFilterDateEditorWidth",
         "DataGridFilterDateEditorFieldSpacing",
         "DataGridFilterEnumEditorWidth",
+        "DataGridFilterDistinctValuesEditorWidth",
+        "DataGridFilterDistinctValuesListMaxHeight",
         "DataGridPivotHeaderSegmentsSpacing",
         "DataGridColumnBandHeaderSegmentsSpacing",
         "DataGridFilterButtonSize",

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
@@ -209,11 +209,21 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
         for (int i = 0; i < descriptors.Count; i++)
         {
             FilteringDescriptor descriptor = descriptors[i];
-            if (Equals(descriptor.ColumnId, _columnId) ||
-                (!string.IsNullOrEmpty(_propertyPath) &&
-                 string.Equals(descriptor.PropertyPath, _propertyPath, StringComparison.Ordinal)))
+            if (Equals(descriptor.ColumnId, _columnId))
             {
                 return descriptor;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(_propertyPath))
+        {
+            for (int i = 0; i < descriptors.Count; i++)
+            {
+                FilteringDescriptor descriptor = descriptors[i];
+                if (string.Equals(descriptor.PropertyPath, _propertyPath, StringComparison.Ordinal))
+                {
+                    return descriptor;
+                }
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
@@ -31,6 +31,7 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
     private readonly bool _usesCustomValueComparer;
     private readonly Func<object?, string> _displayFormatter;
     private readonly List<DataGridDistinctValueFilterOption> _allOptions = new();
+    private object _activeDescriptorColumnId;
     private string? _searchText;
     private bool _suppressFilterUpdates;
 
@@ -55,6 +56,7 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
     {
         _filteringModel = filteringModel ?? throw new ArgumentNullException(nameof(filteringModel));
         _columnId = columnId ?? throw new ArgumentNullException(nameof(columnId));
+        _activeDescriptorColumnId = _columnId;
         _valueAccessor = valueAccessor ?? throw new ArgumentNullException(nameof(valueAccessor));
         _propertyPath = propertyPath;
         _usesCustomValueComparer = valueComparer != null;
@@ -123,6 +125,7 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
         }
 
         FilteringDescriptor? activeDescriptor = FindActiveDescriptor();
+        _activeDescriptorColumnId = activeDescriptor?.ColumnId ?? _columnId;
         IReadOnlyList<object>? selectedValues = activeDescriptor?.Operator == FilteringOperator.In
             ? activeDescriptor.Values
             : null;
@@ -174,7 +177,8 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
 
         if (selectedValues.Count == 0)
         {
-            _filteringModel.Remove(_columnId);
+            _filteringModel.Remove(_activeDescriptorColumnId);
+            _activeDescriptorColumnId = _columnId;
             return;
         }
 
@@ -182,7 +186,7 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
             ? item => Contains(selectedValues, _valueAccessor.GetValue(item))
             : null;
         _filteringModel.SetOrUpdate(new FilteringDescriptor(
-            columnId: _columnId,
+            columnId: _activeDescriptorColumnId,
             @operator: FilteringOperator.In,
             propertyPath: _propertyPath,
             values: selectedValues,

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
@@ -130,6 +130,19 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
             ? activeDescriptor.Values
             : null;
 
+        if (selectedValues != null)
+        {
+            for (int i = 0; i < selectedValues.Count; i++)
+            {
+                object? selectedValue = selectedValues[i];
+                object key = selectedValue ?? s_nullKey;
+                if (!counts.ContainsKey(key))
+                {
+                    counts.Add(key, new ValueCount(selectedValue, count: 0));
+                }
+            }
+        }
+
         var nextOptions = new List<DataGridDistinctValueFilterOption>(counts.Count);
         foreach (ValueCount entry in counts.Values)
         {
@@ -269,10 +282,10 @@ sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, 
 
     private sealed class ValueCount
     {
-        public ValueCount(object? value)
+        public ValueCount(object? value, int count = 1)
         {
             Value = value;
-            Count = 1;
+            Count = count;
         }
 
         public object? Value { get; }

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterContext.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Avalonia.Controls.DataGridFiltering;
+
+/// <summary>
+/// Maintains the values, counts, search state, and selection for an Excel-style column filter.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridDistinctValueFilterContext : IFilterDistinctValuesContext, INotifyPropertyChanged
+{
+    private static readonly object s_nullKey = new();
+
+    private readonly IFilteringModel _filteringModel;
+    private readonly object _columnId;
+    private readonly string? _propertyPath;
+    private readonly IDataGridColumnValueAccessor _valueAccessor;
+    private readonly IEqualityComparer _valueComparer;
+    private readonly bool _usesCustomValueComparer;
+    private readonly Func<object?, string> _displayFormatter;
+    private readonly List<DataGridDistinctValueFilterOption> _allOptions = new();
+    private string? _searchText;
+    private bool _suppressFilterUpdates;
+
+    /// <summary>
+    /// Initializes a new distinct-value filter context.
+    /// </summary>
+    /// <param name="filteringModel">The central filtering model updated by value selections.</param>
+    /// <param name="columnId">The stable identifier of the target column.</param>
+    /// <param name="valueAccessor">The reflection-free accessor used to read column values.</param>
+    /// <param name="label">The label displayed above the available values.</param>
+    /// <param name="propertyPath">The optional property path stored in the generated descriptor.</param>
+    /// <param name="valueComparer">The optional comparer used to group and select values.</param>
+    /// <param name="displayFormatter">The optional formatter used to display values.</param>
+    public DataGridDistinctValueFilterContext(
+        IFilteringModel filteringModel,
+        object columnId,
+        IDataGridColumnValueAccessor valueAccessor,
+        string label,
+        string? propertyPath = null,
+        IEqualityComparer? valueComparer = null,
+        Func<object?, string>? displayFormatter = null)
+    {
+        _filteringModel = filteringModel ?? throw new ArgumentNullException(nameof(filteringModel));
+        _columnId = columnId ?? throw new ArgumentNullException(nameof(columnId));
+        _valueAccessor = valueAccessor ?? throw new ArgumentNullException(nameof(valueAccessor));
+        _propertyPath = propertyPath;
+        _usesCustomValueComparer = valueComparer != null;
+        _valueComparer = valueComparer ?? EqualityComparer<object>.Default;
+        _displayFormatter = displayFormatter ?? FormatDisplayValue;
+        Label = label ?? string.Empty;
+        Options = new ObservableCollection<IFilterDistinctValueOption>();
+    }
+
+    /// <summary>
+    /// Raised when a bindable property changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Gets the label displayed above the filter values.
+    /// </summary>
+    public string Label { get; }
+
+    /// <summary>
+    /// Gets or sets the case-insensitive substring used to search value display text.
+    /// </summary>
+    public string? SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (string.Equals(_searchText, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _searchText = value;
+            OnPropertyChanged();
+            ApplySearch();
+        }
+    }
+
+    /// <summary>
+    /// Gets the value options currently visible after applying <see cref="SearchText"/>.
+    /// </summary>
+    public ObservableCollection<IFilterDistinctValueOption> Options { get; }
+
+    /// <summary>
+    /// Rebuilds distinct values and counts from the supplied unfiltered source.
+    /// </summary>
+    /// <param name="items">The source rows to inspect.</param>
+    public void Refresh(IEnumerable? items)
+    {
+        var counts = new Dictionary<object, ValueCount>(new NullKeyComparer(_valueComparer));
+        if (items != null)
+        {
+            foreach (object? item in items)
+            {
+                object? value = _valueAccessor.GetValue(item!);
+                object key = value ?? s_nullKey;
+                if (counts.TryGetValue(key, out ValueCount? entry))
+                {
+                    entry.Count++;
+                }
+                else
+                {
+                    counts.Add(key, new ValueCount(value));
+                }
+            }
+        }
+
+        FilteringDescriptor? activeDescriptor = FindActiveDescriptor();
+        IReadOnlyList<object>? selectedValues = activeDescriptor?.Operator == FilteringOperator.In
+            ? activeDescriptor.Values
+            : null;
+
+        var nextOptions = new List<DataGridDistinctValueFilterOption>(counts.Count);
+        foreach (ValueCount entry in counts.Values)
+        {
+            bool isSelected = Contains(selectedValues, entry.Value);
+            nextOptions.Add(new DataGridDistinctValueFilterOption(
+                entry.Value,
+                _displayFormatter(entry.Value),
+                entry.Count,
+                isSelected,
+                OnOptionSelectionChanged));
+        }
+
+        nextOptions.Sort(static (left, right) =>
+            StringComparer.CurrentCultureIgnoreCase.Compare(left.Display, right.Display));
+
+        _suppressFilterUpdates = true;
+        try
+        {
+            _allOptions.Clear();
+            _allOptions.AddRange(nextOptions);
+            ApplySearch();
+        }
+        finally
+        {
+            _suppressFilterUpdates = false;
+        }
+    }
+
+    private void OnOptionSelectionChanged()
+    {
+        if (_suppressFilterUpdates)
+        {
+            return;
+        }
+
+        var selectedValues = new List<object>();
+        for (int i = 0; i < _allOptions.Count; i++)
+        {
+            DataGridDistinctValueFilterOption option = _allOptions[i];
+            if (option.IsSelected)
+            {
+                selectedValues.Add(option.Value!);
+            }
+        }
+
+        if (selectedValues.Count == 0)
+        {
+            _filteringModel.Remove(_columnId);
+            return;
+        }
+
+        Func<object, bool>? predicate = _usesCustomValueComparer
+            ? item => Contains(selectedValues, _valueAccessor.GetValue(item))
+            : null;
+        _filteringModel.SetOrUpdate(new FilteringDescriptor(
+            columnId: _columnId,
+            @operator: FilteringOperator.In,
+            propertyPath: _propertyPath,
+            values: selectedValues,
+            predicate: predicate));
+    }
+
+    private void ApplySearch()
+    {
+        Options.Clear();
+        string? search = string.IsNullOrWhiteSpace(_searchText) ? null : _searchText.Trim();
+        for (int i = 0; i < _allOptions.Count; i++)
+        {
+            DataGridDistinctValueFilterOption option = _allOptions[i];
+            if (search == null || option.Display.IndexOf(search, StringComparison.CurrentCultureIgnoreCase) >= 0)
+            {
+                Options.Add(option);
+            }
+        }
+    }
+
+    private FilteringDescriptor? FindActiveDescriptor()
+    {
+        IReadOnlyList<FilteringDescriptor> descriptors = _filteringModel.Descriptors;
+        for (int i = 0; i < descriptors.Count; i++)
+        {
+            FilteringDescriptor descriptor = descriptors[i];
+            if (Equals(descriptor.ColumnId, _columnId) ||
+                (!string.IsNullOrEmpty(_propertyPath) &&
+                 string.Equals(descriptor.PropertyPath, _propertyPath, StringComparison.Ordinal)))
+            {
+                return descriptor;
+            }
+        }
+
+        return null;
+    }
+
+    private bool Contains(IReadOnlyList<object>? values, object? candidate)
+    {
+        if (values == null)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < values.Count; i++)
+        {
+            if (_valueComparer.Equals(values[i], candidate!))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string FormatDisplayValue(object? value)
+    {
+        if (value == null)
+        {
+            return "(Empty)";
+        }
+
+        return Convert.ToString(value, CultureInfo.CurrentCulture) ?? string.Empty;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private sealed class ValueCount
+    {
+        public ValueCount(object? value)
+        {
+            Value = value;
+            Count = 1;
+        }
+
+        public object? Value { get; }
+
+        public int Count { get; set; }
+    }
+
+    private sealed class NullKeyComparer : IEqualityComparer<object>
+    {
+        private readonly IEqualityComparer _inner;
+
+        public NullKeyComparer(IEqualityComparer inner)
+        {
+            _inner = inner;
+        }
+
+        bool IEqualityComparer<object>.Equals(object? left, object? right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(left, s_nullKey) || ReferenceEquals(right, s_nullKey))
+            {
+                return false;
+            }
+
+            return _inner.Equals(left!, right!);
+        }
+
+        int IEqualityComparer<object>.GetHashCode(object value)
+        {
+            return ReferenceEquals(value, s_nullKey) ? 0 : _inner.GetHashCode(value);
+        }
+    }
+}
+
+/// <summary>
+/// Represents one distinct source value and its count.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridDistinctValueFilterOption : IFilterDistinctValueOption, INotifyPropertyChanged
+{
+    private readonly Action _selectionChanged;
+    private bool _isSelected;
+
+    internal DataGridDistinctValueFilterOption(
+        object? value,
+        string display,
+        int count,
+        bool isSelected,
+        Action selectionChanged)
+    {
+        Value = value;
+        Display = display;
+        Count = count;
+        _isSelected = isSelected;
+        _selectionChanged = selectionChanged;
+    }
+
+    /// <summary>
+    /// Raised when <see cref="IsSelected"/> changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Gets the source value represented by this option.
+    /// </summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// Gets the formatted value displayed in the popup.
+    /// </summary>
+    public string Display { get; }
+
+    /// <summary>
+    /// Gets the number of source rows containing this value.
+    /// </summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// Gets or sets whether the value participates in the active filter.
+    /// </summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected == value)
+            {
+                return;
+            }
+
+            _isSelected = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+            _selectionChanged();
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterFlyout.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridDistinctValueFilterFlyout.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Avalonia.Collections;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Controls.DataGridFiltering;
+
+/// <summary>
+/// A column filter flyout that lists distinct values, row counts, and a substring search box.
+/// </summary>
+/// <remarks>
+/// The target column must expose an <see cref="IDataGridColumnValueAccessor"/> through
+/// <see cref="DataGridColumnFilter.ValueAccessorProperty"/> or <see cref="DataGridColumnMetadata.ValueAccessorProperty"/>.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+class DataGridDistinctValueFilterFlyout : Flyout
+{
+    private DataGridDistinctValueFilterContext? _context;
+    private IFilteringModel? _contextModel;
+    private object? _contextColumnId;
+    private IDataGridColumnValueAccessor? _contextAccessor;
+    private System.Collections.IEqualityComparer? _contextComparer;
+    private Func<object?, string>? _contextFormatter;
+
+    /// <summary>
+    /// Gets or sets an optional reflection-free value accessor that overrides the accessor registered on the column.
+    /// </summary>
+    public IDataGridColumnValueAccessor? ValueAccessor { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional comparer used to group values and restore selected values.
+    /// </summary>
+    public System.Collections.IEqualityComparer? ValueComparer { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional formatter for values shown in the popup.
+    /// </summary>
+    public Func<object?, string>? DisplayFormatter { get; set; }
+
+    /// <summary>
+    /// Gets the active filter context after the flyout has opened successfully.
+    /// </summary>
+    public DataGridDistinctValueFilterContext? Context => _context;
+
+    /// <summary>
+    /// Gets an explanation of the last initialization failure, or <see langword="null"/> when initialization succeeded.
+    /// </summary>
+    public string? LastError { get; private set; }
+
+    /// <inheritdoc/>
+    protected override void OnOpening(CancelEventArgs args)
+    {
+        DataGridColumnHeader? header = FindColumnHeader(Target);
+        DataGridColumn? column = header?.OwningColumn;
+        DataGrid? grid = column?.OwningGrid;
+        if (column == null || grid == null)
+        {
+            LastError = "The distinct-value filter must be opened from a DataGrid column header.";
+            args.Cancel = true;
+            base.OnOpening(args);
+            return;
+        }
+
+        IDataGridColumnValueAccessor? accessor = ValueAccessor ??
+            DataGridColumnFilter.GetValueAccessor(column) ??
+            DataGridColumnMetadata.GetValueAccessor(column);
+        if (accessor == null)
+        {
+            LastError = "The column must provide an IDataGridColumnValueAccessor for reflection-free distinct-value filtering.";
+            args.Cancel = true;
+            base.OnOpening(args);
+            return;
+        }
+
+        object columnId = DataGridColumnMetadata.GetColumnId(column);
+        IFilteringModel filteringModel = grid.FilteringModel;
+        if (_context == null ||
+            !ReferenceEquals(_contextModel, filteringModel) ||
+            !Equals(_contextColumnId, columnId) ||
+            !ReferenceEquals(_contextAccessor, accessor) ||
+            !ReferenceEquals(_contextComparer, ValueComparer) ||
+            !ReferenceEquals(_contextFormatter, DisplayFormatter))
+        {
+            string label = Convert.ToString(column.Header) ?? "Values";
+            _context = new DataGridDistinctValueFilterContext(
+                filteringModel,
+                columnId,
+                accessor,
+                label,
+                column.GetSortPropertyName(),
+                ValueComparer,
+                DisplayFormatter);
+            _contextModel = filteringModel;
+            _contextColumnId = columnId;
+            _contextAccessor = accessor;
+            _contextComparer = ValueComparer;
+            _contextFormatter = DisplayFormatter;
+        }
+
+        IEnumerable? source = grid.ItemsSource;
+        if (source is IDataGridCollectionView collectionView)
+        {
+            source = collectionView.SourceCollection;
+        }
+
+        _context.Refresh(source);
+        Content = _context;
+        ResolveThemeResources(grid);
+        LastError = null;
+        base.OnOpening(args);
+    }
+
+    private void ResolveThemeResources(DataGrid grid)
+    {
+        if (ContentTemplate == null &&
+            grid.TryFindResource("DataGridFilterDistinctValuesEditorTemplate", out object? templateResource) &&
+            templateResource is IDataTemplate template)
+        {
+            ContentTemplate = template;
+        }
+
+        if (FlyoutPresenterTheme == null &&
+            grid.TryFindResource("DataGridFilterFlyoutPresenterTheme", out object? themeResource) &&
+            themeResource is ControlTheme theme)
+        {
+            FlyoutPresenterTheme = theme;
+        }
+    }
+
+    private static DataGridColumnHeader? FindColumnHeader(Control? target)
+    {
+        Visual? current = target;
+        while (current != null)
+        {
+            if (current is DataGridColumnHeader header)
+            {
+                return header;
+            }
+
+            current = current.GetVisualParent();
+        }
+
+        return null;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Filtering/FilterContextInterfaces.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/FilterContextInterfaces.cs
@@ -87,3 +87,55 @@ interface IEnumOption
     string Display { get; }
     bool IsSelected { get; set; }
 }
+
+/// <summary>
+/// Contract consumed by the built-in distinct-value filter template.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IFilterDistinctValuesContext
+{
+    /// <summary>
+    /// Gets the label displayed above the filter values.
+    /// </summary>
+    string Label { get; }
+
+    /// <summary>
+    /// Gets or sets the substring used to search the available values.
+    /// </summary>
+    string? SearchText { get; set; }
+
+    /// <summary>
+    /// Gets the values currently visible after applying <see cref="SearchText"/>.
+    /// </summary>
+    ObservableCollection<IFilterDistinctValueOption> Options { get; }
+}
+
+/// <summary>
+/// Represents one value in a distinct-value filter.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IFilterDistinctValueOption
+{
+    /// <summary>
+    /// Gets the display text for the value.
+    /// </summary>
+    string Display { get; }
+
+    /// <summary>
+    /// Gets the number of source rows containing the value.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Gets or sets whether the value participates in the active filter.
+    /// </summary>
+    bool IsSelected { get; set; }
+}

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -193,6 +193,8 @@
       <x:Double x:Key="DataGridFilterDateEditorWidth">260</x:Double>
       <x:Double x:Key="DataGridFilterDateEditorFieldSpacing">6</x:Double>
       <x:Double x:Key="DataGridFilterEnumEditorWidth">240</x:Double>
+      <x:Double x:Key="DataGridFilterDistinctValuesEditorWidth">280</x:Double>
+      <x:Double x:Key="DataGridFilterDistinctValuesListMaxHeight">320</x:Double>
       <x:Double x:Key="DataGridPivotHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridColumnBandHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridFilterButtonSize">22</x:Double>

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -115,6 +115,41 @@
         </StackPanel>
       </DataTemplate>
 
+      <!-- Excel/DataGrip-style distinct-value filter -->
+      <DataTemplate x:Key="DataGridFilterDistinctValuesEditorTemplate"
+                    x:DataType="filtering:IFilterDistinctValuesContext">
+        <StackPanel Spacing="{DynamicResource DataGridFilterEditorSpacing}"
+                    Width="{DynamicResource DataGridFilterDistinctValuesEditorWidth}">
+          <TextBlock Text="{Binding Label, FallbackValue=Values}"
+                     FontWeight="SemiBold" />
+          <TextBox PlaceholderText="Search values"
+                   AutomationProperties.Name="Search distinct values"
+                   Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+          <ListBox ItemsSource="{Binding Options}"
+                   AutomationProperties.Name="Distinct values"
+                   MaxHeight="{DynamicResource DataGridFilterDistinctValuesListMaxHeight}">
+            <ListBox.ItemTemplate>
+              <DataTemplate x:DataType="filtering:IFilterDistinctValueOption">
+                <Grid ColumnDefinitions="Auto,*,Auto"
+                      ColumnSpacing="{DynamicResource DataGridFilterEditorActionSpacing}">
+                  <CheckBox AutomationProperties.Name="{Binding Display}"
+                            IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                            VerticalAlignment="Center" />
+                  <TextBlock Grid.Column="1"
+                             Text="{Binding Display}"
+                             TextTrimming="CharacterEllipsis"
+                             VerticalAlignment="Center" />
+                  <TextBlock Grid.Column="2"
+                             Text="{Binding Count, StringFormat='({0})'}"
+                             Opacity="0.7"
+                             VerticalAlignment="Center" />
+                </Grid>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </StackPanel>
+      </DataTemplate>
+
       <!-- Column chooser item template -->
       <DataTemplate x:Key="DataGridColumnChooserItemTemplate"
                     x:DataType="controls:DataGridColumnChooserItem">

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -127,6 +127,8 @@
       <x:Double x:Key="DataGridFilterDateEditorWidth">260</x:Double>
       <x:Double x:Key="DataGridFilterDateEditorFieldSpacing">6</x:Double>
       <x:Double x:Key="DataGridFilterEnumEditorWidth">240</x:Double>
+      <x:Double x:Key="DataGridFilterDistinctValuesEditorWidth">280</x:Double>
+      <x:Double x:Key="DataGridFilterDistinctValuesListMaxHeight">320</x:Double>
       <x:Double x:Key="DataGridPivotHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridColumnBandHeaderSegmentsSpacing">2</x:Double>
       <x:Double x:Key="DataGridFilterButtonSize">22</x:Double>

--- a/src/DataGridSample/Pages/ColumnDefinitionsFilteringModelPage.axaml
+++ b/src/DataGridSample/Pages/ColumnDefinitionsFilteringModelPage.axaml
@@ -9,6 +9,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:adapters="clr-namespace:DataGridSample.Adapters"
+    xmlns:filtering="clr-namespace:Avalonia.Controls.DataGridFiltering;assembly=Avalonia.Controls.DataGrid"
     xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
     x:DataType="viewModels:FilteringModelSampleViewModel"
     d:DesignHeight="720"
@@ -41,12 +42,8 @@
             Content="{Binding CustomerFilter}"
             ContentTemplate="{StaticResource DataGridFilterTextEditorTemplate}" />
 
-    <Flyout x:Key="StatusFilterFlyout"
-            x:DataType="viewModels:FilteringModelSampleViewModel"
-            Placement="Bottom"
-            FlyoutPresenterTheme="{StaticResource DataGridFilterFlyoutPresenterTheme}"
-            Content="{Binding StatusFilter}"
-            ContentTemplate="{StaticResource DataGridFilterEnumEditorTemplate}" />
+    <filtering:DataGridDistinctValueFilterFlyout x:Key="StatusFilterFlyout"
+                                                 Placement="Bottom" />
 
     <Flyout x:Key="RegionFilterFlyout"
             x:DataType="viewModels:FilteringModelSampleViewModel"
@@ -79,7 +76,7 @@
                 Spacing="4">
       <TextBlock Classes="h2">Column Definitions + FilteringModel</TextBlock>
       <TextBlock TextWrapping="Wrap"
-                 Text="Filter using model descriptors while columns are defined in view models. Per-column filter flyouts are resolved from resources via definition keys, including a custom Region template." />
+                 Text="Filter using model descriptors while columns are defined in view models. The Status header uses the built-in searchable distinct-value/count popup; other columns demonstrate shared and custom editors resolved through definition keys." />
     </StackPanel>
 
     <DataGrid Grid.Row="1"


### PR DESCRIPTION
## Summary

Implements the Excel/DataGrip-style distinct-value column filter requested in #301.

The new `DataGridDistinctValueFilterFlyout` opens from the existing column-header filter button and provides:

- a compiled-binding `ListBox` whose rows contain a checkbox, formatted value, and source-row count;
- case-insensitive substring search over displayed values;
- unchecked-by-default behavior when the column has no active filter;
- immediate `FilteringOperator.In` descriptor updates when one or more values are checked;
- removal of the column descriptor when the final checked value is unchecked;
- selection restoration when the popup is reopened;
- configurable value formatting and equality semantics;
- reflection-free value reads through `IDataGridColumnValueAccessor`.

Fixes #301.

## Previous gap

ProDataGrid already had the pieces needed to apply an `In` descriptor and display an arbitrary per-column `FilterFlyout`, but it did not provide a reusable distinct-value model or a built-in value/count/search presentation. Each application therefore had to enumerate values, keep checkbox state synchronized with `FilteringModel`, and build its own popup.

## Design

### One filtering pipeline

`DataGridDistinctValueFilterContext` owns only popup state: distinct options, counts, search text, and checkbox selection. It does not introduce another filtering pipeline. Checkbox changes call the existing central `IFilteringModel.SetOrUpdate`/`Remove` APIs, so header filtered state, selection preservation, adapter ownership, and collection-view refresh behavior remain unchanged.

The generated descriptor uses:

- the column's stable `ColumnKey`/definition/column identity;
- `FilteringOperator.In`;
- the column's resolved sort/binding property path when available;
- the checked raw values.

When a custom `ValueComparer` is supplied, the descriptor also carries a typed predicate so grouping and row-membership equality remain consistent.

### Reflection-free value access

The popup resolves values in this order:

1. `DataGridDistinctValueFilterFlyout.ValueAccessor`;
2. `DataGridColumnFilter.ValueAccessor`;
3. the accessor generated by a typed `DataGridColumnDefinition` binding.

It deliberately does not reflect over the binding or `SortMemberPath`. If no accessor is available, opening is canceled and `LastError` explains the requirement. This keeps the feature trimming/AOT friendly and follows the repository's no-new-reflection rule.

### Counts and reopening

When the grid is backed by `IDataGridCollectionView`, the popup enumerates `SourceCollection`, not the currently filtered view. Reopening a filter therefore still shows every source value and its full count even when that same column currently filters the visible rows.

Null values are grouped and displayed as `(Empty)`. Options are sorted using the current culture, case-insensitively.

### Search and selection semantics

Search only changes the visible `Options` collection. It does not clear selections hidden by the current search. Rebuilding the list restores checked state from the active `In` descriptor without reapplying the filter.

### Theme and accessibility

Adds the compiled-binding `DataGridFilterDistinctValuesEditorTemplate` to `Themes/Generic.xaml`, with:

- `DataGridFilterDistinctValuesEditorWidth`;
- `DataGridFilterDistinctValuesListMaxHeight`;
- accessible names for the search box, values list, and individual checkboxes;
- coverage in both Simple and Fluent theme resource tests, including v2 variants.

## Sample and documentation

- Updates the Column Definitions + FilteringModel sample so the Status header uses the new built-in popup with its existing typed binding accessor.
- Adds a dedicated Distinct-Value Column Filtering guide covering typed definitions, existing-column accessors, customization, equality, formatting, and template replacement.
- Links the guide from Data Operations, Column Header Menus and Filters, and the DocFX table of contents.

## Tests

New model tests cover:

- sorted distinct values and counts, including null;
- unchecked defaults;
- case-insensitive substring search;
- selection persistence while search hides values;
- `In` descriptor creation and removal;
- selection restoration from an existing descriptor;
- custom equality grouping and predicate consistency.

Headless integration tests cover:

- opening from a real column header;
- template resolution;
- source counts and immediate collection-view filtering;
- clearing by unchecking the final value;
- rebuilding from the unfiltered source on reopen;
- flyout-level accessor/comparer/formatter overrides;
- graceful cancellation when no typed accessor exists.

## Validation

- `dotnet test ... -f net10.0`: **2,259 passed, 0 failed**
- focused distinct-value/flyout/theme tests: **30 passed, 0 failed**
- production library build (`net8.0` and `net10.0`): **0 errors**
- DataGrid sample build (`net10.0`): **0 errors**
- DocFX build: **0 errors** (existing repository warnings remain)
- `git diff --check`: clean

Builds retain the repository's existing warning baseline; this change adds no build errors.

## Review hardening

Follow-up review preserves filter identity and state across ambiguous or changing data:

- exact descriptor identity is preferred before falling back to ColumnId matching;
- selected values temporarily absent from the current distinct-value scan remain available as zero-count options, including comparer and null semantics.

Current validation: **8/8** focused distinct-filter tests and **2,262/2,262** full unit tests pass. Review threads are resolved.
