### PR TITLE
Fix vertical scrollbar page increment synchronization

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridScrollingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridScrollingTests.cs
@@ -1118,6 +1118,30 @@ public class DataGridScrollingTests
     #region Mouse Wheel Scrolling Tests
 
     [AvaloniaFact]
+    public void Legacy_Vertical_ScrollBar_LargeChange_Tracks_Viewport_Height()
+    {
+        var items = Enumerable.Range(0, 200).Select(x => new ScrollTestModel($"Item {x}")).ToList();
+        var target = CreateTarget(items, height: 140);
+        target.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
+        target.UpdateLayout();
+
+        var verticalBar = target.GetSelfAndVisualDescendants()
+            .OfType<ScrollBar>()
+            .First(sb => sb.Orientation == Orientation.Vertical);
+
+        Assert.True(verticalBar.ViewportSize > 0);
+        Assert.Equal(verticalBar.ViewportSize, verticalBar.LargeChange);
+
+        var initialLargeChange = verticalBar.LargeChange;
+        var root = Assert.IsType<Window>(target.GetVisualRoot());
+        root.Height = 240;
+        root.UpdateLayout();
+
+        Assert.True(verticalBar.LargeChange > initialLargeChange);
+        Assert.Equal(verticalBar.ViewportSize, verticalBar.LargeChange);
+    }
+
+    [AvaloniaFact]
     public void MouseWheel_Scrolls_In_Legacy_Mode()
     {
         // Arrange

--- a/src/Avalonia.Controls.DataGrid/DataGrid.LegacyScrolling.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.LegacyScrolling.cs
@@ -254,6 +254,7 @@ internal
 
                         // total height of the display area
                         _vScrollBar.ViewportSize = cellsHeight;
+                        _vScrollBar.LargeChange = cellsHeight;
                         _vScrollBar.IsEnabled = true;
                     }
                     else


### PR DESCRIPTION
# Summary

- Synchronize the legacy vertical scrollbar's large-change increment with the visible viewport height.
- Make vertical page navigation move by one currently visible page instead of relying on the scrollbar's default increment.
- Add headless regression coverage that verifies the increment initially and after the grid viewport is resized.

# Problem

The legacy DataGrid scrolling path updated the vertical scrollbar's `ViewportSize`, but left `LargeChange` at its default value. Operations that use the scrollbar's large increment could therefore move by an unrelated fixed amount rather than by the height of the visible rows.

The horizontal legacy scrollbar already keeps these two values synchronized. Vertical scrolling should follow the same contract.

# Implementation

When the legacy vertical scrollbar has a finite, scrollable viewport, its `LargeChange` is now assigned the same calculated `cellsHeight` used for `ViewportSize`.

The change is intentionally limited to the legacy scrolling implementation. Logical scrolling is hosted by Avalonia's `ScrollViewer`, which owns its viewport and page-step behavior.

# Tests

Added `Legacy_Vertical_ScrollBar_LargeChange_Tracks_Viewport_Height`, an Avalonia Headless test that verifies:

- the vertical viewport is non-zero for a scrollable grid;
- `LargeChange` equals `ViewportSize` after initial layout;
- increasing the window height increases the page increment;
- `LargeChange` remains synchronized with `ViewportSize` after relayout.

# Validation

- Targeted regression test passed.
- Full `DataGridScrollingTests` suite passed: 94 tests.
- Core DataGrid project built successfully for all configured target frameworks with zero errors.
- `git diff --check` passed before committing.
