### PR TITLE
Fix scrollbar auto-hide propagation across DataGrid themes

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Themes/DataGridThemeResourceCoverageTests.cs
@@ -764,6 +764,14 @@ public class DataGridThemeResourceCoverageTests
 
 public class DataGridThemeTemplateCoverageTests
 {
+    public static IEnumerable<object[]> AllThemes()
+    {
+        yield return new object[] { DataGridTheme.Simple };
+        yield return new object[] { DataGridTheme.SimpleV2 };
+        yield return new object[] { DataGridTheme.Fluent };
+        yield return new object[] { DataGridTheme.FluentV2 };
+    }
+
     public static IEnumerable<object[]> V2Themes()
     {
         yield return new object[] { DataGridTheme.SimpleV2 };
@@ -841,6 +849,82 @@ public class DataGridThemeTemplateCoverageTests
         finally
         {
             window.Close();
+        }
+    }
+
+    [AvaloniaTheory]
+    [MemberData(nameof(AllThemes))]
+    public void DataGrid_template_tracks_allow_auto_hide_changes(DataGridTheme theme)
+    {
+        var window = new Window
+        {
+            Width = 400,
+            Height = 300
+        };
+
+        window.SetThemeStyles(theme);
+
+        var grid = CreateSampleGrid();
+        ScrollViewer.SetAllowAutoHide(grid, true);
+        window.Content = grid;
+        window.Show();
+
+        try
+        {
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            var targets = GetAllowAutoHideTargets(grid, theme);
+            int expectedTargetCount = theme is DataGridTheme.SimpleV2 or DataGridTheme.FluentV2 ? 1 : 2;
+            Assert.Equal(expectedTargetCount, targets.Count);
+            AssertAllowAutoHide(targets, true);
+
+            ScrollViewer.SetAllowAutoHide(grid, false);
+            grid.UpdateLayout();
+            AssertAllowAutoHide(targets, false);
+
+            ScrollViewer.SetAllowAutoHide(grid, true);
+            grid.UpdateLayout();
+            AssertAllowAutoHide(targets, true);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static IReadOnlyList<Control> GetAllowAutoHideTargets(DataGrid grid, DataGridTheme theme)
+    {
+        if (theme is DataGridTheme.SimpleV2 or DataGridTheme.FluentV2)
+        {
+            return grid
+                .GetVisualDescendants()
+                .OfType<ScrollViewer>()
+                .Where(viewer => viewer.Name == "PART_ScrollViewer")
+                .Cast<Control>()
+                .ToList();
+        }
+
+        return grid
+            .GetVisualDescendants()
+            .OfType<ScrollBar>()
+            .Where(scrollBar => scrollBar.Name is "PART_VerticalScrollbar" or "PART_HorizontalScrollbar")
+            .Cast<Control>()
+            .ToList();
+    }
+
+    private static void AssertAllowAutoHide(IEnumerable<Control> targets, bool expected)
+    {
+        foreach (Control target in targets)
+        {
+            bool actual = target switch
+            {
+                ScrollBar scrollBar => scrollBar.AllowAutoHide,
+                ScrollViewer scrollViewer => ScrollViewer.GetAllowAutoHide(scrollViewer),
+                _ => throw new InvalidOperationException($"Unexpected control type: {target.GetType()}.")
+            };
+
+            Assert.Equal(expected, actual);
         }
     }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.LegacyScrolling.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.LegacyScrolling.cs
@@ -90,7 +90,6 @@ internal
                 _hScrollBar.Orientation = Layout.Orientation.Horizontal;
                 _hScrollBar.IsVisible = false;
                 _hScrollBar.Scroll += HorizontalScrollBar_Scroll;
-                _hScrollBar.AllowAutoHide = this.GetValue(ScrollViewer.AllowAutoHideProperty);
             }
 
             if (_vScrollBar != null)
@@ -107,7 +106,6 @@ internal
                 _vScrollBar.Orientation = Layout.Orientation.Vertical;
                 _vScrollBar.IsVisible = false;
                 _vScrollBar.Scroll += VerticalScrollBar_Scroll;
-                _vScrollBar.AllowAutoHide = this.GetValue(ScrollViewer.AllowAutoHideProperty);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.v2.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.v2.xaml
@@ -42,7 +42,7 @@
                               HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
                               VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
                               IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}"
-                              AllowAutoHide="True">
+                              AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}">
                   <DataGridRowsPresenter Name="PART_RowsPresenter" />
                 </ScrollViewer>
                 <controls:DataGridSelectionOverlay Name="PART_SelectionOverlay"

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -1514,6 +1514,7 @@
                            Grid.Column="2"
                            Grid.Row="3" />
                 <ScrollBar Name="PART_VerticalScrollbar"
+                           AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                            Orientation="Vertical"
                            Grid.Column="2"
                            Grid.Row="2"
@@ -1524,6 +1525,7 @@
                       ColumnDefinitions="Auto,*,Auto">
                   <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
                   <ScrollBar Name="PART_HorizontalScrollbar"
+                             AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                              Grid.Column="1"
                              Orientation="Horizontal"
                              Height="{DynamicResource ScrollBarSize}" />

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.v2.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.v2.xaml
@@ -41,7 +41,7 @@
                               HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
                               VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
                               IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}"
-                              AllowAutoHide="True">
+                              AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}">
                   <DataGridRowsPresenter Name="PART_RowsPresenter" />
                 </ScrollViewer>
                 <controls:DataGridSelectionOverlay Name="PART_SelectionOverlay"


### PR DESCRIPTION
## Summary

Ensure `ScrollViewer.AllowAutoHide` changes on `DataGrid` are propagated dynamically to the scrolling controls created by every shipped DataGrid theme.

The fix covers both supported scrolling implementations:

- Legacy templates backed by the named horizontal and vertical `ScrollBar` parts.
- Logical-scrolling v2 templates backed by the internal `ScrollViewer`.

## Problem

Changing `ScrollViewer.AllowAutoHide` after a DataGrid template had been applied did not consistently update its scrolling controls.

In legacy scrolling mode, the value was copied to each internal scrollbar once during template setup. Subsequent property changes on the DataGrid therefore had no effect. In the Fluent v2 and Simple v2 templates, the internal `ScrollViewer` used a hard-coded `AllowAutoHide="True"` value, so the attached property on the DataGrid was ignored entirely.

This produced different behavior depending on the selected theme and scrolling mode, and prevented applications from changing scrollbar auto-hide behavior at runtime.

## Root cause

The template-created scrolling controls did not retain a live binding to the templated DataGrid's `ScrollViewer.AllowAutoHide` attached property:

- Legacy scrollbars received an imperative, one-time assignment during `SetupLegacyScrollBars`.
- V2 `ScrollViewer` instances used a fixed value instead of reading from the templated parent.

## Changes

### Legacy scrolling templates

- Bind `PART_VerticalScrollbar.AllowAutoHide` to the templated parent's `ScrollViewer.AllowAutoHide` property.
- Bind `PART_HorizontalScrollbar.AllowAutoHide` to the same property.
- Remove the one-time assignments from `SetupLegacyScrollBars` so they no longer replace the template bindings.
- Apply the bindings in the shared legacy DataGrid template, covering both Simple and Fluent themes.

### Logical-scrolling v2 templates

- Replace the hard-coded `AllowAutoHide="True"` value in the Fluent v2 template with a templated-parent binding.
- Apply the equivalent binding in the Simple v2 template.

### Regression coverage

- Add a headless theme test covering Simple, Simple v2, Fluent, and Fluent v2.
- Verify the expected scrolling control parts are created for each template generation.
- Toggle `ScrollViewer.AllowAutoHide` from `true` to `false` and back to `true` after template application.
- Assert that every relevant internal `ScrollBar` or `ScrollViewer` tracks each runtime change.

## User impact

Applications can now set or bind `ScrollViewer.AllowAutoHide` on a DataGrid and update it at runtime with consistent results across all shipped Simple and Fluent theme variants. Existing behavior remains unchanged when the property is left at its default value.

## Validation

- Focused auto-hide propagation tests: 4 passed, 0 failed.
- Complete `Avalonia.Controls.DataGrid.UnitTests` suite: 2,355 passed, 0 failed.
- `git diff --check`: passed.
