### PR TITLE
Infer row data types for clipboard bindings

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridClipboardBindingMetadataTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridClipboardBindingMetadataTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Metadata;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Columns;
+
+public class DataGridClipboardBindingMetadataTests
+{
+    [Theory]
+    [InlineData(typeof(DataGridColumn))]
+    [InlineData(typeof(DataGridBoundColumn))]
+    [InlineData(typeof(DataGridComboBoxColumn))]
+    [InlineData(typeof(DataGridHyperlinkColumn))]
+    public void ClipboardContentBinding_Inherits_Row_Item_DataType(Type columnType)
+    {
+        PropertyInfo? property = columnType.GetProperty(
+            nameof(DataGridColumn.ClipboardContentBinding),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+        Assert.NotNull(property);
+        Assert.NotNull(property.GetCustomAttribute<AssignBindingAttribute>(inherit: false));
+
+        InheritDataTypeFromItemsAttribute? attribute =
+            property.GetCustomAttribute<InheritDataTypeFromItemsAttribute>(inherit: false);
+
+        Assert.NotNull(attribute);
+        Assert.Equal(nameof(DataGrid.ItemsSource), attribute.AncestorItemsProperty);
+        Assert.Equal(typeof(DataGrid), attribute.AncestorType);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
@@ -90,6 +90,8 @@ internal
         /// The binding that will be used to get or set cell content for the clipboard.
         /// If the base ClipboardContentBinding is not explicitly set, this will return the value of Binding.
         /// </summary>
+        [AssignBinding]
+        [InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
         public override BindingBase ClipboardContentBinding
         {
             get

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -915,6 +915,8 @@ internal
         /// <summary>
         /// The binding that will be used to get or set cell content for the clipboard.
         /// </summary>
+        [AssignBinding]
+        [InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
         public virtual BindingBase ClipboardContentBinding
         {
             get

--- a/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
@@ -17,6 +17,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
+using Avalonia.Metadata;
 using Avalonia.Reactive;
 using Avalonia.Styling;
 
@@ -222,6 +223,8 @@ internal
         /// <summary>
         /// The binding that will be used to get or set cell content for the clipboard.
         /// </summary>
+        [AssignBinding]
+        [InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
         public override BindingBase ClipboardContentBinding
         {
             get => base.ClipboardContentBinding ?? EffectiveBinding;

--- a/src/Avalonia.Controls.DataGrid/DataGridHyperlinkColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridHyperlinkColumn.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Metadata;
 using Avalonia.Styling;
 using Avalonia.Controls.Utils;
 
@@ -100,6 +101,8 @@ internal
         /// <summary>
         /// The binding that will be used to get or set cell content for the clipboard.
         /// </summary>
+        [AssignBinding]
+        [InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
         public override BindingBase ClipboardContentBinding
         {
             get

--- a/src/DataGridSample/Pages/PowerFxSpreadsheetPage.axaml
+++ b/src/DataGridSample/Pages/PowerFxSpreadsheetPage.axaml
@@ -171,7 +171,6 @@
                                 Tag="A"
                                 Width="*"
                                 SortMemberPath="A"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding A.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">
@@ -189,7 +188,6 @@
                                 Tag="B"
                                 Width="*"
                                 SortMemberPath="B"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding B.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">
@@ -207,7 +205,6 @@
                                 Tag="C"
                                 Width="*"
                                 SortMemberPath="C"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding C.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">
@@ -225,7 +222,6 @@
                                 Tag="D"
                                 Width="*"
                                 SortMemberPath="D"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding D.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">
@@ -243,7 +239,6 @@
                                 Tag="E"
                                 Width="*"
                                 SortMemberPath="E"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding E.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">
@@ -261,7 +256,6 @@
                                 Tag="F"
                                 Width="*"
                                 SortMemberPath="F"
-                                x:DataType="models:PowerFxSheetRow"
                                 ClipboardContentBinding="{Binding F.Input}">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate x:DataType="models:PowerFxSheetRow">


### PR DESCRIPTION
## Summary

This change enables compiled XAML bindings assigned to `ClipboardContentBinding` to infer their data type from the owning `DataGrid.ItemsSource`.

It adds the metadata required to:

- preserve the binding object for deferred application to generated cells;
- infer the row item type for compiled clipboard bindings;
- support the base `DataGridColumn` property and every override that redeclares the property;
- remove redundant column-level `x:DataType` declarations from the PowerFx spreadsheet sample.

## Motivation

`ClipboardContentBinding` is stored by a column and applied later when clipboard content is read or written. Without explicit metadata on the CLR property, the XAML compiler does not know that it should retain the binding object or that the binding evaluates against an item from the grid's `ItemsSource`.

This forced callers to repeat `x:DataType` on individual column declarations even when the row type was already available from the grid's typed `ItemsSource`. Overrides also need to declare the metadata so the compiler receives the same behavior regardless of the concrete column type resolved in XAML.

## Implementation

- Annotated `DataGridColumn.ClipboardContentBinding` with `AssignBinding` and `InheritDataTypeFromItems`.
- Applied the same metadata to the overrides on `DataGridBoundColumn`, `DataGridComboBoxColumn`, and `DataGridHyperlinkColumn`.
- Pointed inherited data-type resolution at `DataGrid.ItemsSource` through the containing `DataGrid` ancestor.
- Added reflection-based regression coverage that verifies both attributes are declared on the base property and each override, including the expected ancestor property and type.
- Removed six redundant `x:DataType` declarations from clipboard-bound columns in the PowerFx spreadsheet sample, allowing that sample to exercise the inferred row type during XAML compilation.

## User impact

Consumers can use compiled bindings on `ClipboardContentBinding` without repeating the row model type on each affected column. Existing explicitly typed declarations remain compatible, and the change does not alter runtime clipboard behavior or the public property shape.

## Validation

- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj --no-build --filter FullyQualifiedName~DataGridClipboardBindingMetadataTests --logger "console;verbosity=minimal"`
  - Passed: 4, Failed: 0, Skipped: 0.
- `dotnet build src/DataGridSample/DataGridSample.csproj --no-restore`
  - Build succeeded with 0 errors. Existing repository warnings remain unchanged in scope.
