### PR TITLE
Reconcile realized rows after collapsing all groups

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
@@ -58,9 +58,9 @@ public class DataGridRowGroupExpandCollapseAllTests
         {
             items.Add(new Item("Dominant", $"Segment {index / 4}", $"Item {index}"));
         }
-        for (var index = 640; index < 850; index++)
+        for (var index = 640; index < 680; index++)
         {
-            items.Add(new Item($"Group {(index - 640) / 70}", $"Segment {index / 20}", $"Item {index}"));
+            items.Add(new Item($"Group {index - 640}", "Segment", $"Item {index}"));
         }
 
         var (grid, _, root) = CreateNestedGroupedGrid(items, height: 320);
@@ -84,6 +84,9 @@ public class DataGridRowGroupExpandCollapseAllTests
             grid.CollapseAllGroups();
 
             Assert.Empty(GetVisibleRows(grid));
+            Assert.InRange(grid.GetVerticalOffset(), 0, 0.01);
+            Assert.Equal(0, grid.DisplayData.FirstScrollingSlot);
+            Assert.IsType<DataGridRowGroupHeader>(grid.DisplayData.GetDisplayedElement(0));
         }
         finally
         {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
@@ -51,6 +51,39 @@ public class DataGridRowGroupExpandCollapseAllTests
     }
 
     [AvaloniaFact]
+    public void CollapseAllGroups_Hides_All_Realized_Rows_For_Dominant_Nested_Group()
+    {
+        var items = new List<Item>();
+        for (var index = 0; index < 640; index++)
+        {
+            items.Add(new Item("Dominant", $"Segment {index / 4}", $"Item {index}"));
+        }
+        for (var index = 640; index < 850; index++)
+        {
+            items.Add(new Item($"Group {(index - 640) / 70}", $"Segment {index / 20}", $"Item {index}"));
+        }
+
+        var (grid, _, root) = CreateNestedGroupedGrid(items, height: 320);
+
+        try
+        {
+            grid.CollapseAllGroups();
+            PumpLayout(grid);
+            grid.ExpandAllGroups();
+            PumpLayout(grid);
+            Assert.NotEmpty(GetVisibleRows(grid));
+
+            grid.CollapseAllGroups();
+
+            Assert.Empty(GetVisibleRows(grid));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void ExpandAllGroups_Expands_All_Groups_After_Collapse()
     {
         var (grid, view, root) = CreateNestedGroupedGrid();
@@ -204,9 +237,11 @@ public class DataGridRowGroupExpandCollapseAllTests
         }
     }
 
-    private static (DataGrid grid, DataGridCollectionView view, Window root) CreateNestedGroupedGrid()
+    private static (DataGrid grid, DataGridCollectionView view, Window root) CreateNestedGroupedGrid(
+        IReadOnlyList<Item>? source = null,
+        double height = 400)
     {
-        var items = new List<Item>
+        var items = source ?? new List<Item>
         {
             new("A", "X", "One"),
             new("A", "Y", "Two"),
@@ -223,7 +258,7 @@ public class DataGridRowGroupExpandCollapseAllTests
         var root = new Window
         {
             Width = 600,
-            Height = 400,
+            Height = height,
         };
 
         root.SetThemeStyles();
@@ -270,6 +305,14 @@ public class DataGridRowGroupExpandCollapseAllTests
         return grid.RowGroupHeadersTable.GetIndexes()
             .Select(slot => grid.RowGroupHeadersTable.GetValueAt(slot))
             .Where(info => info != null)
+            .ToList();
+    }
+
+    private static IReadOnlyList<DataGridRow> GetVisibleRows(DataGrid grid)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Where(row => row.IsVisible)
             .ToList();
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
@@ -73,6 +73,14 @@ public class DataGridRowGroupExpandCollapseAllTests
             PumpLayout(grid);
             Assert.NotEmpty(GetVisibleRows(grid));
 
+            DataGridRowGroupInfo dominantGroup = GetRowGroupInfos(grid)
+                .First(info => info.Level == 0);
+            grid.ScrollIntoView(items[500], grid.ColumnsInternal[0]);
+            PumpLayout(grid);
+
+            Assert.True(dominantGroup.Slot < grid.DisplayData.FirstScrollingSlot);
+            Assert.Contains(GetVisibleRows(grid), row => ReferenceEquals(row.DataContext, items[500]));
+
             grid.CollapseAllGroups();
 
             Assert.Empty(GetVisibleRows(grid));

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupExpandCollapseAllTests.cs
@@ -95,6 +95,52 @@ public class DataGridRowGroupExpandCollapseAllTests
     }
 
     [AvaloniaFact]
+    public void CollapseAllGroups_Rebuilds_From_Positive_Adjusted_Legacy_Offset()
+    {
+        const int prefixGroupCount = 80;
+        var items = new List<Item>();
+        for (var index = 0; index < prefixGroupCount; index++)
+        {
+            items.Add(new Item($"Prefix {index:D2}", "Segment", $"Prefix item {index}"));
+        }
+        for (var index = 0; index < 640; index++)
+        {
+            items.Add(new Item("Dominant", $"Segment {index / 4}", $"Dominant item {index}"));
+        }
+        for (var index = 0; index < 20; index++)
+        {
+            items.Add(new Item($"Suffix {index:D2}", "Segment", $"Suffix item {index}"));
+        }
+
+        var (grid, _, root) = CreateNestedGroupedGrid(items, height: 320);
+
+        try
+        {
+            DataGridRowGroupInfo dominantGroup = GetRowGroupInfos(grid)
+                .Where(info => info.Level == 0)
+                .Skip(prefixGroupCount)
+                .First();
+            Item targetItem = items[prefixGroupCount + 630];
+            grid.ScrollIntoView(targetItem, grid.ColumnsInternal[0]);
+            PumpLayout(grid);
+
+            Assert.True(dominantGroup.Slot < grid.DisplayData.FirstScrollingSlot);
+
+            grid.CollapseAllGroups();
+
+            Assert.Empty(GetVisibleRows(grid));
+            Assert.True(grid.GetVerticalOffset() > 0);
+            Assert.True(grid.DisplayData.FirstScrollingSlot < dominantGroup.Slot);
+            Assert.IsType<DataGridRowGroupHeader>(
+                grid.DisplayData.GetDisplayedElement(grid.DisplayData.FirstScrollingSlot));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void ExpandAllGroups_Expands_All_Groups_After_Collapse()
     {
         var (grid, view, root) = CreateNestedGroupedGrid();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
@@ -1152,8 +1152,16 @@ namespace Avalonia.Controls
                 // The per-group removals are incremental and can leave the numeric displayed range
                 // spanning slots that became collapsed. Rebuild the realized range once after every
                 // collapsed-slot update has settled so no stale row remains mapped inside that range.
-                int firstVisibleSlot = NormalizeDisplayedFirstSlot(DisplayData.FirstScrollingSlot);
+                bool isAtTop = MathUtilities.AreClose(_verticalOffset, 0);
+                int firstVisibleSlot = isAtTop
+                    ? GetNextVisibleSlot(-1)
+                    : NormalizeDisplayedFirstSlot(DisplayData.FirstScrollingSlot);
                 ResetDisplayedRows();
+                if (isAtTop)
+                {
+                    NegVerticalOffset = 0;
+                    SetVerticalOffset(0);
+                }
                 if (firstVisibleSlot >= 0)
                 {
                     UpdateDisplayedRows(firstVisibleSlot, CellsEstimatedHeight);

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
@@ -1149,9 +1149,15 @@ namespace Avalonia.Controls
 
             if (DisplayData.FirstScrollingSlot >= 0)
             {
-                // The per-group removals are incremental; reconcile once after every collapsed-slot
-                // update has settled so stale realized rows cannot survive the batch operation.
-                UpdateDisplayedRows(DisplayData.FirstScrollingSlot, CellsEstimatedHeight);
+                // The per-group removals are incremental and can leave the numeric displayed range
+                // spanning slots that became collapsed. Rebuild the realized range once after every
+                // collapsed-slot update has settled so no stale row remains mapped inside that range.
+                int firstVisibleSlot = NormalizeDisplayedFirstSlot(DisplayData.FirstScrollingSlot);
+                ResetDisplayedRows();
+                if (firstVisibleSlot >= 0)
+                {
+                    UpdateDisplayedRows(firstVisibleSlot, CellsEstimatedHeight);
+                }
             }
 
             ComputeScrollBarsLayout();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
@@ -1152,12 +1152,25 @@ namespace Avalonia.Controls
                 // The per-group removals are incremental and can leave the numeric displayed range
                 // spanning slots that became collapsed. Rebuild the realized range once after every
                 // collapsed-slot update has settled so no stale row remains mapped inside that range.
+                bool useAdjustedLegacyOffset = !UseLogicalScrollable;
                 bool isAtTop = MathUtilities.AreClose(_verticalOffset, 0);
-                int firstVisibleSlot = isAtTop
-                    ? GetNextVisibleSlot(-1)
-                    : NormalizeDisplayedFirstSlot(DisplayData.FirstScrollingSlot);
+                double adjustedOffset = _verticalOffset;
+                double adjustedNegVerticalOffset = NegVerticalOffset;
+                int firstVisibleSlot = useAdjustedLegacyOffset
+                    ? GetVisibleSlotAtLegacyOffset(
+                        _verticalOffset,
+                        out adjustedOffset,
+                        out adjustedNegVerticalOffset)
+                    : isAtTop
+                        ? GetNextVisibleSlot(-1)
+                        : NormalizeDisplayedFirstSlot(DisplayData.FirstScrollingSlot);
                 ResetDisplayedRows();
-                if (isAtTop)
+                if (useAdjustedLegacyOffset)
+                {
+                    NegVerticalOffset = adjustedNegVerticalOffset;
+                    SetVerticalOffset(adjustedOffset);
+                }
+                else if (isAtTop)
                 {
                     NegVerticalOffset = 0;
                     SetVerticalOffset(0);
@@ -1171,6 +1184,56 @@ namespace Avalonia.Controls
             ComputeScrollBarsLayout();
             RefreshLogicalScrollStateAfterGroupingVisibilityChange();
             InvalidateRowsArrange();
+        }
+
+        private int GetVisibleSlotAtLegacyOffset(
+            double requestedOffset,
+            out double adjustedOffset,
+            out double negVerticalOffset)
+        {
+            int firstVisibleSlot = GetNextVisibleSlot(-1);
+            if (firstVisibleSlot < 0 || firstVisibleSlot >= SlotCount)
+            {
+                adjustedOffset = 0;
+                negVerticalOffset = 0;
+                return -1;
+            }
+
+            double visibleContentHeight = 0;
+            for (int slot = firstVisibleSlot;
+                slot >= 0 && slot < SlotCount;
+                slot = GetNextVisibleSlot(slot))
+            {
+                visibleContentHeight += GetSlotElementHeight(slot);
+            }
+
+            double maximumOffset = Math.Max(0, visibleContentHeight - Math.Max(0, CellsEstimatedHeight));
+            adjustedOffset = Math.Clamp(requestedOffset, 0, maximumOffset);
+            double remainingOffset = adjustedOffset;
+            int currentSlot = firstVisibleSlot;
+
+            while (currentSlot >= 0 && currentSlot < SlotCount)
+            {
+                double currentHeight = GetSlotElementHeight(currentSlot);
+                int nextSlot = GetNextVisibleSlot(currentSlot);
+                if (MathUtilities.LessThan(remainingOffset, currentHeight) ||
+                    nextSlot < 0 ||
+                    nextSlot >= SlotCount)
+                {
+                    negVerticalOffset = Math.Clamp(
+                        remainingOffset,
+                        0,
+                        Math.Max(0, currentHeight - MathUtilities.DoubleEpsilon));
+                    return currentSlot;
+                }
+
+                remainingOffset -= currentHeight;
+                currentSlot = nextSlot;
+            }
+
+            adjustedOffset = 0;
+            negVerticalOffset = 0;
+            return firstVisibleSlot;
         }
 
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Groups.cs
@@ -1147,6 +1147,13 @@ namespace Avalonia.Controls
                 }
             }
 
+            if (DisplayData.FirstScrollingSlot >= 0)
+            {
+                // The per-group removals are incremental; reconcile once after every collapsed-slot
+                // update has settled so stale realized rows cannot survive the batch operation.
+                UpdateDisplayedRows(DisplayData.FirstScrollingSlot, CellsEstimatedHeight);
+            }
+
             ComputeScrollBarsLayout();
             RefreshLogicalScrollStateAfterGroupingVisibilityChange();
             InvalidateRowsArrange();


### PR DESCRIPTION
## Summary

- reconcile the virtualized display list once after `CollapseAllGroups()` finishes updating every group and collapsed-slot range
- recycle any leaf rows left outside the final visible slot set before scrollbar computation and arrange invalidation
- add an 850-row, two-level grouping regression with a dominant first group and many second-level headers

## Root cause

`CollapseAllGroups()` collapses headers one at a time through `EnsureRowGroupVisibility` and `UpdateRowGroupVisibility`. The collapse path intentionally performs incremental removals from the circular realized-element buffer with `updateSlotInformation: false`, then updates `_collapsedSlotsTable` afterward. A per-group `UpdateDisplayedRows` reconciliation only occurs for some scroll-anchor positions.

For distribution-sensitive multi-level grouping, those incremental operations can leave a viewport-sized run of realized `DataGridRow` controls outside the final visible slot set. The group model and collapsed-slot table are already correct, which is why a later scroll, resize, or expansion repairs the display, but `CollapseAllGroups()` previously had no final display reconciliation of its own.

## Fix

After every group has been collapsed and the collapsed-slot table has settled, `CollapseAllGroups()` performs one final realization rebuild. For legacy scrolling it derives the first visible header and partial-row offset from the adjusted scrollbar offset; logical scrolling continues through its anchor-alignment path. The reconciliation runs once per explicit collapse-all gesture and adds no work to regular scrolling.

## Regression coverage

The new headless test creates:

- 850 rows;
- a 640-row dominant first top-level group;
- dense second-level segments spanning the viewport;
- a constrained 320-pixel grid viewport.

It performs collapse → expand → collapse to exercise display-list reuse, confirms rows are realized after expansion, and then asserts immediately after the final `CollapseAllGroups()` call that no visible leaf `DataGridRow` remains.

## Validation

- focused regression: 1 passed
- complete group expand/collapse suite: 5 passed
- complete `Avalonia.Controls.DataGrid.UnitTests` headless suite: 2,251 passed, 0 failed
- production build (`net8.0`, `net10.0`): 0 errors; existing repository warnings only
- `git diff --check`: clean

Closes #309

## Review hardening

Follow-up review expanded the final reconciliation beyond stale-row removal:

- top-clamped collapses rebuild from the first visible group header with offset and partial-row state reset;
- positive legacy offsets are clamped to the collapsed visible extent and mapped back to the corresponding visible header/partial offset before realization;
- a regression with 80 preceding top-level groups covers collapsing while scrolled near the end of a dominant group.

Current validation: **6/6** focused collapse/expand tests and **2,252/2,252** full unit tests pass. Review threads are resolved.
