### PR TITLE
Test DataGrid popup and cross-window focus boundaries

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridFocusTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridFocusTests.cs
@@ -1,15 +1,122 @@
 // Copyright (c) Wieslaw Soltes. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reflection;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Controls.DataGridTests;
 
 public class DataGridFocusTests
 {
+    [AvaloniaFact]
+    public void ContextMenu_Focus_Does_Not_Commit_Active_Text_Edit()
+    {
+        var item = new FocusItem { Text = "Original" };
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ItemsSource = new ObservableCollection<FocusItem> { item },
+            SelectionMode = DataGridSelectionMode.Extended,
+            SelectionUnit = DataGridSelectionUnit.Cell
+        };
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Binding = new Binding(nameof(FocusItem.Text)),
+            Width = new DataGridLength(160)
+        });
+
+        var root = new Window
+        {
+            Width = 320,
+            Height = 180
+        };
+        root.SetThemeStyles();
+        root.Content = grid;
+
+        var menuItem = new MenuItem { Header = "Copy" };
+        var contextMenu = new ContextMenu();
+        contextMenu.Items.Add(menuItem);
+
+        try
+        {
+            root.Show();
+            Dispatcher.UIThread.RunJobs();
+            grid.ApplyTemplate();
+            grid.UpdateLayout();
+
+            Assert.True(grid.UpdateSelectionAndCurrency(
+                columnIndex: 0,
+                slot: grid.SlotFromRowIndex(0),
+                DataGridSelectionAction.SelectCurrent,
+                scrollIntoView: false));
+            grid.UpdateLayout();
+            Assert.True(grid.BeginEdit());
+            grid.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            var row = grid.GetSelfAndVisualDescendants()
+                .OfType<DataGridRow>()
+                .Single(candidate => ReferenceEquals(candidate.DataContext, item));
+            var cell = Enumerable.Range(0, row.Cells.Count)
+                .Select(index => row.Cells[index])
+                .Single(candidate => candidate.OwningColumn is DataGridTextColumn);
+            var editor = Assert.IsType<TextBox>(cell.Content);
+            editor.ContextMenu = contextMenu;
+            Assert.True(editor.Focus());
+
+            contextMenu.Open(editor);
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(menuItem.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(contextMenu.IsOpen);
+            Assert.Equal(0, grid.EditingColumnIndex);
+            Assert.True(grid.IsFocusWithinDataGrid(menuItem, out var dataGridWillReceiveRoutedEvent));
+            Assert.False(dataGridWillReceiveRoutedEvent);
+        }
+        finally
+        {
+            contextMenu.Close();
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void IsFocusWithinDataGrid_Does_Not_Treat_Another_Window_As_InternalFocus()
+    {
+        var grid = new DataGrid();
+        var externalControl = new Button();
+        var gridWindow = new Window { Content = grid };
+        var externalWindow = new Window { Content = externalControl };
+
+        try
+        {
+            gridWindow.Show();
+            externalWindow.Show();
+
+            var containsFocus = grid.IsFocusWithinDataGrid(
+                externalControl,
+                out var dataGridWillReceiveRoutedEvent);
+
+            Assert.False(containsFocus);
+            Assert.True(dataGridWillReceiveRoutedEvent);
+        }
+        finally
+        {
+            externalWindow.Close();
+            gridWindow.Close();
+        }
+    }
+
     [Fact]
     public void IsFocusWithinDataGrid_Treats_LogicalDescendant_As_InternalFocus()
     {
@@ -47,5 +154,10 @@ public class DataGridFocusTests
         var property = typeof(StyledElement).GetProperty("Parent", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         Assert.NotNull(property);
         property!.SetValue(element, parent);
+    }
+
+    private sealed class FocusItem
+    {
+        public string Text { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
# Summary

This change adds focused headless coverage for DataGrid focus transitions that cross popup and top-level boundaries while a cell is being edited.

- Verifies that moving focus from an active text editor into its context menu keeps the menu open and preserves the current edit.
- Verifies that the active editing column remains correctly reported while popup content owns focus.
- Verifies that focus in an unrelated window is not treated as focus within the DataGrid.

# Motivation

DataGrid editing depends on distinguishing focus that temporarily moves into editor-owned popup content from focus that genuinely leaves the control. These paths have similar visual-tree shapes but require different behavior:

- Context menus and other editor popups must remain part of the editing focus scope so opening them does not prematurely commit the row or dismiss the popup.
- Controls hosted by another window must remain outside the DataGrid focus scope so ordinary focus-loss behavior is preserved.

The new tests document both sides of that boundary and protect the existing logical-parent-aware focus handling from regressions.

# Implementation details

The context-menu test creates a themed, headless DataGrid with one editable text column, enters edit mode, assigns a context menu to the generated `TextBox`, and moves keyboard focus to a menu item. It then confirms that:

- the context menu remains open;
- `EditingColumnIndex` continues to identify the active column;
- the menu item is recognized as logically within the DataGrid focus scope; and
- the routed focus event is not expected to return through the DataGrid visual tree.

The cross-window test hosts the DataGrid and an external button in separate windows and confirms that the external control is not classified as internal DataGrid focus.

No production behavior or public API surface is changed.

# Validation

- Focus and editing test selection: 11 passed.
- Full `Avalonia.Controls.DataGrid.UnitTests` suite: 2,357 passed.
- Release external-editing-element leak test: 1 passed.
- `git diff --check`: clean.
