### PR TITLE
Harden DataGrid lifecycle, binding, and scrolling edge cases

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnsBranchCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnsBranchCoverageTests.cs
@@ -761,6 +761,37 @@ public class DataGridColumnsBranchCoverageTests
     }
 
     [AvaloniaFact]
+    public void ComputeDisplayedColumns_Clamps_Stale_Offset_At_First_Scrolling_Column()
+    {
+        var grid = new DataGrid();
+        grid.ColumnsInternal.Add(new DataGridTextColumn { Width = new DataGridLength(40) });
+        grid.RowsPresenterAvailableSize = new Size(100, 100);
+        grid.ColumnsInternal.EnsureVisibleEdgedColumnsWidth();
+        grid.DisplayData.FirstDisplayedScrollingCol = 0;
+        SetPrivateField(grid, "_horizontalOffset", 1.0);
+        SetPrivateField(grid, "_negHorizontalOffset", 0.0);
+        SetPrivateProperty(grid, "HorizontalAdjustment", 1.0);
+
+        var invalidated = InvokePrivate<bool>(grid, "ComputeDisplayedColumns");
+
+        Assert.True(invalidated);
+        Assert.Equal(0, grid.HorizontalOffset);
+        Assert.Equal(0, grid.FirstDisplayedScrollingColumnHiddenWidth);
+        Assert.Equal(0, grid.HorizontalAdjustment);
+        Assert.Equal(0, grid.DisplayData.FirstDisplayedScrollingCol);
+    }
+
+    [AvaloniaFact]
+    public void HorizontalSmallScroll_Ignores_Stale_Column_Index()
+    {
+        var grid = new DataGrid();
+        grid.DisplayData.FirstDisplayedScrollingCol = 0;
+
+        Assert.Equal(0, InvokePrivate<double>(grid, "GetHorizontalSmallScrollDecrease"));
+        Assert.Equal(0, InvokePrivate<double>(grid, "GetHorizontalSmallScrollIncrease"));
+    }
+
+    [AvaloniaFact]
     public void ComputeFirstVisibleScrollingColumn_Covers_Null_And_Offsets()
     {
         var grid = new DataGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupHeaderLifecycleTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowGroupHeaderLifecycleTests.cs
@@ -20,6 +20,28 @@ namespace Avalonia.Controls.DataGridTests;
 public class DataGridRowGroupHeaderLifecycleTests
 {
     [AvaloniaFact]
+    public void Standalone_RowGroupHeader_Detaches_Without_Group_State()
+    {
+        var root = new Window
+        {
+            Content = new DataGridRowGroupHeader()
+        };
+
+        try
+        {
+            root.Show();
+
+            var exception = Record.Exception(() => root.Content = null);
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void UpdatePseudoClasses_Does_Not_Throw_After_Detach()
     {
         var (grid, root) = CreateGroupedGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Utils/BindingCloneHelperTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Utils/BindingCloneHelperTests.cs
@@ -65,6 +65,30 @@ public class BindingCloneHelperTests
     }
 
     [Fact]
+    public void DataGridBoundColumn_Accepts_Pathless_Bindings()
+    {
+        var converter = new PassThroughConverter();
+        BindingBase[] bindings =
+        {
+            new Binding { Converter = converter },
+            new ReflectionBinding { Converter = converter },
+            new CompiledBindingExtension { Converter = converter },
+            new CompiledBinding { Converter = converter }
+        };
+
+        foreach (BindingBase binding in bindings)
+        {
+            var column = new DataGridTextColumn();
+
+            var exception = Record.Exception(() => column.Binding = binding);
+
+            Assert.Null(exception);
+            Assert.True(string.IsNullOrEmpty(BindingCloneHelper.GetPath(column.Binding)));
+            Assert.Equal(BindingMode.Default, BindingCloneHelper.GetMode(column.Binding));
+        }
+    }
+
+    [Fact]
     public void SupportsDirectDataContextMemberWrite_Rejects_Unsafe_Bindings()
     {
         var safeBinding = new Binding(nameof(TestItem.Enabled))

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -1202,15 +1202,24 @@ internal
                     {
                         Debug.Assert(_negHorizontalOffset == 0);
                         dataGridColumn = ColumnsInternal.GetPreviousVisibleScrollingColumn(ColumnsItemsInternal[firstDisplayedScrollingCol]);
-                        Debug.Assert(dataGridColumn != null);
-                        Debug.Assert(GetEdgedColumnWidth(dataGridColumn) > displayWidth - cx);
-                        firstDisplayedScrollingCol = dataGridColumn.Index;
-                        _negHorizontalOffset = GetEdgedColumnWidth(dataGridColumn) - displayWidth + cx;
-                        _horizontalOffset -= displayWidth - cx;
-                        visibleScrollingColumnsTmp++;
-                        invalidate = true;
-                        cx = displayWidth;
-                        Debug.Assert(_negHorizontalOffset == GetNegHorizontalOffsetFromHorizontalOffset(_horizontalOffset));
+                        if (dataGridColumn == null)
+                        {
+                            _horizontalOffset = 0;
+                            _negHorizontalOffset = 0;
+                            HorizontalAdjustment = 0;
+                            invalidate = true;
+                        }
+                        else
+                        {
+                            Debug.Assert(GetEdgedColumnWidth(dataGridColumn) > displayWidth - cx);
+                            firstDisplayedScrollingCol = dataGridColumn.Index;
+                            _negHorizontalOffset = GetEdgedColumnWidth(dataGridColumn) - displayWidth + cx;
+                            _horizontalOffset -= displayWidth - cx;
+                            visibleScrollingColumnsTmp++;
+                            invalidate = true;
+                            cx = displayWidth;
+                            Debug.Assert(_negHorizontalOffset == GetNegHorizontalOffsetFromHorizontalOffset(_horizontalOffset));
+                        }
                     }
 
                     // update the number of visible columns to the new reality
@@ -1234,12 +1243,18 @@ internal
                 {
                     Debug.Assert(firstDisplayedScrollingCol >= 0);
                     dataGridColumn = ColumnsItemsInternal[firstDisplayedScrollingCol];
+                    DataGridColumn lastDisplayedColumn = dataGridColumn;
                     for (int jump = 0; jump < jumpFromFirstVisibleScrollingCol; jump++)
                     {
                         dataGridColumn = ColumnsInternal.GetNextVisibleScrollingColumn(dataGridColumn);
-                        Debug.Assert(dataGridColumn != null);
+                        if (dataGridColumn == null)
+                        {
+                            break;
+                        }
+
+                        lastDisplayedColumn = dataGridColumn;
                     }
-                    DisplayData.LastTotallyDisplayedScrollingCol = dataGridColumn.Index;
+                    DisplayData.LastTotallyDisplayedScrollingCol = lastDisplayedColumn.Index;
                 }
             }
             else

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -158,7 +158,7 @@ internal
 
         private KeyModifiers GetCommandModifiers()
         {
-            return this.GetPlatformSettings()?.HotkeyConfiguration.CommandModifiers ?? KeyModifiers.Control;
+            return KeyboardHelper.GetPlatformCtrlOrCmdKeyModifier(this);
         }
 
         private static KeyGesture ResolveGesture(KeyGesture overrideGesture, KeyGesture defaultGesture)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.cs
@@ -184,6 +184,11 @@ internal
             }
             else
             {
+                if (IsColumnOutOfBounds(DisplayData.FirstDisplayedScrollingCol))
+                {
+                    return 0;
+                }
+
                 // The entire first column is displayed, show the entire previous column when the user clicks
                 // the left button
                 DataGridColumn previousColumn = ColumnsInternal.GetPreviousVisibleScrollingColumn(
@@ -205,7 +210,7 @@ internal
         // This is a method rather than a property to emphasize a calculation
         private double GetHorizontalSmallScrollIncrease()
         {
-            if (DisplayData.FirstDisplayedScrollingCol >= 0)
+            if (!IsColumnOutOfBounds(DisplayData.FirstDisplayedScrollingCol))
             {
                 return GetEdgedColumnWidth(ColumnsItemsInternal[DisplayData.FirstDisplayedScrollingCol]) - _negHorizontalOffset;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -635,7 +635,11 @@ internal
         {
             base.OnDetachedFromLogicalTree(e);
             DetachExpanderButtonSubscription();
-            OwningGrid.RemoveReferenceFromCollectionViewGroup(RowGroupInfo.CollectionViewGroup);
+            if (OwningGrid != null && RowGroupInfo?.CollectionViewGroup is { } collectionViewGroup)
+            {
+                OwningGrid.RemoveReferenceFromCollectionViewGroup(collectionViewGroup);
+            }
+
             OwningGrid = null;
         }
     }

--- a/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
@@ -3,6 +3,7 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
 
+using Avalonia;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.VisualTree;
@@ -26,7 +27,7 @@ namespace Avalonia.Controls.Utils
 
         public static KeyModifiers GetPlatformCtrlOrCmdKeyModifier(Control target)
         {
-            var keymap = TopLevel.GetTopLevel(target)?.GetPlatformSettings()?.HotkeyConfiguration;
+            var keymap = (target.GetPlatformSettings() ?? Application.Current?.PlatformSettings)?.HotkeyConfiguration;
             return keymap?.CommandModifiers ?? KeyModifiers.Control;
         }
     }


### PR DESCRIPTION
# Summary

This change hardens several DataGrid edge cases involving platform shortcut resolution, grouped-row lifecycle teardown, pathless bindings, and horizontal column scrolling state.

## What changed

- Resolve command-key modifiers from the control's platform settings when available, fall back to application platform settings for detached controls, and finally use `Control` as a safe default.
- Route DataGrid default keyboard gesture creation through the shared keyboard helper so keyboard handling, cell selection, and column sorting use the same platform-specific modifier resolution.
- Guard row-group-header teardown when the header is detached without a complete owning-grid or collection-group context.
- Validate displayed-column indexes before calculating horizontal small-scroll increments and decrements.
- Clamp stale horizontal offset, hidden-width, and adjustment state when layout expansion reaches the first scrolling column and no previous scrolling column exists.
- Preserve the last valid scrolling column if defensive displayed-column traversal reaches the end of the scrolling-column sequence.
- Verify that bound columns accept pathless bindings backed by converters across classic, reflection, compiled-extension, and compiled binding representations.

## Why

Several normal UI lifecycle and layout transitions can temporarily expose incomplete or stale state:

- Controls can receive input or construct keyboard gestures while detached from a visual root.
- Group headers can be removed while their owner or group metadata has already been cleared.
- Layout rounding and window-size changes can leave a small positive horizontal offset even though the first scrolling column is already the leftmost available column.
- Displayed-column indexes can briefly refer to columns that no longer exist during collection or layout changes.
- Converter-only bindings intentionally have no property path and must not be treated as invalid bindings.

These conditions previously allowed null dereferences, out-of-range indexing, debug assertion failures, or inconsistent scroll state. The new guards make those transitions deterministic while preserving existing behavior for fully initialized controls and valid scrolling state.

## User and developer impact

- Prevents crashes during grouped-grid detach and reattach flows, including tab or content switching.
- Prevents horizontal scrolling failures after resize, maximize, layout-rounding, or column collection transitions.
- Keeps platform-specific command shortcuts consistent for attached and detached DataGrid controls.
- Maintains support for converter-only bound columns without forcing an artificial binding path.
- Does not add or change public API surface.

## Validation

- Focused lifecycle, scrolling, frozen-column, binding, and keyboard compatibility tests: **88 passed**.
- Complete core DataGrid test project: **2,354 passed**.
- Solution-wide test run: **2,840 passed**, with **35 release-only leak tests skipped** in the Debug configuration.
- Complete solution build: **0 errors**.
- Diff whitespace validation: `git diff --check` passed.
