### PR TITLE
Fix sorting for explicitly implemented interface properties

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Collections/DataGridSortDescriptionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Collections/DataGridSortDescriptionTests.cs
@@ -137,6 +137,165 @@ namespace Avalonia.Controls.DataGridTests.Collections
             Assert.IsType<DataGridColumnValueAccessorComparer<NumericItem, int>>(comparerSort.SourceComparer);
         }
 
+        [Theory]
+        [InlineData(ListSortDirection.Ascending, "Alice", "Bob", "Charlie")]
+        [InlineData(ListSortDirection.Descending, "Charlie", "Bob", "Alice")]
+        public void FromPath_Orders_Explicit_Interface_Property(
+            ListSortDirection direction,
+            params string[] expected)
+        {
+            IExplicitRow[] items =
+            {
+                new ExplicitRow("Charlie", 3),
+                new ExplicitRow("Alice", 1),
+                new ExplicitRow("Bob", 2)
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IExplicitRow.Name), direction);
+
+            sortDescription.Initialize(typeof(IExplicitRow));
+            var result = sortDescription.OrderBy(items).Cast<IExplicitRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void FromPath_Orders_Explicit_Interface_Property_When_Initialized_With_Concrete_Type()
+        {
+            var items = new[]
+            {
+                new ExplicitRow("Charlie", 3),
+                new ExplicitRow("Alice", 1),
+                new ExplicitRow("Bob", 2)
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IExplicitRow.Name));
+
+            sortDescription.Initialize(typeof(ExplicitRow));
+            var result = sortDescription.OrderBy(items).Cast<IExplicitRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
+        [Fact]
+        public void FromPath_Orders_Explicit_Interface_Property_Without_Initialize()
+        {
+            var items = new[]
+            {
+                new ExplicitRow("Charlie", 3),
+                new ExplicitRow("Alice", 1),
+                new ExplicitRow("Bob", 2)
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IExplicitRow.Name));
+
+            var result = sortDescription.OrderBy(items).Cast<IExplicitRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
+        [Fact]
+        public void FromPath_Orders_Inherited_Explicit_Interface_Property()
+        {
+            IInheritedRow[] items =
+            {
+                new InheritedRow("Charlie"),
+                new InheritedRow("Alice"),
+                new InheritedRow("Bob")
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IBaseRow.Name));
+
+            sortDescription.Initialize(typeof(IInheritedRow));
+            var result = sortDescription.OrderBy(items).Cast<IBaseRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
+        [Fact]
+        public void FromPath_Orders_Nested_Explicit_Interface_Path_And_Nulls()
+        {
+            INestedRow[] items =
+            {
+                new NestedRow(new ExplicitRow("Charlie", 3)),
+                new NestedRow(null),
+                new NestedRow(new ExplicitRow("Alice", 1)),
+                new NestedRow(new ExplicitRow("Bob", 2))
+            };
+            var sortDescription = DataGridSortDescription.FromPath(
+                $"{nameof(INestedRow.Detail)}.{nameof(IExplicitRow.Rank)}");
+
+            sortDescription.Initialize(typeof(INestedRow));
+            var result = sortDescription.OrderBy(items).Cast<INestedRow>().Select(item => item.Detail?.Rank).ToArray();
+
+            Assert.Equal(new int?[] { null, 1, 2, 3 }, result);
+        }
+
+        [Fact]
+        public void FromPath_Orders_Polymorphic_Explicit_Interface_Implementations()
+        {
+            IExplicitRow[] items =
+            {
+                new AlternateExplicitRow("Charlie", 3),
+                new ExplicitRow("Alice", 1),
+                new AlternateExplicitRow("Bob", 2)
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IExplicitRow.Name));
+
+            sortDescription.Initialize(typeof(IExplicitRow));
+            var result = sortDescription.OrderBy(items).Cast<IExplicitRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
+        [Fact]
+        public void SwitchSortDirection_Preserves_Explicit_Interface_Item_Type()
+        {
+            IExplicitRow[] items =
+            {
+                new ExplicitRow("Charlie", 3),
+                new ExplicitRow("Alice", 1),
+                new ExplicitRow("Bob", 2)
+            };
+            var ascending = DataGridSortDescription.FromPath(nameof(IExplicitRow.Name));
+            ascending.Initialize(typeof(IExplicitRow));
+
+            var descending = ascending.SwitchSortDirection();
+            var result = descending.OrderBy(items).Cast<IExplicitRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Charlie", "Bob", "Alice" }, result);
+        }
+
+        [Fact]
+        public void FromPath_Uses_Declared_Interface_To_Disambiguate_Explicit_Properties()
+        {
+            IPrimaryLabel[] items =
+            {
+                new AmbiguousLabel("Charlie", "Alpha"),
+                new AmbiguousLabel("Alice", "Zulu"),
+                new AmbiguousLabel("Bob", "Mike")
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(IPrimaryLabel.Label));
+
+            sortDescription.Initialize(typeof(IPrimaryLabel));
+            var result = sortDescription.OrderBy(items).Cast<IPrimaryLabel>().Select(item => item.Label).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
+        [Fact]
+        public void FromPath_Falls_Back_To_Runtime_Type_When_Declared_Base_Type_Has_No_Path()
+        {
+            RuntimeBaseRow[] items =
+            {
+                new RuntimeDerivedRow("Charlie"),
+                new RuntimeDerivedRow("Alice"),
+                new RuntimeDerivedRow("Bob")
+            };
+            var sortDescription = DataGridSortDescription.FromPath(nameof(RuntimeDerivedRow.Name));
+
+            sortDescription.Initialize(typeof(RuntimeBaseRow));
+            var result = sortDescription.OrderBy(items).Cast<RuntimeDerivedRow>().Select(item => item.Name).ToArray();
+
+            Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, result);
+        }
+
         private class Item : IEquatable<Item>
         {
             public Item(string? prop1, string? prop2)
@@ -180,6 +339,123 @@ namespace Avalonia.Controls.DataGridTests.Collections
             }
 
             public int Value { get; }
+        }
+
+        private interface IExplicitRow
+        {
+            string Name { get; }
+
+            int Rank { get; }
+        }
+
+        private interface IBaseRow
+        {
+            string Name { get; }
+        }
+
+        private interface IInheritedRow : IBaseRow
+        {
+        }
+
+        private interface INestedRow
+        {
+            IExplicitRow? Detail { get; }
+        }
+
+        private interface IPrimaryLabel
+        {
+            string Label { get; }
+        }
+
+        private interface ISecondaryLabel
+        {
+            string Label { get; }
+        }
+
+        private sealed class ExplicitRow : IExplicitRow
+        {
+            private readonly string _name;
+            private readonly int _rank;
+
+            public ExplicitRow(string name, int rank)
+            {
+                _name = name;
+                _rank = rank;
+            }
+
+            string IExplicitRow.Name => _name;
+
+            int IExplicitRow.Rank => _rank;
+        }
+
+        private sealed class AlternateExplicitRow : IExplicitRow
+        {
+            private readonly string _name;
+            private readonly int _rank;
+
+            public AlternateExplicitRow(string name, int rank)
+            {
+                _name = name;
+                _rank = rank;
+            }
+
+            string IExplicitRow.Name => _name;
+
+            int IExplicitRow.Rank => _rank;
+        }
+
+        private sealed class InheritedRow : IInheritedRow
+        {
+            private readonly string _name;
+
+            public InheritedRow(string name)
+            {
+                _name = name;
+            }
+
+            string IBaseRow.Name => _name;
+        }
+
+        private sealed class NestedRow : INestedRow
+        {
+            private readonly IExplicitRow? _detail;
+
+            public NestedRow(IExplicitRow? detail)
+            {
+                _detail = detail;
+            }
+
+            IExplicitRow? INestedRow.Detail => _detail;
+        }
+
+        private sealed class AmbiguousLabel : IPrimaryLabel, ISecondaryLabel
+        {
+            private readonly string _primary;
+            private readonly string _secondary;
+
+            public AmbiguousLabel(string primary, string secondary)
+            {
+                _primary = primary;
+                _secondary = secondary;
+            }
+
+            string IPrimaryLabel.Label => _primary;
+
+            string ISecondaryLabel.Label => _secondary;
+        }
+
+        private abstract class RuntimeBaseRow
+        {
+        }
+
+        private sealed class RuntimeDerivedRow : RuntimeBaseRow
+        {
+            public RuntimeDerivedRow(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sorting/DataGridSortingHeaderTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sorting/DataGridSortingHeaderTests.cs
@@ -58,6 +58,37 @@ public class DataGridSortingHeaderTests
     }
 
     [AvaloniaFact]
+    public void Header_Click_Sorts_Explicit_Interface_Property_And_Updates_Indicator()
+    {
+        var items = new ObservableCollection<IExplicitHeaderRow>
+        {
+            new ExplicitHeaderRow("Charlie", new DateTime(2026, 7, 30, 12, 30, 0)),
+            new ExplicitHeaderRow("Alice", new DateTime(2026, 7, 30, 8, 15, 0)),
+            new ExplicitHeaderRow("Bob", new DateTime(2026, 7, 30, 10, 45, 0))
+        };
+        var grid = CreateExplicitInterfaceGrid(items);
+
+        ClickHeader(grid, "Name");
+        grid.UpdateLayout();
+
+        Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, GetExplicitRowOrder(grid));
+        AssertHeaderSort(grid, "Name", asc: true, desc: false);
+
+        ClickHeader(grid, "Name");
+        grid.UpdateLayout();
+
+        Assert.Equal(new[] { "Charlie", "Bob", "Alice" }, GetExplicitRowOrder(grid));
+        AssertHeaderSort(grid, "Name", asc: false, desc: true);
+
+        ClickHeader(grid, "Time");
+        grid.UpdateLayout();
+
+        Assert.Equal(new[] { "Alice", "Bob", "Charlie" }, GetExplicitRowOrder(grid));
+        AssertHeaderSort(grid, "Name", asc: false, desc: false);
+        AssertHeaderSort(grid, "Time", asc: true, desc: false);
+    }
+
+    [AvaloniaFact]
     public void Header_Click_Two_State_Cycle_Works_In_Observe_Mode()
     {
         var items = new ObservableCollection<Item>
@@ -297,6 +328,39 @@ public class DataGridSortingHeaderTests
         return grid;
     }
 
+    private static DataGrid CreateExplicitInterfaceGrid(IEnumerable<IExplicitHeaderRow> items)
+    {
+        var root = new Window
+        {
+            Width = 400,
+            Height = 300
+        };
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            ItemsSource = new DataGridCollectionView(items),
+            SelectionMode = DataGridSelectionMode.Extended
+        };
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(IExplicitHeaderRow.Name)),
+            SortMemberPath = nameof(IExplicitHeaderRow.Name)
+        });
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Time",
+            Binding = new Binding(nameof(IExplicitHeaderRow.Time)),
+            SortMemberPath = nameof(IExplicitHeaderRow.Time)
+        });
+
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+        return grid;
+    }
+
     private static void ClickHeader(DataGrid grid, string header, KeyModifiers modifiers = KeyModifiers.None)
     {
         var headerCell = grid.GetVisualDescendants()
@@ -343,6 +407,14 @@ public class DataGridSortingHeaderTests
             .ToArray();
     }
 
+    private static string[] GetExplicitRowOrder(DataGrid grid)
+    {
+        return ((System.Collections.IEnumerable)grid.ItemsSource!)
+            .Cast<IExplicitHeaderRow>()
+            .Select(item => item.Name)
+            .ToArray();
+    }
+
     private class Item
     {
         public Item(string name, string group = "", int value = 0)
@@ -357,5 +429,28 @@ public class DataGridSortingHeaderTests
         public string Group { get; }
 
         public int Value { get; }
+    }
+
+    private interface IExplicitHeaderRow
+    {
+        string Name { get; }
+
+        DateTime Time { get; }
+    }
+
+    private sealed class ExplicitHeaderRow : IExplicitHeaderRow
+    {
+        private readonly string _name;
+        private readonly DateTime _time;
+
+        public ExplicitHeaderRow(string name, DateTime time)
+        {
+            _name = name;
+            _time = time;
+        }
+
+        string IExplicitHeaderRow.Name => _name;
+
+        DateTime IExplicitHeaderRow.Time => _time;
     }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Utils/ReflectionHelperTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Utils/ReflectionHelperTests.cs
@@ -81,6 +81,96 @@ namespace Avalonia.Controls.DataGridTests.Utils
         }
 
         [Fact]
+        public void GetPropertyOrIndexer_Finds_Explicit_Interface_Property_On_Class()
+        {
+            var property = typeof(ExplicitInterfaceItem).GetPropertyOrIndexer(
+                nameof(IExplicitInterfaceItem.Name),
+                out var index);
+
+            Assert.NotNull(property);
+            Assert.Null(index);
+            Assert.Equal(typeof(IExplicitInterfaceItem), property!.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Finds_Inherited_Explicit_Interface_Property_On_Class()
+        {
+            var property = typeof(InheritedExplicitInterfaceItem).GetPropertyOrIndexer(
+                nameof(IParentInterface.Name),
+                out var index);
+
+            Assert.NotNull(property);
+            Assert.Null(index);
+            Assert.Equal(typeof(IParentInterface), property!.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Prefers_Public_Class_Property_Over_Interface_Property()
+        {
+            var property = typeof(PublicAndExplicitInterfaceItem).GetPropertyOrIndexer(
+                nameof(IExplicitInterfaceItem.Name),
+                out var index);
+
+            Assert.NotNull(property);
+            Assert.Null(index);
+            Assert.Equal(typeof(PublicAndExplicitInterfaceItem), property!.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Prefers_Most_Derived_Interface_Property()
+        {
+            var property = typeof(RedeclaredExplicitInterfaceItem).GetPropertyOrIndexer(
+                nameof(IRedeclaredChildInterface.Value),
+                out var index);
+
+            Assert.NotNull(property);
+            Assert.Null(index);
+            Assert.Equal(typeof(IRedeclaredChildInterface), property!.DeclaringType);
+            Assert.Equal(typeof(string), property.PropertyType);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Uses_Diamond_Interface_Redeclaration_To_Disambiguate_Property()
+        {
+            var property = typeof(DiamondExplicitInterfaceItem).GetPropertyOrIndexer(
+                nameof(IDiamondInterface.Value),
+                out var index);
+
+            Assert.NotNull(property);
+            Assert.Null(index);
+            Assert.Equal(typeof(IDiamondInterface), property!.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Returns_Null_For_Unrelated_Ambiguous_Interface_Properties()
+        {
+            var property = typeof(AmbiguousExplicitInterfaceItem).GetPropertyOrIndexer("Value", out var index);
+
+            Assert.Null(property);
+            Assert.Null(index);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Finds_Explicit_Interface_Indexer_On_Class()
+        {
+            var property = typeof(ExplicitInterfaceIndexer).GetPropertyOrIndexer("[2]", out var index);
+
+            Assert.NotNull(property);
+            Assert.Equal(typeof(IExplicitInterfaceIndexer), property!.DeclaringType);
+            Assert.Equal(new object[] { 2 }, index);
+        }
+
+        [Fact]
+        public void GetPropertyOrIndexer_Uses_Diamond_Interface_Redeclaration_To_Disambiguate_Indexer()
+        {
+            var property = typeof(DiamondExplicitInterfaceIndexer).GetPropertyOrIndexer("[2]", out var index);
+
+            Assert.NotNull(property);
+            Assert.Equal(typeof(IDiamondIndexer), property!.DeclaringType);
+            Assert.Equal(new object[] { 2 }, index);
+        }
+
+        [Fact]
         public void GetNestedProperty_Resolves_Indexer_Path()
         {
             var model = new ParentWithChildren
@@ -124,6 +214,54 @@ namespace Avalonia.Controls.DataGridTests.Utils
             var value = TypeHelper.GetNestedPropertyValue(model, "Child.Name");
 
             Assert.Equal("beta", value);
+        }
+
+        [Fact]
+        public void GetNestedPropertyValue_Reads_Explicit_Interface_Property()
+        {
+            IExplicitInterfaceItem model = new ExplicitInterfaceItem("alpha");
+
+            var value = TypeHelper.GetNestedPropertyValue(model, nameof(IExplicitInterfaceItem.Name));
+
+            Assert.Equal("alpha", value);
+        }
+
+        [Fact]
+        public void GetNestedPropertyValue_Reads_Nested_Explicit_Interface_Properties()
+        {
+            INestedExplicitContainer model = new NestedExplicitContainer(new ExplicitInterfaceItem("nested"));
+
+            var value = TypeHelper.GetNestedPropertyValue(
+                model,
+                $"{nameof(INestedExplicitContainer.Item)}.{nameof(IExplicitInterfaceItem.Name)}");
+
+            Assert.Equal("nested", value);
+        }
+
+        [Fact]
+        public void GetNestedPropertyValue_Reads_Explicit_Interface_Indexer()
+        {
+            IExplicitInterfaceIndexer model = new ExplicitInterfaceIndexer();
+
+            var value = TypeHelper.GetNestedPropertyValue(model, "[3]");
+
+            Assert.Equal("item-3", value);
+        }
+
+        [Fact]
+        public void TrySetNestedPropertyValue_Writes_Explicit_Interface_Property()
+        {
+            var model = new WritableExplicitInterfaceItem();
+
+            var result = TypeHelper.TrySetNestedPropertyValue(
+                model,
+                nameof(IWritableExplicitInterfaceItem.Value),
+                42,
+                out var exception);
+
+            Assert.True(result);
+            Assert.Null(exception);
+            Assert.Equal(42, ((IWritableExplicitInterfaceItem)model).Value);
         }
 
         [Fact]
@@ -250,6 +388,144 @@ namespace Avalonia.Controls.DataGridTests.Utils
 
         private interface IChildInterface : IParentInterface
         {
+        }
+
+        private interface IExplicitInterfaceItem
+        {
+            string Name { get; }
+        }
+
+        private interface INestedExplicitContainer
+        {
+            IExplicitInterfaceItem Item { get; }
+        }
+
+        private interface IWritableExplicitInterfaceItem
+        {
+            int Value { get; set; }
+        }
+
+        private interface IRedeclaredParentInterface
+        {
+            object Value { get; }
+        }
+
+        private interface IRedeclaredChildInterface : IRedeclaredParentInterface
+        {
+            new string Value { get; }
+        }
+
+        private interface IAmbiguousLeftInterface
+        {
+            string Value { get; }
+        }
+
+        private interface IAmbiguousRightInterface
+        {
+            string Value { get; }
+        }
+
+        private interface IDiamondInterface : IAmbiguousLeftInterface, IAmbiguousRightInterface
+        {
+            new string Value { get; }
+        }
+
+        private interface IExplicitInterfaceIndexer
+        {
+            string this[int index] { get; }
+        }
+
+        private interface ILeftExplicitInterfaceIndexer
+        {
+            string this[int index] { get; }
+        }
+
+        private interface IRightExplicitInterfaceIndexer
+        {
+            string this[int index] { get; }
+        }
+
+        private interface IDiamondIndexer : ILeftExplicitInterfaceIndexer, IRightExplicitInterfaceIndexer
+        {
+            new string this[int index] { get; }
+        }
+
+        private sealed class ExplicitInterfaceItem : IExplicitInterfaceItem
+        {
+            private readonly string _name;
+
+            public ExplicitInterfaceItem(string name)
+            {
+                _name = name;
+            }
+
+            string IExplicitInterfaceItem.Name => _name;
+        }
+
+        private sealed class InheritedExplicitInterfaceItem : IChildInterface
+        {
+            string IParentInterface.Name => "inherited";
+        }
+
+        private sealed class PublicAndExplicitInterfaceItem : IExplicitInterfaceItem
+        {
+            public string Name => "public";
+
+            string IExplicitInterfaceItem.Name => "explicit";
+        }
+
+        private sealed class NestedExplicitContainer : INestedExplicitContainer
+        {
+            private readonly IExplicitInterfaceItem _item;
+
+            public NestedExplicitContainer(IExplicitInterfaceItem item)
+            {
+                _item = item;
+            }
+
+            IExplicitInterfaceItem INestedExplicitContainer.Item => _item;
+        }
+
+        private sealed class WritableExplicitInterfaceItem : IWritableExplicitInterfaceItem
+        {
+            int IWritableExplicitInterfaceItem.Value { get; set; }
+        }
+
+        private sealed class RedeclaredExplicitInterfaceItem : IRedeclaredChildInterface
+        {
+            object IRedeclaredParentInterface.Value => "parent";
+
+            string IRedeclaredChildInterface.Value => "child";
+        }
+
+        private sealed class AmbiguousExplicitInterfaceItem : IAmbiguousLeftInterface, IAmbiguousRightInterface
+        {
+            string IAmbiguousLeftInterface.Value => "left";
+
+            string IAmbiguousRightInterface.Value => "right";
+        }
+
+        private sealed class DiamondExplicitInterfaceItem : IDiamondInterface
+        {
+            string IAmbiguousLeftInterface.Value => "left";
+
+            string IAmbiguousRightInterface.Value => "right";
+
+            string IDiamondInterface.Value => "diamond";
+        }
+
+        private sealed class ExplicitInterfaceIndexer : IExplicitInterfaceIndexer
+        {
+            string IExplicitInterfaceIndexer.this[int index] => $"item-{index}";
+        }
+
+        private sealed class DiamondExplicitInterfaceIndexer : IDiamondIndexer
+        {
+            string ILeftExplicitInterfaceIndexer.this[int index] => $"left-{index}";
+
+            string IRightExplicitInterfaceIndexer.this[int index] => $"right-{index}";
+
+            string IDiamondIndexer.this[int index] => $"diamond-{index}";
         }
 
         private class ParentWithChildren

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -42,9 +42,14 @@ internal
         internal virtual void Initialize(Type itemType)
         { }
 
-        private static object InvokePath(object item, string propertyPath, Type propertyType)
+        private static object InvokePath(object item, string propertyPath, Type propertyType, Type itemType)
         {
-            object propertyValue = TypeHelper.GetNestedPropertyValue(item, propertyPath, propertyType, out Exception exception);
+            object propertyValue = TypeHelper.GetNestedPropertyValue(
+                item,
+                propertyPath,
+                propertyType,
+                itemType,
+                out Exception exception);
             if (exception != null)
             {
                 throw exception;
@@ -118,6 +123,7 @@ internal
                 private readonly string _propertyPath;
                 private readonly Lazy<CultureSensitiveComparer> _cultureSensitiveComparer;
                 private readonly Lazy<IComparer<object>> _comparer;
+                private Type _itemType;
                 private Type _propertyType;
                 private IComparer _internalComparer;
                 private IComparer<object> _internalComparerTyped;
@@ -153,6 +159,7 @@ internal
             {
                 _propertyPath = inner._propertyPath;
                 _direction = direction;
+                _itemType = inner._itemType;
                 _propertyType = inner._propertyType;
                 _cultureSensitiveComparer = inner._cultureSensitiveComparer;
                 _internalComparer = inner._internalComparer;
@@ -167,7 +174,19 @@ internal
                     return null;
 
                 if (HasPropertyPath)
-                    return InvokePath(o, _propertyPath, _propertyType);
+                {
+                    if (_propertyType == null)
+                    {
+                        _propertyType = GetPropertyType(o);
+                    }
+
+                    if (_propertyType == null)
+                    {
+                        return null;
+                    }
+
+                    return InvokePath(o, _propertyPath, _propertyType, _itemType ?? o.GetType());
+                }
 
                 if (_propertyType == o.GetType())
                     return o;
@@ -209,7 +228,33 @@ internal
 
             private Type GetPropertyType(object o)
             {
-                return o.GetType().GetNestedPropertyType(_propertyPath);
+                Type itemType = _itemType ?? GetPathRootType(o.GetType());
+                Type propertyType = itemType.GetNestedPropertyType(_propertyPath);
+                if (propertyType != null)
+                {
+                    _itemType = itemType;
+                }
+
+                return propertyType;
+            }
+
+            private Type GetPathRootType(Type itemType)
+            {
+                if (!HasPropertyPath)
+                {
+                    return itemType;
+                }
+
+                List<string> propertyNames = TypeHelper.SplitPropertyPath(_propertyPath);
+                if (propertyNames.Count == 0)
+                {
+                    return itemType;
+                }
+
+                var property = itemType.GetPropertyOrIndexer(propertyNames[0], out _);
+                return property?.DeclaringType?.IsInterface == true
+                    ? property.DeclaringType
+                    : itemType;
             }
 
             private int Compare(object x, object y)
@@ -247,7 +292,14 @@ internal
                 base.Initialize(itemType);
 
                 if(_propertyType == null)
-                    _propertyType = itemType.GetNestedPropertyType(_propertyPath);
+                {
+                    Type pathRootType = GetPathRootType(itemType);
+                    _propertyType = pathRootType.GetNestedPropertyType(_propertyPath);
+                    if (_propertyType != null)
+                    {
+                        _itemType = pathRootType;
+                    }
+                }
                 if (_internalComparer == null && _propertyType != null)
                     _internalComparer = GetComparerForType(_propertyType);
             }

--- a/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Controls.Utils
 
                 // Only a single parameter is supported and it must be a string or Int32 value.
                 parameters = pi.GetIndexParameters();
-                if (parameters.Length > 1)
+                if (parameters.Length != 1)
                 {
                     continue;
                 }
@@ -96,6 +96,132 @@ namespace Avalonia.Controls.Utils
             }
 
             return stringIndexer;
+        }
+
+        private static PropertyInfo? FindIndexerInInterfaces(Type type, string stringIndex, out object[]? index)
+        {
+            PropertyInfo? candidate = null;
+            Type? candidateInterface = null;
+            Type? candidateParameterType = null;
+            object[]? candidateIndex = null;
+            Type[] interfaces = type.GetInterfaces();
+
+            foreach (Type typeInterface in interfaces)
+            {
+                PropertyInfo? indexer = FindIndexerInMembers(typeInterface.GetDefaultMembers(), stringIndex, out object[]? currentIndex);
+                if (indexer == null)
+                {
+                    continue;
+                }
+
+                Type currentParameterType = indexer.GetIndexParameters()[0].ParameterType;
+                Type currentInterface = indexer.DeclaringType ?? typeInterface;
+                if (candidate == null ||
+                    (candidateParameterType == typeof(string) && currentParameterType == typeof(int)))
+                {
+                    candidate = indexer;
+                    candidateInterface = currentInterface;
+                    candidateParameterType = currentParameterType;
+                    candidateIndex = currentIndex;
+                    continue;
+                }
+
+                if (candidateParameterType == typeof(int) && currentParameterType == typeof(string))
+                {
+                    continue;
+                }
+
+                if (candidateInterface!.IsAssignableFrom(currentInterface))
+                {
+                    candidate = indexer;
+                    candidateInterface = currentInterface;
+                    candidateParameterType = currentParameterType;
+                    candidateIndex = currentIndex;
+                }
+            }
+
+            if (candidate == null)
+            {
+                index = null;
+                return null;
+            }
+
+            // Reflection does not define interface enumeration order. Validate that
+            // the selected member is declared by a unique interface which is at least
+            // as specific as every other candidate of the preferred indexer kind.
+            foreach (Type typeInterface in interfaces)
+            {
+                PropertyInfo? indexer = FindIndexerInMembers(typeInterface.GetDefaultMembers(), stringIndex, out _);
+                if (indexer == null || indexer.GetIndexParameters()[0].ParameterType != candidateParameterType)
+                {
+                    continue;
+                }
+
+                Type currentInterface = indexer.DeclaringType ?? typeInterface;
+                if (!currentInterface.IsAssignableFrom(candidateInterface))
+                {
+                    index = null;
+                    return null;
+                }
+            }
+
+            index = candidateIndex;
+            return candidate;
+        }
+
+        private static PropertyInfo? FindPropertyInInterfaces(Type type, string propertyName)
+        {
+            PropertyInfo? candidate = null;
+            Type? candidateInterface = null;
+            Type[] interfaces = type.GetInterfaces();
+
+            foreach (Type typeInterface in interfaces)
+            {
+                PropertyInfo? property = typeInterface.GetProperty(propertyName);
+                if (property == null)
+                {
+                    continue;
+                }
+
+                Type propertyInterface = property.DeclaringType ?? typeInterface;
+                if (candidate == null)
+                {
+                    candidate = property;
+                    candidateInterface = propertyInterface;
+                    continue;
+                }
+
+                if (candidateInterface!.IsAssignableFrom(propertyInterface))
+                {
+                    candidate = property;
+                    candidateInterface = propertyInterface;
+                }
+            }
+
+            if (candidate == null)
+            {
+                return null;
+            }
+
+            // A derived interface may intentionally redeclare members from otherwise
+            // unrelated parents, so defer ambiguity detection until the most-specific
+            // candidate has been selected independently of reflection enumeration order.
+            foreach (Type typeInterface in interfaces)
+            {
+                PropertyInfo? property = typeInterface.GetProperty(propertyName);
+                if (property == null)
+                {
+                    continue;
+                }
+
+                Type propertyInterface = property.DeclaringType ?? typeInterface;
+                if (!propertyInterface.IsAssignableFrom(candidateInterface))
+                {
+                    return null;
+                }
+            }
+
+            return candidate;
         }
 
         /// <summary>
@@ -277,6 +403,16 @@ namespace Avalonia.Controls.Utils
         /// <returns>Property value</returns>
         internal static object? GetNestedPropertyValue(object? item, string? propertyPath, Type propertyType, out Exception? exception)
         {
+            return GetNestedPropertyValue(item, propertyPath, propertyType, null, out exception);
+        }
+
+        internal static object? GetNestedPropertyValue(
+            object? item,
+            string? propertyPath,
+            Type propertyType,
+            Type? parentType,
+            out Exception? exception)
+        {
             exception = null;
 
             // if the item is null, treat the property value as null
@@ -292,15 +428,15 @@ namespace Avalonia.Controls.Utils
             }
 
             object? propertyValue = item;
-            Type? itemType = item.GetType();
-            if (itemType != null)
+            Type itemType = parentType != null && parentType.IsInstanceOfType(item)
+                ? parentType
+                : item.GetType();
+            PropertyInfo? propertyInfo = itemType.GetNestedProperty(propertyPath, out exception, ref propertyValue);
+            if (propertyInfo != null && propertyInfo.PropertyType != propertyType)
             {
-                PropertyInfo? propertyInfo = itemType.GetNestedProperty(propertyPath, out exception, ref propertyValue);
-                if (propertyInfo != null && propertyInfo.PropertyType != propertyType)
-                {
-                    return null;
-                }
+                return null;
             }
+
             return propertyValue;
         }
 
@@ -434,18 +570,13 @@ namespace Avalonia.Controls.Utils
                     return property;
                 }
 
-                // GetProperty does not return inherited interface properties,
-                // so we need to enumerate them manually.
-                if (type.IsInterface)
+                // GetProperty does not return inherited interface properties or
+                // properties implemented explicitly by a class, so inspect the
+                // implemented interfaces when no public class property was found.
+                property = FindPropertyInInterfaces(type, propertyPath);
+                if (property != null)
                 {
-                    foreach (var typeInterface in type.GetInterfaces())
-                    {
-                        property = typeInterface.GetProperty(propertyPath);
-                        if (property != null)
-                        {
-                            return property;
-                        }
-                    }
+                    return property;
                 }
 
                 return null;
@@ -462,6 +593,12 @@ namespace Avalonia.Controls.Utils
             if (indexer != null)
             {
                 // We found the indexer, so return it.
+                return indexer;
+            }
+
+            indexer = FindIndexerInInterfaces(type, stringIndex, out index);
+            if (indexer != null)
+            {
                 return indexer;
             }
 

--- a/src/DataGridSample.UnitTests/ExplicitInterfaceSortingSampleTests.cs
+++ b/src/DataGridSample.UnitTests/ExplicitInterfaceSortingSampleTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DataGridSample.Models;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class ExplicitInterfaceSortingSampleTests
+{
+    [Fact]
+    public void ViewModel_Provides_All_Supported_Interface_Scenarios()
+    {
+        var viewModel = new ExplicitInterfaceSortingViewModel();
+
+        Assert.Equal(3, viewModel.DirectRows.Count);
+        Assert.IsType<ExplicitSortRow>(viewModel.DirectRows[0]);
+        Assert.IsType<AlternateExplicitSortRow>(viewModel.DirectRows[1]);
+        Assert.Equal(new[] { "Charlie", "Alice", "Bob" }, viewModel.DirectRows.Select(row => row.Name));
+
+        Assert.Equal(new[] { "Charlie", "Alice", "Bob" }, viewModel.InheritedRows.Select(row => row.Name));
+        Assert.Equal(new[] { 30, 10, 20 }, viewModel.InheritedRows.Select(row => row.Priority));
+
+        Assert.Equal(4, viewModel.NestedRows.Count);
+        Assert.Null(viewModel.NestedRows[1].Detail);
+        Assert.Equal(new int?[] { 30, null, 10, 20 }, viewModel.NestedRows.Select(row => row.Detail?.Score));
+
+        Assert.Equal(3, viewModel.PrimaryLabelRows.Count);
+        Assert.Equal(3, viewModel.SecondaryLabelRows.Count);
+        for (var index = 0; index < viewModel.PrimaryLabelRows.Count; index++)
+        {
+            Assert.Same(viewModel.PrimaryLabelRows[index], viewModel.SecondaryLabelRows[index]);
+        }
+        Assert.Equal(new[] { "Charlie", "Alice", "Bob" }, viewModel.PrimaryLabelRows.Select(row => row.Label));
+        Assert.Equal(new[] { "Alpha", "Zulu", "Mike" }, viewModel.SecondaryLabelRows.Select(row => row.Label));
+    }
+
+    [AvaloniaFact]
+    public void Page_Sorts_Direct_Inherited_Nested_And_Ambiguous_Interface_Paths()
+    {
+        var page = new ExplicitInterfaceSortingPage
+        {
+            DataContext = new ExplicitInterfaceSortingViewModel()
+        };
+        var window = CreateHostWindow(page);
+
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            Assert.IsType<ExplicitInterfaceSortingViewModel>(page.DataContext);
+
+            var directGrid = GetGrid(page, "DirectGrid");
+            Sort(directGrid, "Name", ListSortDirection.Ascending);
+            Assert.Equal(
+                new[] { "Alice", "Bob", "Charlie" },
+                directGrid.CollectionView.Cast<IExplicitSortRow>().Select(row => row.Name));
+            Sort(directGrid, "Time", ListSortDirection.Descending);
+            Assert.Equal(
+                new[] { "Charlie", "Bob", "Alice" },
+                directGrid.CollectionView.Cast<IExplicitSortRow>().Select(row => row.Name));
+
+            var inheritedGrid = GetGrid(page, "InheritedGrid");
+            Sort(inheritedGrid, "Name", ListSortDirection.Ascending);
+            Assert.Equal(
+                new[] { "Alice", "Bob", "Charlie" },
+                inheritedGrid.CollectionView.Cast<IInheritedExplicitSortRow>().Select(row => row.Name));
+            Sort(inheritedGrid, "Priority", ListSortDirection.Descending);
+            Assert.Equal(
+                new[] { 30, 20, 10 },
+                inheritedGrid.CollectionView.Cast<IInheritedExplicitSortRow>().Select(row => row.Priority));
+
+            var nestedGrid = GetGrid(page, "NestedGrid");
+            Sort(nestedGrid, "Detail score", ListSortDirection.Ascending);
+            Assert.Equal(
+                new int?[] { null, 10, 20, 30 },
+                nestedGrid.CollectionView.Cast<INestedExplicitSortRow>().Select(row => row.Detail?.Score));
+
+            var primaryGrid = GetGrid(page, "PrimaryLabelGrid");
+            Sort(primaryGrid, "Primary label", ListSortDirection.Ascending);
+            Assert.Equal(
+                new[] { "Alice", "Bob", "Charlie" },
+                primaryGrid.CollectionView.Cast<IPrimaryExplicitLabel>().Select(row => row.Label));
+
+            var secondaryGrid = GetGrid(page, "SecondaryLabelGrid");
+            Sort(secondaryGrid, "Secondary label", ListSortDirection.Ascending);
+            Assert.Equal(
+                new[] { "Alpha", "Mike", "Zulu" },
+                secondaryGrid.CollectionView.Cast<ISecondaryExplicitLabel>().Select(row => row.Label));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static DataGrid GetGrid(Control page, string name)
+    {
+        return Assert.IsType<DataGrid>(page.FindControl<DataGrid>(name));
+    }
+
+    private static void Sort(DataGrid grid, string header, ListSortDirection direction)
+    {
+        DataGridColumn column = Assert.Single(grid.Columns, column => Equals(column.Header, header));
+        foreach (DataGridColumn otherColumn in grid.Columns)
+        {
+            if (!ReferenceEquals(otherColumn, column))
+            {
+                otherColumn.SortDirection = null;
+            }
+        }
+        column.SortDirection = direction;
+        PumpLayout(grid);
+    }
+
+    private static Window CreateHostWindow(Control content)
+    {
+        var window = new Window
+        {
+            Width = 1280,
+            Height = 900,
+            Content = content
+        };
+        window.ApplySampleTheme();
+        return window;
+    }
+
+    private static void PumpLayout(Control control)
+    {
+        Dispatcher.UIThread.RunJobs();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/src/DataGridSample.UnitTests/SamplePageCatalog.cs
+++ b/src/DataGridSample.UnitTests/SamplePageCatalog.cs
@@ -73,6 +73,7 @@ internal static class SamplePageCatalog
             ("DataGridSample.Pages.DynamicDataStreamingSourceListPage", static () => new global::DataGridSample.Pages.DynamicDataStreamingSourceListPage()),
             ("DataGridSample.Pages.EditingInteractionModelPage", static () => new global::DataGridSample.Pages.EditingInteractionModelPage()),
             ("DataGridSample.Pages.ExcelLikeEditingPage", static () => new global::DataGridSample.Pages.ExcelLikeEditingPage()),
+            ("DataGridSample.Pages.ExplicitInterfaceSortingPage", static () => new global::DataGridSample.Pages.ExplicitInterfaceSortingPage()),
             ("DataGridSample.Pages.FillHandleModelPage", static () => new global::DataGridSample.Pages.FillHandleModelPage()),
             ("DataGridSample.Pages.FilteringModelSamplePage", static () => new global::DataGridSample.Pages.FilteringModelSamplePage()),
             ("DataGridSample.Pages.FocusLossOnScrollPage", static () => new global::DataGridSample.Pages.FocusLossOnScrollPage()),

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -540,6 +540,13 @@
     <TabItem Header="Sorting Model">
       <pages:SortingModelPage />
     </TabItem>
+    <TabItem Header="Explicit Interface Sorting">
+      <pages:ExplicitInterfaceSortingPage>
+        <pages:ExplicitInterfaceSortingPage.DataContext>
+          <viewModels:ExplicitInterfaceSortingViewModel />
+        </pages:ExplicitInterfaceSortingPage.DataContext>
+      </pages:ExplicitInterfaceSortingPage>
+    </TabItem>
     <TabItem Header="Sort Direction Restore">
       <pages:SortDirectionPage />
     </TabItem>

--- a/src/DataGridSample/Models/ExplicitInterfaceSortingModels.cs
+++ b/src/DataGridSample/Models/ExplicitInterfaceSortingModels.cs
@@ -1,0 +1,195 @@
+using System;
+
+namespace DataGridSample.Models;
+
+/// <summary>
+/// Defines the direct explicit-interface sorting contract used by the sample.
+/// </summary>
+public interface IExplicitSortRow
+{
+    /// <summary>Gets the row name.</summary>
+    string Name { get; }
+
+    /// <summary>Gets the row timestamp.</summary>
+    DateTime Time { get; }
+}
+
+/// <summary>
+/// Defines a base interface whose property is implemented explicitly by sample rows.
+/// </summary>
+public interface IBaseExplicitSortRow
+{
+    /// <summary>Gets the inherited row name.</summary>
+    string Name { get; }
+}
+
+/// <summary>
+/// Extends the base sorting contract without redeclaring its property.
+/// </summary>
+public interface IInheritedExplicitSortRow : IBaseExplicitSortRow
+{
+    /// <summary>Gets the row priority.</summary>
+    int Priority { get; }
+}
+
+/// <summary>
+/// Defines nested details whose properties are implemented explicitly.
+/// </summary>
+public interface IExplicitSortDetail
+{
+    /// <summary>Gets the detail name.</summary>
+    string Name { get; }
+
+    /// <summary>Gets the detail score.</summary>
+    int Score { get; }
+}
+
+/// <summary>
+/// Defines a row with an explicitly implemented nullable nested object.
+/// </summary>
+public interface INestedExplicitSortRow
+{
+    /// <summary>Gets the stable row identifier.</summary>
+    string Id { get; }
+
+    /// <summary>Gets the optional nested details.</summary>
+    IExplicitSortDetail? Detail { get; }
+}
+
+/// <summary>
+/// Defines the primary label used to disambiguate same-name interface properties.
+/// </summary>
+public interface IPrimaryExplicitLabel
+{
+    /// <summary>Gets the primary label.</summary>
+    string Label { get; }
+}
+
+/// <summary>
+/// Defines the secondary label used to disambiguate same-name interface properties.
+/// </summary>
+public interface ISecondaryExplicitLabel
+{
+    /// <summary>Gets the secondary label.</summary>
+    string Label { get; }
+}
+
+/// <summary>
+/// Implements the direct row contract explicitly.
+/// </summary>
+public sealed class ExplicitSortRow : IExplicitSortRow
+{
+    private readonly string _name;
+    private readonly DateTime _time;
+
+    /// <summary>Initializes a direct explicit-interface row.</summary>
+    public ExplicitSortRow(string name, DateTime time)
+    {
+        _name = name;
+        _time = time;
+    }
+
+    string IExplicitSortRow.Name => _name;
+
+    DateTime IExplicitSortRow.Time => _time;
+}
+
+/// <summary>
+/// Provides a second runtime type for polymorphic explicit-interface sorting.
+/// </summary>
+public sealed class AlternateExplicitSortRow : IExplicitSortRow
+{
+    private readonly string _name;
+    private readonly DateTime _time;
+
+    /// <summary>Initializes a polymorphic explicit-interface row.</summary>
+    public AlternateExplicitSortRow(string name, DateTime time)
+    {
+        _name = name;
+        _time = time;
+    }
+
+    string IExplicitSortRow.Name => _name;
+
+    DateTime IExplicitSortRow.Time => _time;
+}
+
+/// <summary>
+/// Implements both an inherited and a directly declared interface property explicitly.
+/// </summary>
+public sealed class InheritedExplicitSortRow : IInheritedExplicitSortRow
+{
+    private readonly string _name;
+    private readonly int _priority;
+
+    /// <summary>Initializes an inherited explicit-interface row.</summary>
+    public InheritedExplicitSortRow(string name, int priority)
+    {
+        _name = name;
+        _priority = priority;
+    }
+
+    string IBaseExplicitSortRow.Name => _name;
+
+    int IInheritedExplicitSortRow.Priority => _priority;
+}
+
+/// <summary>
+/// Implements nested detail properties explicitly.
+/// </summary>
+public sealed class ExplicitSortDetail : IExplicitSortDetail
+{
+    private readonly string _name;
+    private readonly int _score;
+
+    /// <summary>Initializes nested explicit-interface details.</summary>
+    public ExplicitSortDetail(string name, int score)
+    {
+        _name = name;
+        _score = score;
+    }
+
+    string IExplicitSortDetail.Name => _name;
+
+    int IExplicitSortDetail.Score => _score;
+}
+
+/// <summary>
+/// Implements the root and nested-object properties explicitly.
+/// </summary>
+public sealed class NestedExplicitSortRow : INestedExplicitSortRow
+{
+    private readonly string _id;
+    private readonly IExplicitSortDetail? _detail;
+
+    /// <summary>Initializes a nested explicit-interface row.</summary>
+    public NestedExplicitSortRow(string id, IExplicitSortDetail? detail)
+    {
+        _id = id;
+        _detail = detail;
+    }
+
+    string INestedExplicitSortRow.Id => _id;
+
+    IExplicitSortDetail? INestedExplicitSortRow.Detail => _detail;
+}
+
+/// <summary>
+/// Implements two unrelated same-name interface properties explicitly.
+/// </summary>
+public sealed class DualExplicitLabelRow : IPrimaryExplicitLabel, ISecondaryExplicitLabel
+{
+    private readonly string _primaryLabel;
+    private readonly string _secondaryLabel;
+
+    /// <summary>Initializes a row with independently sortable interface labels.</summary>
+    public DualExplicitLabelRow(string primaryLabel, string secondaryLabel)
+    {
+        _primaryLabel = primaryLabel;
+        _secondaryLabel = secondaryLabel;
+    }
+
+    string IPrimaryExplicitLabel.Label => _primaryLabel;
+
+    string ISecondaryExplicitLabel.Label => _secondaryLabel;
+}

--- a/src/DataGridSample/Pages/ExplicitInterfaceSortingPage.axaml
+++ b/src/DataGridSample/Pages/ExplicitInterfaceSortingPage.axaml
@@ -1,0 +1,142 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.ExplicitInterfaceSortingPage"
+             x:DataType="viewModels:ExplicitInterfaceSortingViewModel">
+  <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+    <StackPanel Margin="12" Spacing="12">
+      <StackPanel Spacing="4">
+        <TextBlock Classes="h2" Text="Explicit interface property sorting" />
+        <TextBlock TextWrapping="Wrap"
+                   Text="Click every column header to sort. The grids cover direct and polymorphic implementations, inherited interface members, nullable nested paths, and unrelated interfaces that expose the same member name." />
+      </StackPanel>
+
+      <Border BorderBrush="{DynamicResource ThemeBorderLowBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="10">
+        <Grid RowDefinitions="Auto,Auto,180" RowSpacing="6">
+          <TextBlock FontWeight="SemiBold" Text="Direct + polymorphic explicit implementations" />
+          <TextBlock Grid.Row="1"
+                     TextWrapping="Wrap"
+                     Text="ObservableCollection&lt;IExplicitSortRow&gt; contains two concrete runtime types. Sort Name or Time in both directions." />
+          <DataGrid x:Name="DirectGrid"
+                    Grid.Row="2"
+                    ItemsSource="{Binding DirectRows}"
+                    AutoGenerateColumns="False"
+                    CanUserSortColumns="True">
+            <DataGrid.Columns>
+              <DataGridTextColumn x:DataType="models:IExplicitSortRow"
+                                  Header="Name"
+                                  Binding="{Binding Name}"
+                                  SortMemberPath="Name" />
+              <DataGridTextColumn x:DataType="models:IExplicitSortRow"
+                                  Header="Time"
+                                  Binding="{Binding Time, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                  SortMemberPath="Time" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </Grid>
+      </Border>
+
+      <Border BorderBrush="{DynamicResource ThemeBorderLowBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="10">
+        <Grid RowDefinitions="Auto,Auto,180" RowSpacing="6">
+          <TextBlock FontWeight="SemiBold" Text="Inherited interface members" />
+          <TextBlock Grid.Row="1"
+                     TextWrapping="Wrap"
+                     Text="Name is declared by IBaseExplicitSortRow; Priority is declared by the derived interface. Both are explicit on the concrete row." />
+          <DataGrid x:Name="InheritedGrid"
+                    Grid.Row="2"
+                    ItemsSource="{Binding InheritedRows}"
+                    AutoGenerateColumns="False"
+                    CanUserSortColumns="True">
+            <DataGrid.Columns>
+              <DataGridTextColumn x:DataType="models:IInheritedExplicitSortRow"
+                                  Header="Name"
+                                  Binding="{Binding Name}"
+                                  SortMemberPath="Name" />
+              <DataGridTextColumn x:DataType="models:IInheritedExplicitSortRow"
+                                  Header="Priority"
+                                  Binding="{Binding Priority}"
+                                  SortMemberPath="Priority" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </Grid>
+      </Border>
+
+      <Border BorderBrush="{DynamicResource ThemeBorderLowBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="10">
+        <Grid RowDefinitions="Auto,Auto,200" RowSpacing="6">
+          <TextBlock FontWeight="SemiBold" Text="Nested explicit paths + nulls" />
+          <TextBlock Grid.Row="1"
+                     TextWrapping="Wrap"
+                     Text="The root Id and Detail properties are explicit, as are Detail.Name and Detail.Score. One row has null details to exercise null ordering." />
+          <DataGrid x:Name="NestedGrid"
+                    Grid.Row="2"
+                    ItemsSource="{Binding NestedRows}"
+                    AutoGenerateColumns="False"
+                    CanUserSortColumns="True">
+            <DataGrid.Columns>
+              <DataGridTextColumn x:DataType="models:INestedExplicitSortRow"
+                                  Header="Id"
+                                  Binding="{Binding Id}"
+                                  SortMemberPath="Id" />
+              <DataGridTextColumn x:DataType="models:INestedExplicitSortRow"
+                                  Header="Detail name"
+                                  Binding="{Binding Detail.Name}"
+                                  SortMemberPath="Detail.Name" />
+              <DataGridTextColumn x:DataType="models:INestedExplicitSortRow"
+                                  Header="Detail score"
+                                  Binding="{Binding Detail.Score}"
+                                  SortMemberPath="Detail.Score" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </Grid>
+      </Border>
+
+      <Border BorderBrush="{DynamicResource ThemeBorderLowBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="10">
+        <Grid RowDefinitions="Auto,Auto,200" RowSpacing="6">
+          <TextBlock FontWeight="SemiBold" Text="Same member name on unrelated interfaces" />
+          <TextBlock Grid.Row="1"
+                     TextWrapping="Wrap"
+                     Text="Both grids contain the same objects. Their declared collection item interface disambiguates which explicit Label property SortMemberPath resolves." />
+          <Grid Grid.Row="2" ColumnDefinitions="*,*" ColumnSpacing="10">
+            <DataGrid x:Name="PrimaryLabelGrid"
+                      ItemsSource="{Binding PrimaryLabelRows}"
+                      AutoGenerateColumns="False"
+                      CanUserSortColumns="True">
+              <DataGrid.Columns>
+                <DataGridTextColumn x:DataType="models:IPrimaryExplicitLabel"
+                                    Header="Primary label"
+                                    Binding="{Binding Label}"
+                                    SortMemberPath="Label" />
+              </DataGrid.Columns>
+            </DataGrid>
+            <DataGrid x:Name="SecondaryLabelGrid"
+                      Grid.Column="1"
+                      ItemsSource="{Binding SecondaryLabelRows}"
+                      AutoGenerateColumns="False"
+                      CanUserSortColumns="True">
+              <DataGrid.Columns>
+                <DataGridTextColumn x:DataType="models:ISecondaryExplicitLabel"
+                                    Header="Secondary label"
+                                    Binding="{Binding Label}"
+                                    SortMemberPath="Label" />
+              </DataGrid.Columns>
+            </DataGrid>
+          </Grid>
+        </Grid>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/src/DataGridSample/Pages/ExplicitInterfaceSortingPage.axaml.cs
+++ b/src/DataGridSample/Pages/ExplicitInterfaceSortingPage.axaml.cs
@@ -1,0 +1,15 @@
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+/// <summary>
+/// Displays supported explicit-interface property sorting scenarios.
+/// </summary>
+public sealed partial class ExplicitInterfaceSortingPage : UserControl
+{
+    /// <summary>Initializes the sample page.</summary>
+    public ExplicitInterfaceSortingPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/ViewModels/ExplicitInterfaceSortingViewModel.cs
+++ b/src/DataGridSample/ViewModels/ExplicitInterfaceSortingViewModel.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.ObjectModel;
+using DataGridSample.Models;
+using ReactiveUI;
+
+namespace DataGridSample.ViewModels;
+
+/// <summary>
+/// Supplies interface-typed collections for the explicit-interface sorting showcase.
+/// </summary>
+public sealed class ExplicitInterfaceSortingViewModel : ReactiveObject
+{
+    /// <summary>Initializes every supported explicit-interface sorting scenario.</summary>
+    public ExplicitInterfaceSortingViewModel()
+    {
+        DirectRows = new ObservableCollection<IExplicitSortRow>
+        {
+            new ExplicitSortRow("Charlie", new DateTime(2026, 7, 30, 12, 30, 0)),
+            new AlternateExplicitSortRow("Alice", new DateTime(2026, 7, 30, 8, 15, 0)),
+            new ExplicitSortRow("Bob", new DateTime(2026, 7, 30, 10, 45, 0))
+        };
+        InheritedRows = new ObservableCollection<IInheritedExplicitSortRow>
+        {
+            new InheritedExplicitSortRow("Charlie", 30),
+            new InheritedExplicitSortRow("Alice", 10),
+            new InheritedExplicitSortRow("Bob", 20)
+        };
+        NestedRows = new ObservableCollection<INestedExplicitSortRow>
+        {
+            new NestedExplicitSortRow("ROW-3", new ExplicitSortDetail("Charlie", 30)),
+            new NestedExplicitSortRow("ROW-0", null),
+            new NestedExplicitSortRow("ROW-1", new ExplicitSortDetail("Alice", 10)),
+            new NestedExplicitSortRow("ROW-2", new ExplicitSortDetail("Bob", 20))
+        };
+
+        DualExplicitLabelRow[] labels =
+        {
+            new("Charlie", "Alpha"),
+            new("Alice", "Zulu"),
+            new("Bob", "Mike")
+        };
+        PrimaryLabelRows = new ObservableCollection<IPrimaryExplicitLabel>(labels);
+        SecondaryLabelRows = new ObservableCollection<ISecondaryExplicitLabel>(labels);
+    }
+
+    /// <summary>Gets direct and polymorphic explicit-interface rows.</summary>
+    public ObservableCollection<IExplicitSortRow> DirectRows { get; }
+
+    /// <summary>Gets rows whose sortable name is declared by a base interface.</summary>
+    public ObservableCollection<IInheritedExplicitSortRow> InheritedRows { get; }
+
+    /// <summary>Gets rows with nullable nested explicit-interface paths.</summary>
+    public ObservableCollection<INestedExplicitSortRow> NestedRows { get; }
+
+    /// <summary>Gets dual-label rows viewed through the primary interface.</summary>
+    public ObservableCollection<IPrimaryExplicitLabel> PrimaryLabelRows { get; }
+
+    /// <summary>Gets the same dual-label rows viewed through the secondary interface.</summary>
+    public ObservableCollection<ISecondaryExplicitLabel> SecondaryLabelRows { get; }
+}


### PR DESCRIPTION
## Summary

- resolve explicitly implemented interface properties and indexers when a path is evaluated against a concrete runtime type
- retain the declared interface root in path sort descriptions so sorting remains correct for inherited, nested, nullable, polymorphic, and same-name interface scenarios
- preserve public concrete-member precedence and deterministically reject genuinely ambiguous unrelated interface members
- add reflection, sort-description, headless header-click, and sample integration regression coverage
- add an **Explicit Interface Sorting** sample page with compiled bindings and five interactive grids

## Root cause

`DataGridPathSortDescription.Initialize` could discover a member from the collection's interface item type, but value evaluation walked the concrete runtime type again. `TypeHelper.GetPropertyOrIndexer` only searched inherited interfaces when the current type itself was an interface, so explicitly implemented members on concrete rows resolved to `null`. Every comparison therefore appeared equal even though the header sort indicator changed.

## Validation

- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --filter "FullyQualifiedName~ReflectionHelperTests|FullyQualifiedName~DataGridSortDescriptionTests|FullyQualifiedName~DataGridSortingHeaderTests" -p:CollectCoverage=false`
- `dotnet test Avalonia.Controls.DataGrid.slnx --no-restore -p:CollectCoverage=false`
- `dotnet build Avalonia.Controls.DataGrid.slnx -c Release --no-restore`
- `dotnet test Avalonia.Controls.DataGrid.slnx -c Release --no-build --settings build/ci.runsettings --filter "FullyQualifiedName!~LeakTests" -p:TestTfmsInParallel=false -p:CollectCoverage=false`

Fixes #322
