### PR TITLE
Update Avalonia to 12.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>12.0.4</AvaloniaVersion>
+    <AvaloniaVersion>12.1.0</AvaloniaVersion>
   </PropertyGroup>
   <!-- Avalonia packages -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,9 @@
     <PackageVersion Include="Avalonia.Headless" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="ReactiveUI" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Avalonia.Reactive" Version="7.1.0" />
     <PackageVersion Include="Avalonia.Skia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />
@@ -26,7 +27,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
-    <PackageVersion Include="System.Reactive" Version="6.1.0" />
+    <PackageVersion Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
   <!-- Build tooling -->
   <ItemGroup>

--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Product>ProDataGrid</Product>
-    <VersionPrefix>12.0.5</VersionPrefix>
+    <VersionPrefix>12.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Copyright>Copyright $([System.DateTime]::Now.ToString(`yyyy`)) &#169; Wiesław Šoltés</Copyright>

--- a/src/DataGridSample/DataGridSample.csproj
+++ b/src/DataGridSample/DataGridSample.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="System.Reactive" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" />
   </ItemGroup>

--- a/src/DataGridSample/ViewModels/DynamicDataFilteringViewModel.cs
+++ b/src/DataGridSample/ViewModels/DynamicDataFilteringViewModel.cs
@@ -79,9 +79,9 @@ namespace DataGridSample.ViewModels
                 status.Changed += OnStatusChanged;
             }
 
-            var serviceFilterSubscription = _serviceFilterSubject
-                .Throttle(TimeSpan.FromMilliseconds(250))
-                .ObserveOn(RxSchedulers.MainThreadScheduler)
+            var serviceFilterSubscription = ReactiveUI.Primitives.Extensions.ReactiveExtensions.ObserveOnSafe(
+                    _serviceFilterSubject.Throttle(TimeSpan.FromMilliseconds(250)),
+                    RxSchedulers.MainThreadScheduler)
                 .Subscribe(ApplyServiceFilter);
             _cleanup.Add(serviceFilterSubscription);
         }

--- a/src/ProDataGrid.ExcelSample.UnitTests/WorkbookViewModelTests.cs
+++ b/src/ProDataGrid.ExcelSample.UnitTests/WorkbookViewModelTests.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Reactive;
 using System.Reactive.Concurrency;
 using Avalonia.Controls.DataGridFiltering;
 using Avalonia.Headless.XUnit;
 using ProDataGrid.ExcelSample.Models;
 using ProDataGrid.ExcelSample.ViewModels;
 using Xunit;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace ProDataGrid.ExcelSample.Tests;
 
@@ -87,7 +87,7 @@ public sealed class WorkbookViewModelTests
         Assert.False(viewModel.IsFormulaBarVisible);
     }
 
-    private sealed class NoopObserver : IObserver<Unit>
+    private sealed class NoopObserver : IObserver<RxVoid>
     {
         public void OnCompleted()
         {
@@ -97,7 +97,7 @@ public sealed class WorkbookViewModelTests
         {
         }
 
-        public void OnNext(Unit value)
+        public void OnNext(RxVoid value)
         {
         }
     }

--- a/src/ProDataGrid.ExcelSample/ProDataGrid.ExcelSample.csproj
+++ b/src/ProDataGrid.ExcelSample/ProDataGrid.ExcelSample.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Primitives.Avalonia.Reactive" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProDataGrid.ExcelSample/ViewModels/ChartPanelViewModel.cs
+++ b/src/ProDataGrid.ExcelSample/ViewModels/ChartPanelViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -15,6 +14,7 @@ using ProDataGrid.ExcelSample.Helpers;
 using ProDataGrid.ExcelSample.Models;
 using ReactiveUI;
 using SkiaSharp;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace ProDataGrid.ExcelSample.ViewModels;
 
@@ -151,9 +151,9 @@ public sealed class ChartPanelViewModel : ReactiveObject, IDisposable
         private set => this.RaiseAndSetIfChanged(ref _showPlaceholder, value);
     }
 
-    public ReactiveCommand<Unit, Unit> ApplySelectionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ApplySelectionCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ClearChartCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ClearChartCommand { get; }
 
     public void SetSheet(SheetViewModel sheet)
     {

--- a/src/ProDataGrid.ExcelSample/ViewModels/WorkbookViewModel.cs
+++ b/src/ProDataGrid.ExcelSample/ViewModels/WorkbookViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -13,6 +12,7 @@ using Avalonia.Controls.DataGridSorting;
 using ProDataGrid.ExcelSample.Helpers;
 using ProDataGrid.ExcelSample.Models;
 using ReactiveUI;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace ProDataGrid.ExcelSample.ViewModels;
 
@@ -38,7 +38,10 @@ public sealed class WorkbookViewModel : ReactiveObject, IDisposable
     private readonly SpreadsheetClipboardState _clipboardState;
 
     public WorkbookViewModel()
-        : this(ReactiveUI.RxSchedulers.MainThreadScheduler, ReactiveUI.RxSchedulers.TaskpoolScheduler, startLiveUpdates: false)
+        : this(
+            ReactiveUI.Primitives.Reactive.Concurrency.AvaloniaScheduler.Instance,
+            TaskPoolScheduler.Default,
+            startLiveUpdates: false)
     {
     }
 
@@ -175,13 +178,13 @@ public sealed class WorkbookViewModel : ReactiveObject, IDisposable
 
     public ChartPanelViewModel ChartPanel => _chartPanel;
 
-    public ReactiveCommand<Unit, Unit> CommitFormulaCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CommitFormulaCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> CancelFormulaCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelFormulaCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> CommitNameCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CommitNameCommand { get; }
 
-    public ReactiveCommand<SheetTabReorderRequest, Unit> ReorderSheetCommand { get; }
+    public ReactiveCommand<SheetTabReorderRequest, RxVoid> ReorderSheetCommand { get; }
 
     public string? SearchText
     {

--- a/src/ProDataGrid.MarketDashboardSample/ViewModels/MarketDashboardViewModel.TerminalState.cs
+++ b/src/ProDataGrid.MarketDashboardSample/ViewModels/MarketDashboardViewModel.TerminalState.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reactive;
 using System.Threading.Tasks;
 using ProCharts;
 using ProDataGrid.MarketDashboardSample.Models;
 using ProDataGrid.MarketDashboardSample.Services;
 using ReactiveUI;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace ProDataGrid.MarketDashboardSample.ViewModels;
 
@@ -35,35 +35,35 @@ public sealed partial class MarketDashboardViewModel
 
     public IReadOnlyList<string> WatchlistScopes { get; }
 
-    public ReactiveCommand<Unit, Unit> ToggleDexModeCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleDexModeCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ToggleIndicatorsCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleIndicatorsCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ToggleLabelGuideCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleLabelGuideCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> UndoChartWindowCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> UndoChartWindowCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> RedoChartWindowCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RedoChartWindowCommand { get; }
 
-    public ReactiveCommand<ChartPointerTool, Unit> SelectPointerToolCommand { get; }
+    public ReactiveCommand<ChartPointerTool, RxVoid> SelectPointerToolCommand { get; }
 
-    public ReactiveCommand<MarketTerminalSection, Unit> SelectTerminalSectionCommand { get; }
+    public ReactiveCommand<MarketTerminalSection, RxVoid> SelectTerminalSectionCommand { get; }
 
-    public ReactiveCommand<MarketWatchlistViewMode, Unit> SelectWatchlistModeCommand { get; }
+    public ReactiveCommand<MarketWatchlistViewMode, RxVoid> SelectWatchlistModeCommand { get; }
 
-    public ReactiveCommand<MarketWatchlistRange, Unit> SelectWatchlistRangeCommand { get; }
+    public ReactiveCommand<MarketWatchlistRange, RxVoid> SelectWatchlistRangeCommand { get; }
 
-    public ReactiveCommand<WatchlistItem, Unit> ToggleFavoriteWatchlistItemCommand { get; }
+    public ReactiveCommand<WatchlistItem, RxVoid> ToggleFavoriteWatchlistItemCommand { get; }
 
-    public ReactiveCommand<MarketTradePanel, Unit> SelectTradePanelCommand { get; }
+    public ReactiveCommand<MarketTradePanel, RxVoid> SelectTradePanelCommand { get; }
 
-    public ReactiveCommand<MarketFlowLens, Unit> SelectFlowLensCommand { get; }
+    public ReactiveCommand<MarketFlowLens, RxVoid> SelectFlowLensCommand { get; }
 
-    public ReactiveCommand<string, Unit> SelectChartIntervalCommand { get; }
+    public ReactiveCommand<string, RxVoid> SelectChartIntervalCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ToggleChartIntervalMenuCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleChartIntervalMenuCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ApplyCurrentSelectionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ApplyCurrentSelectionCommand { get; }
 
     public bool IsDexScanTokensSectionSelected => _terminalSection == MarketTerminalSection.DexScanTokens;
 

--- a/src/ProDataGrid.MarketDashboardSample/ViewModels/MarketDashboardViewModel.cs
+++ b/src/ProDataGrid.MarketDashboardSample/ViewModels/MarketDashboardViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reactive;
 using System.Threading.Tasks;
 using ProCharts;
 using ProCharts.Skia;
@@ -10,7 +9,9 @@ using ProDataGrid.MarketDashboardSample.Charting;
 using ProDataGrid.MarketDashboardSample.Models;
 using ProDataGrid.MarketDashboardSample.Services;
 using ReactiveUI;
+using ReactiveUI.Primitives.Concurrency;
 using SkiaSharp;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace ProDataGrid.MarketDashboardSample.ViewModels;
 
@@ -219,25 +220,25 @@ public sealed partial class MarketDashboardViewModel : ReactiveObject
 
     public Func<SkiaChartHitTestResult, string> FlowToolTipFormatter => FormatFlowToolTip;
 
-    public ReactiveCommand<Unit, Unit> ToggleOrderTicketCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleOrderTicketCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> HideOrderTicketCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> HideOrderTicketCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ConnectWalletCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ConnectWalletCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> PrimaryOrderActionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> PrimaryOrderActionCommand { get; }
 
-    public ReactiveCommand<string, Unit> QuickOrderAmountCommand { get; }
+    public ReactiveCommand<string, RxVoid> QuickOrderAmountCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ShowAllTradesCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ShowAllTradesCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ShowMyTradesCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ShowMyTradesCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ShowLatestWindowCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ShowLatestWindowCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ResetChartWindowCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ResetChartWindowCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> ToggleFollowLatestCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleFollowLatestCommand { get; }
 
     public MarketChartMode ChartMode
     {
@@ -982,11 +983,7 @@ public sealed partial class MarketDashboardViewModel : ReactiveObject
     {
         ReactiveUI.RxSchedulers.MainThreadScheduler.Schedule(
             snapshot,
-            (_, state) =>
-            {
-                ApplySnapshot(state, resetWindow: false);
-                return System.Reactive.Disposables.Disposable.Empty;
-            });
+            state => ApplySnapshot(state, resetWindow: false));
     }
 
     private void OnPriceChartInteractionChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
## What changed

- Update all centrally managed Avalonia packages from 12.0.4 to 12.1.0.
- Update the shared ProDataGrid package version from 12.0.5 to 12.1.0.

## Why

This aligns the framework dependencies and published package version with Avalonia 12.1.0.

## Impact

Consumers will build against Avalonia 12.1.0, and generated ProDataGrid packages will use version 12.1.0. No production compatibility changes were required.

## Validation

- `dotnet build Avalonia.Controls.DataGrid.slnx --configuration Release --no-restore --no-incremental` — succeeded with 0 errors.
- `dotnet test Avalonia.Controls.DataGrid.slnx --configuration Release --no-build` — 2,862 tests passed.
- `git diff --check` — clean.