### PR TITLE
Add regression coverage for offset row drag coordinates

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DragDrop/DataGridRowDragDropControllerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DragDrop/DataGridRowDragDropControllerTests.cs
@@ -351,6 +351,41 @@ namespace Avalonia.Controls.DataGridTests.DragDrop;
     }
 
     [AvaloniaFact]
+    public void DragOver_Uses_Grid_Relative_Position_When_Grid_Is_Offset_From_Root()
+    {
+        var items = new ObservableCollection<RowItem>(
+            Enumerable.Range(0, 20).Select(index => new RowItem($"Item {index}")));
+        var (grid, window) = CreateGrid(items, new Thickness(48, 72, 0, 0));
+        grid.CanUserReorderRows = true;
+        grid.UpdateLayout();
+
+        var handler = new DataGridRowReorderHandler();
+        using var controller = new DataGridRowDragDropController(grid, handler, new DataGridRowDragDropOptions());
+
+        var targetRow = grid.GetVisualDescendants().OfType<DataGridRow>().Skip(1).First();
+        var rowPoint = targetRow.TranslatePoint(new Point(2, 2), grid) ?? new Point(2, 2);
+        var dragInfo = new DataGridRowDragInfo(
+            grid,
+            new List<object> { items[0] },
+            new List<int> { 0 },
+            fromSelection: false);
+        var dragEvent = CreateDragEventArgs(
+            AvaloniaDragDrop.DragOverEvent,
+            grid,
+            rowPoint,
+            KeyModifiers.None);
+
+        var dropArgs = InvokeCreateDropArgs(controller, dragInfo, dragEvent, DragDropEffects.Move);
+
+        Assert.NotNull(dropArgs);
+        Assert.Same(targetRow, dropArgs!.TargetRow);
+        Assert.Same(targetRow.DataContext, dropArgs.TargetItem);
+        Assert.Equal(targetRow.Index, dropArgs.InsertIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void DragOver_Above_First_Row_Produces_Before_Target()
     {
         var items = new ObservableCollection<RowItem>
@@ -976,7 +1011,7 @@ namespace Avalonia.Controls.DataGridTests.DragDrop;
         return (bool)(field?.GetValue(controller) ?? false);
     }
 
-    private static (DataGrid Grid, Window Window) CreateGrid(IEnumerable items)
+    private static (DataGrid Grid, Window Window) CreateGrid(IEnumerable items, Thickness? containerPadding = null)
     {
         var window = new Window
         {
@@ -1000,7 +1035,13 @@ namespace Avalonia.Controls.DataGridTests.DragDrop;
             Binding = new Binding("Value")
         });
         
-        window.Content = grid;
+        window.Content = containerPadding.HasValue
+            ? new Border
+            {
+                Padding = containerPadding.Value,
+                Child = grid
+            }
+            : grid;
 
         window.Show();
         grid.ApplyTemplate();


### PR DESCRIPTION
## Summary

- add regression coverage for row drag/drop hit testing when a `DataGrid` is offset from its window root
- verify that a grid-relative drag point resolves the visible row under the pointer, including its target item and insertion index
- extend the shared test fixture with an optional padded container so coordinate-space regressions can be reproduced without duplicating setup

## Root cause analysis

The issue recording shows the pointer over row `60` while `ActiveRowDragSession` reports `Data sync` (row `230`) as the hovered target and draws the insertion line there. The vertical error closely matches the DataGrid's offset from the window root. Both the Row Drag & Drop and ListBox Mimic samples use the same row-drop hit-testing path, which explains why both were affected.

The recording was made after this repository moved to Avalonia 12.0.0. That release briefly regressed subtree hit-test coordinates: a point already relative to the subtree was transformed as though it were root-relative, effectively applying the control's root offset a second time. Avalonia corrected that behavior in [AvaloniaUI/Avalonia#21125](https://github.com/AvaloniaUI/Avalonia/pull/21125). This repository subsequently upgraded from Avalonia 12.0.0 to 12.0.4 in commit `6917f11`, so current production code already receives the corrected coordinate contract.

Adding a DataGrid-specific coordinate workaround now would double-correct positions on supported Avalonia versions. This PR instead locks in the corrected behavior with a focused regression test that recreates the non-zero root offset visible in the report.

## Test coverage

The new test:

1. hosts a DataGrid inside a container with a `48,72` offset from the window root;
2. creates a drag-over point relative to the second realized row;
3. runs the same `CreateDropArgs` path used by both affected samples;
4. asserts that the target row, target item, and insertion index all match the row under the pointer.

Validation performed:

- focused regression test: 1 passed
- all `DataGridRowDragDropControllerTests`: 22 passed
- complete `Avalonia.Controls.DataGrid.UnitTests` headless suite: 2,251 passed, 0 failed
- `git diff --check`: clean

Closes #304
