### PR TITLE
Allow nested scrolling at ProDataGrid boundaries

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridLogicalScrollStabilityTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridLogicalScrollStabilityTests.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Layout;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -59,6 +60,26 @@ public class DataGridLogicalScrollStabilityTests
         Assert.InRange(pendingAdded, 0, expectedMaxDelta + 0.01);
         Assert.True(pendingAfter <= logicalMaximum + 0.01,
             $"Pending delta exceeded logical max. Pending: {pendingAfter}, LogicalMax: {logicalMaximum}");
+    }
+
+    [AvaloniaFact]
+    public void LogicalScrollable_DownwardScroll_WithinLayoutEpsilonOfBottom_IsNotHandled()
+    {
+        var target = CreateStandaloneTarget(itemCount: 400, height: 160, useLogicalScrollable: true);
+        target.UpdateLayout();
+
+        var presenter = GetRowsPresenter(target);
+        var logicalMaximum = Math.Max(0, presenter.Extent.Height - presenter.Viewport.Height);
+        Assert.True(logicalMaximum > LayoutHelper.LayoutEpsilon,
+            $"Expected logical maximum greater than layout epsilon, got {logicalMaximum}.");
+
+        presenter.Offset = new Vector(0, logicalMaximum - (LayoutHelper.LayoutEpsilon / 2));
+        var pendingBefore = target.DisplayData.PendingVerticalScrollHeight;
+
+        var handled = target.UpdateScroll(new Vector(0, -30));
+
+        Assert.False(handled, "A layout-level residual at the bottom should allow scroll chaining.");
+        Assert.Equal(pendingBefore, target.DisplayData.PendingVerticalScrollHeight);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.Mouse.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.Mouse.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 using System.Diagnostics;
@@ -84,7 +85,7 @@ namespace Avalonia.Controls
                     }
                 }
 
-                if (scrollHeight != 0)
+                if (Math.Abs(scrollHeight) > LayoutHelper.LayoutEpsilon)
                 {
                     // Accumulate scroll height to handle rapid scroll events
                     DisplayData.PendingVerticalScrollHeight += scrollHeight;


### PR DESCRIPTION
## Summary

- Allows pointer-wheel input to continue to a parent scroll container when ProDataGrid is already at a vertical scrolling boundary.
- Treats layout-scale floating-point residuals as zero by comparing the calculated vertical scroll distance with `LayoutHelper.LayoutEpsilon`.
- Adds headless regression coverage for a logical-scrolling grid positioned within half a layout epsilon of its maximum vertical offset.

## Problem

Fractional render scaling can produce row heights that are not represented exactly after layout rounding. When those heights accumulate across many rows, the calculated distance remaining at the bottom of a grid can be a tiny positive value even though the grid is effectively at its vertical boundary.

In a nested scrolling layout, ProDataGrid interpreted that residual as usable scroll distance. It therefore reported the wheel input as handled, preventing an ancestor `ScrollViewer` from receiving the input and continuing the scroll operation.

## Root cause

`DataGrid.UpdateScroll` used an exact comparison against zero when deciding whether a calculated vertical scroll distance should be handled. Exact equality is too strict for values derived from layout measurements, particularly at fractional render scales.

## Implementation

The vertical scroll decision now requires the absolute calculated distance to exceed `LayoutHelper.LayoutEpsilon`. Meaningful vertical input continues through the existing pending-delta accumulation and routed scroll-event path, while insignificant layout residuals leave the event unhandled so normal scroll chaining can occur.

The regression test creates a logical-scrolling grid, positions its rows presenter within half a layout epsilon of the bottom, and verifies that downward input:

- is not reported as handled;
- does not modify the pending vertical scroll distance.

## User impact

Nested scrolling behaves consistently at the top and bottom of ProDataGrid, including under fractional display scaling. Existing scrolling behavior is unchanged whenever the available distance is larger than the framework's layout tolerance.

Both logical and legacy vertical scrolling use the corrected shared decision point.

## Validation

- Confirmed the new regression test fails against the previous exact-zero behavior and passes with this change.
- Passed all 4 `DataGridLogicalScrollStabilityTests`.
- Passed the complete core unit/headless suite: 2,350 passed, 0 failed, 0 skipped.
- Built the ProDataGrid library for `net8.0` and `net10.0`: 0 errors.
- Verified the committed diff with `git diff --check`.
