### PR TITLE
Fix blank recycled row cells by regenerating non-template content

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
@@ -95,11 +95,19 @@ namespace Avalonia.Controls
                 ApplyConditionalFormattingForRow(dataGridRow);
                 dataGridRow.ClearRecyclingState();
 
-                // Recycled text/checkbox cells keep prior Content; indexer bindings on Fields[i]
-                // often do not refresh until the row is fully re-realized (scroll away/back).
-                // Template columns already refresh on DataContext change; bound columns need
-                // explicit content regeneration — same path as placeholder transitions.
-                if (recycledRow != null)
+                // Placeholder transitions clear every cell's Content before DataContext change,
+                // so regenerate all columns (including templates) — same as before.
+                // Normal recycle: non-template cells keep prior Content; indexer bindings on
+                // Fields[i] often do not refresh until the row is fully re-realized. Template
+                // columns already refresh on DataContext change via OnPropertyChanged.
+                if (hasPlaceholderTransition)
+                {
+                    foreach (DataGridCell cell in dataGridRow.Cells)
+                    {
+                        cell.Content = cell.OwningColumn.GenerateElementInternal(cell, dataContext);
+                    }
+                }
+                else if (recycledRow != null)
                 {
                     foreach (DataGridCell cell in dataGridRow.Cells)
                     {
@@ -108,13 +116,6 @@ namespace Avalonia.Controls
                         {
                             cell.Content = cell.OwningColumn.GenerateElementInternal(cell, dataContext);
                         }
-                    }
-                }
-                else if (hasPlaceholderTransition)
-                {
-                    foreach (DataGridCell cell in dataGridRow.Cells)
-                    {
-                        cell.Content = cell.OwningColumn.GenerateElementInternal(cell, dataContext);
                     }
                 }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
@@ -95,7 +95,22 @@ namespace Avalonia.Controls
                 ApplyConditionalFormattingForRow(dataGridRow);
                 dataGridRow.ClearRecyclingState();
 
-                if (hasPlaceholderTransition)
+                // Recycled text/checkbox cells keep prior Content; indexer bindings on Fields[i]
+                // often do not refresh until the row is fully re-realized (scroll away/back).
+                // Template columns already refresh on DataContext change; bound columns need
+                // explicit content regeneration — same path as placeholder transitions.
+                if (recycledRow != null)
+                {
+                    foreach (DataGridCell cell in dataGridRow.Cells)
+                    {
+                        if (cell.OwningColumn != null &&
+                            cell.OwningColumn is not DataGridTemplateColumn)
+                        {
+                            cell.Content = cell.OwningColumn.GenerateElementInternal(cell, dataContext);
+                        }
+                    }
+                }
+                else if (hasPlaceholderTransition)
                 {
                     foreach (DataGridCell cell in dataGridRow.Cells)
                     {

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -192,6 +192,7 @@ internal
         {
             RecycledDataContext = null;
             RecycledIsPlaceholder = false;
+            IsRecycled = false;
         }
 
         static DataGridRow()


### PR DESCRIPTION
## Problem

With `UseLogicalScrollable` enabled, recycled rows near the **top/bottom edge of the viewport** sometimes showed **blank or stale cells** after scrolling (or after a larger result set finished loading into the grid).

Typical failure mode in an app that binds many text columns via indexer paths (e.g. `Fields[i]`):

1. Scroll so rows are recycled into view at the viewport edge.
2. Some edge-row cells render empty / wrong (previous recycle content did not refresh).
3. Scroll that row **fully out of view**, then scroll it **back in** → cells suddenly look correct.

So the data was present; the recycled non-template cell `Content` (e.g. `DataGridTextColumn`) was not reliably rebinding until the row was fully re-realized. Template columns were generally fine because they already refresh on `DataContext` change.

This was easy to miss in small demos, and very visible on wider grids (many columns) with virtualization under load.

## Fix

- On recycled-row reuse, regenerate **non-template** cell content via `GenerateElementInternal` (forces fresh element + binding for the new item).
- Keep the existing **placeholder-transition** path regenerating **all** cells (including templates), because that path clears `Content` before `DataContext` changes.
- Clear `IsRecycled` in `ClearRecyclingState()` when the row is prepared for a new item.

## Notes

- This trades some recycle allocation (new text/checkbox visuals per reused row) for correct content. A narrower “refresh binding in place” path may be possible as follow-up (especially for indexer bindings that do not notify cleanly).