### PR TITLE
fix(datagrid): correct selection shrinking with Shift+Up/Down

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridKeyboardInputTests.cs
@@ -66,6 +66,86 @@ public class DataGridKeyboardInputTests
     }
 
     [AvaloniaFact]
+    public void Shift_Up_Shrinks_Downward_Selection()
+    {
+        var (grid, items) = CreateGrid(rowCount: 6);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        for (var i = 0; i < 4; i++)
+        {
+            PressKey(grid, Key.Down, KeyModifiers.Shift);
+        }
+
+        PressKey(grid, Key.Up, KeyModifiers.Shift);
+
+        var selected = grid.SelectedItems.Cast<RowItem>().ToList();
+        Assert.Equal(4, selected.Count);
+        Assert.Equal(items.Take(4), selected);
+    }
+
+    [AvaloniaFact]
+    public void Shift_Down_Shrinks_Upward_Selection()
+    {
+        var (grid, items) = CreateGrid(rowCount: 6);
+        SetCurrentCell(grid, rowIndex: 4, columnIndex: 0);
+
+        for (var i = 0; i < 4; i++)
+        {
+            PressKey(grid, Key.Up, KeyModifiers.Shift);
+        }
+
+        PressKey(grid, Key.Down, KeyModifiers.Shift);
+
+        var selected = grid.SelectedItems.Cast<RowItem>().ToList();
+        Assert.Equal(4, selected.Count);
+        Assert.Equal(items.Skip(1).Take(4), selected);
+    }
+
+    [AvaloniaFact]
+    public void Shift_Up_Shrinks_Downward_Selection_From_Ten_To_One()
+    {
+        var (grid, items) = CreateGrid(rowCount: 10);
+        SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+        for (var i = 0; i < 9; i++)
+        {
+            PressKey(grid, Key.Down, KeyModifiers.Shift);
+        }
+
+        Assert.Equal(10, grid.SelectedItems.Count);
+
+        for (var i = 0; i < 9; i++)
+        {
+            PressKey(grid, Key.Up, KeyModifiers.Shift);
+        }
+
+        Assert.Equal(new[] { items[0] }, grid.SelectedItems.Cast<RowItem>());
+    }
+
+    [AvaloniaFact]
+    public void Shift_Down_Shrinks_Upward_Selection_From_Ten_To_One()
+    {
+        var (grid, items) = CreateGrid(rowCount: 10);
+        SetCurrentCell(grid, rowIndex: 9, columnIndex: 0);
+
+        for (var i = 0; i < 9; i++)
+        {
+            PressKey(grid, Key.Up, KeyModifiers.Shift);
+        }
+
+        Assert.Equal(10, grid.SelectedItems.Count);
+
+        for (var i = 0; i < 9; i++)
+        {
+            PressKey(grid, Key.Down, KeyModifiers.Shift);
+            Assert.Equal(grid.SlotFromRowIndex(i + 1), grid.CurrentSlot);
+            Assert.Equal(9 - i, grid.SelectedItems.Count);
+        }
+
+        Assert.Equal(new[] { items[9] }, grid.SelectedItems.Cast<RowItem>());
+    }
+
+    [AvaloniaFact]
     public void Home_End_Move_Between_Columns()
     {
         var (grid, _) = CreateGrid();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.DragSelection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.DragSelection.cs
@@ -516,7 +516,12 @@ internal
             _noSelectionChangeCount++;
             try
             {
-                if (!UpdateSelectionAndCurrency(-1, slot, DataGridSelectionAction.SelectFromAnchorToCurrent, scrollIntoView: false))
+                KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out _);
+                var selectionAction = ctrl
+                    ? DataGridSelectionAction.None
+                    : DataGridSelectionAction.SelectFromAnchorToCurrent;
+
+                if (!UpdateSelectionAndCurrency(-1, slot, selectionAction, scrollIntoView: false))
                 {
                     return false;
                 }
@@ -530,9 +535,9 @@ internal
                 var rangeEnd = Math.Max(anchorSlot, slot);
                 if (SelectionMode == DataGridSelectionMode.Extended)
                 {
-                    KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out _);
                     if (ctrl)
                     {
+                        SetRowsSelection(rangeStart, rangeEnd);
                         DeselectRowsForCtrlDrag(previousSlot, rangeStart, rangeEnd);
                     }
                     else

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
@@ -76,7 +76,10 @@ internal
 
                 columnIndex = CoerceColumnIndexToVisible(columnIndex);
 
-                ApplySelectionActionToSelectionModel(slot, action);
+                if (action != DataGridSelectionAction.SelectFromAnchorToCurrent)
+                {
+                    ApplySelectionActionToSelectionModel(slot, action);
+                }
 
                 switch (action)
                 {
@@ -92,12 +95,15 @@ internal
                             int anchorSlot = AnchorSlot;
                             if (slot <= anchorSlot)
                             {
+                                ClearRowSelection(resetAnchorSlot: false);
                                 SetRowsSelection(slot, anchorSlot);
                             }
                             else
                             {
+                                ClearRowSelection(resetAnchorSlot: false);
                                 SetRowsSelection(anchorSlot, slot);
                             }
+                            SyncSelectionModelFromGridSelection();
                         }
                         else
                         {


### PR DESCRIPTION
## Description

When using extended row selection with `Shift+Up` or `Shift+Down`, reversing the selection direction does not consistently remove rows that are no longer inside the anchor-to-current range.

## Steps to reproduce

1. Create a `DataGrid` with at least 10 rows.
2. Select row 1.
3. Hold `Shift` and press `Down` until rows 1–10 are selected.
4. Continue holding `Shift` and press `Up` repeatedly until the selection returns to row 1.

Also test the reverse direction:

1. Select row 10.
2. Hold `Shift` and press `Up` until rows 10–1 are selected.
3. Continue holding `Shift` and press `Down` repeatedly until the selection returns to row 10.

## Expected behavior

The selection should always equal the range between the fixed anchor row and the current row.

For example:

- After selecting rows 1–10 and pressing `Shift+Up` once, rows 1–9 should remain selected.
- After repeatedly pressing `Shift+Up`, only row 1 should remain selected.
- The reverse operation should behave symmetrically, ending with only row 10 selected.

## Actual behavior

Rows outside the new anchor-to-current range can remain selected. With a 10-row selection, repeatedly reversing direction may leave multiple rows selected instead of shrinking the range to a single row.

## Additional context

Keyboard input uses `DataGridSelectionAction.SelectFromAnchorToCurrent`, which is the appropriate action for Shift-based range selection.

The issue appears to be that the range-selection implementation adds the new range but does not reliably remove rows from the previous range when the selection direction is reversed.
