### PR TITLE
Fix runtime compiled binding handling across DataGrid columns

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnsBranchCoverageTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridColumnsBranchCoverageTests.cs
@@ -209,12 +209,22 @@ public class DataGridColumnsBranchCoverageTests
         var writableColumn = new DataGridTextColumn { Binding = new Binding(nameof(ReadOnlyRow.Name)) };
         Assert.False(grid.GetColumnReadOnlyState(writableColumn, isReadOnly: false));
 
+        var reflectionColumn = new DataGridTextColumn { Binding = new ReflectionBinding(nameof(ReadOnlyRow.Name)) };
+        Assert.False(grid.GetColumnReadOnlyState(reflectionColumn, isReadOnly: false));
+
         var multiBindingColumn = new DataGridTextColumn { Binding = new MultiBinding() };
         Assert.True(grid.GetColumnReadOnlyState(multiBindingColumn, isReadOnly: false));
 
-        var compiled = CreateCompiledBinding(nameof(ReadOnlyRow.Name));
-        var compiledColumn = new DataGridTextColumn { Binding = compiled };
-        Assert.True(grid.GetColumnReadOnlyState(compiledColumn, isReadOnly: false));
+        var compiledBindingExtension = Assert.IsType<CompiledBindingExtension>(
+            DataGridBindingDefinition.Create<ReadOnlyRow, string>(row => row.Name).CreateBinding());
+        var extensionColumn = new DataGridTextColumn { Binding = compiledBindingExtension };
+        Assert.False(grid.GetColumnReadOnlyState(extensionColumn, isReadOnly: false));
+
+        var compiledColumn = new DataGridTextColumn
+        {
+            Binding = new CompiledBinding { Path = compiledBindingExtension.Path }
+        };
+        Assert.False(grid.GetColumnReadOnlyState(compiledColumn, isReadOnly: false));
     }
 
     [AvaloniaFact]
@@ -1214,41 +1224,6 @@ public class DataGridColumnsBranchCoverageTests
         public string ReadOnlyName { get; } = "ReadOnly";
 
         public string Name { get; set; } = "Name";
-    }
-
-    private static BindingBase CreateCompiledBinding(string path)
-    {
-        var compiledBindingType = typeof(CompiledBindingExtension);
-        var instance = Activator.CreateInstance(compiledBindingType);
-        Assert.NotNull(instance);
-        var binding = instance as BindingBase;
-        Assert.NotNull(binding);
-        var pathProperty = compiledBindingType.GetProperty("Path");
-        if (pathProperty != null)
-        {
-            var pathType = pathProperty.PropertyType;
-            object? pathValue = null;
-            var ctor = pathType.GetConstructor(new[] { typeof(string) });
-            if (ctor != null)
-            {
-                pathValue = ctor.Invoke(new object[] { path });
-            }
-            else
-            {
-                var parse = pathType.GetMethod("Parse", new[] { typeof(string) });
-                if (parse != null)
-                {
-                    pathValue = parse.Invoke(null, new object[] { path });
-                }
-                else
-                {
-                    pathValue = Activator.CreateInstance(pathType);
-                }
-            }
-            pathProperty.SetValue(instance, pathValue);
-        }
-
-        return binding!;
     }
 
     private sealed class TestRow

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridAccessorSearchAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridAccessorSearchAdapterTests.cs
@@ -6,7 +6,10 @@ using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridSearching;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Threading;
 using Xunit;
 
@@ -36,6 +39,36 @@ public class DataGridAccessorSearchAdapterTests
         var result = Assert.Single(model.Results);
         Assert.Same(items[1], result.Item);
         Assert.Same(column, result.ColumnId);
+    }
+
+    [Fact]
+    public void AccessorAdapter_Runtime_CompiledBinding_Uses_Display_Metadata()
+    {
+        var items = new[] { new Person("Alpha") };
+        var view = new DataGridCollectionView(items);
+        var model = new SearchModel();
+        var compiledBindingExtension = Assert.IsType<CompiledBindingExtension>(
+            DataGridBindingDefinition.Create<Person, string>(person => person.Name).CreateBinding());
+        var column = new DataGridTextColumn
+        {
+            Binding = new CompiledBinding
+            {
+                Path = compiledBindingExtension.Path,
+                Converter = new PrefixConverter(),
+                ConverterParameter = "display",
+                StringFormat = "[{0}]"
+            }
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<Person, string>(person => person.Name));
+        var adapter = new DataGridAccessorSearchAdapter(model, () => new[] { column });
+        adapter.AttachView(view);
+
+        model.SetOrUpdate(new SearchDescriptor("display:Alpha", comparison: StringComparison.Ordinal));
+
+        var result = Assert.Single(model.Results);
+        Assert.Same(items[0], result.Item);
     }
 
     [Fact]
@@ -407,6 +440,19 @@ public class DataGridAccessorSearchAdapterTests
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+    }
+
+    private sealed class PrefixConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return $"{parameter}:{value}";
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
     }
 
     private sealed class TextAccessor : IDataGridColumnValueAccessor, IDataGridColumnTextAccessor

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridSearchAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridSearchAdapterTests.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridSearching;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Threading;
 using Xunit;
 
@@ -72,6 +76,33 @@ public class DataGridSearchAdapterTests
     }
 
     [AvaloniaFact]
+    public void Runtime_CompiledBinding_Uses_Display_Metadata()
+    {
+        var items = new[] { new Person("Alpha") };
+        var view = new DataGridCollectionView(items);
+        var model = new SearchModel();
+        var compiledBindingExtension = Assert.IsType<CompiledBindingExtension>(
+            DataGridBindingDefinition.Create<Person, string>(person => person.Name).CreateBinding());
+        var column = new DataGridTextColumn
+        {
+            Binding = new CompiledBinding
+            {
+                Path = compiledBindingExtension.Path,
+                Converter = new PrefixConverter(),
+                ConverterParameter = "display",
+                StringFormat = "[{0}]"
+            }
+        };
+        var adapter = new DataGridSearchAdapter(model, () => new[] { column });
+        adapter.AttachView(view);
+
+        model.SetOrUpdate(new SearchDescriptor("[display:Alpha]", comparison: StringComparison.Ordinal));
+
+        var result = Assert.Single(model.Results);
+        Assert.Same(items[0], result.Item);
+    }
+
+    [AvaloniaFact]
     public void Collection_Changes_Are_Coalesced_To_Single_Refresh()
     {
         var items = new ObservableCollection<Person>
@@ -131,5 +162,18 @@ public class DataGridSearchAdapterTests
         }
 
         public string Name { get; }
+    }
+
+    private sealed class PrefixConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return $"{parameter}:{value}";
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Sorting/DataGridSortingHeaderTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Sorting/DataGridSortingHeaderTests.cs
@@ -14,6 +14,7 @@ using Avalonia.Controls.DataGridSorting;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.VisualTree;
 using Xunit;
@@ -55,6 +56,47 @@ public class DataGridSortingHeaderTests
         ClickHeader(grid, "Name", KeyModifiers.Control);
         grid.UpdateLayout();
         AssertHeaderSort(grid, "Name", asc: false, desc: false);
+    }
+
+    [AvaloniaFact]
+    public void Header_Click_Sorts_Runtime_CompiledBinding_Without_SortMemberPath()
+    {
+        var items = new ObservableCollection<Item>
+        {
+            new("B"),
+            new("A"),
+        };
+        var compiledBindingExtension = Assert.IsType<CompiledBindingExtension>(
+            DataGridBindingDefinition.Create<Item, string>(item => item.Name).CreateBinding());
+        var column = new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new CompiledBinding { Path = compiledBindingExtension.Path }
+        };
+        var root = new Window
+        {
+            Width = 400,
+            Height = 300
+        };
+        root.SetThemeStyles();
+
+        var grid = new DataGrid
+        {
+            ItemsSource = new DataGridCollectionView(items),
+            SelectionMode = DataGridSelectionMode.Extended
+        };
+        grid.ColumnsInternal.Add(column);
+        root.Content = grid;
+        root.Show();
+        grid.UpdateLayout();
+
+        ClickHeader(grid, "Name");
+        grid.UpdateLayout();
+
+        Assert.True(column.CanUserSort);
+        Assert.Equal(nameof(Item.Name), column.GetSortPropertyName());
+        Assert.Equal(new[] { "A", "B" }, GetRowOrder(grid));
+        AssertHeaderSort(grid, "Name", asc: true, desc: false);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -7,7 +7,6 @@
 
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Utilities;
 using System;
 using System.Collections.Generic;
@@ -226,7 +225,7 @@ internal
             if (dataGridColumn is DataGridBoundColumn dataGridBoundColumn &&
                 dataGridBoundColumn.Binding is BindingBase binding)
             {
-                var path = (binding as Binding)?.Path ?? (binding as CompiledBindingExtension)?.Path.ToString();
+                var path = BindingCloneHelper.GetPath(binding);
 
                 if (string.IsNullOrWhiteSpace(path))
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
@@ -13,7 +13,6 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using System;
@@ -413,19 +412,9 @@ namespace Avalonia.Controls
         {
             string result = SortMemberPath;
 
-            if (String.IsNullOrEmpty(result))
+            if (string.IsNullOrEmpty(result) && this is DataGridBoundColumn boundColumn)
             {
-                if (this is DataGridBoundColumn boundColumn)
-                {
-                    if (boundColumn.Binding is Binding binding)
-                    {
-                        result = binding.Path;
-                    }
-                    else if (boundColumn.Binding is CompiledBindingExtension compiledBinding)
-                    {
-                        result = compiledBinding.Path.ToString();
-                    }
-                }
+                result = BindingCloneHelper.GetPath(boundColumn.Binding);
             }
 
             return result;

--- a/src/Avalonia.Controls.DataGrid/Searching/DataGridAccessorSearchAdapter.cs
+++ b/src/Avalonia.Controls.DataGrid/Searching/DataGridAccessorSearchAdapter.cs
@@ -14,9 +14,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 
 namespace Avalonia.Controls.DataGridSearching
 {
@@ -390,18 +390,9 @@ namespace Avalonia.Controls.DataGridSearching
 
             if (column is DataGridBoundColumn boundColumn)
             {
-                if (boundColumn.Binding is Binding binding)
-                {
-                    stringFormat = binding.StringFormat;
-                    converter = binding.Converter;
-                    converterParameter = binding.ConverterParameter;
-                }
-                else if (boundColumn.Binding is CompiledBindingExtension compiledBinding)
-                {
-                    stringFormat = compiledBinding.StringFormat;
-                    converter = compiledBinding.Converter;
-                    converterParameter = compiledBinding.ConverterParameter;
-                }
+                stringFormat = BindingCloneHelper.GetStringFormat(boundColumn.Binding);
+                converter = BindingCloneHelper.GetConverter(boundColumn.Binding);
+                converterParameter = BindingCloneHelper.GetConverterParameter(boundColumn.Binding);
             }
 
             Func<object, object> valueGetter = null;

--- a/src/Avalonia.Controls.DataGrid/Searching/DataGridSearchAdapter.cs
+++ b/src/Avalonia.Controls.DataGrid/Searching/DataGridSearchAdapter.cs
@@ -17,7 +17,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia.Utilities;
 using Avalonia.Threading;
@@ -337,18 +336,9 @@ namespace Avalonia.Controls.DataGridSearching
 
             if (column is DataGridBoundColumn boundColumn)
             {
-                if (boundColumn.Binding is Binding binding)
-                {
-                    stringFormat = binding.StringFormat;
-                    converter = binding.Converter;
-                    converterParameter = binding.ConverterParameter;
-                }
-                else if (boundColumn.Binding is CompiledBindingExtension compiledBinding)
-                {
-                    stringFormat = compiledBinding.StringFormat;
-                    converter = compiledBinding.Converter;
-                    converterParameter = compiledBinding.ConverterParameter;
-                }
+                stringFormat = BindingCloneHelper.GetStringFormat(boundColumn.Binding);
+                converter = BindingCloneHelper.GetConverter(boundColumn.Binding);
+                converterParameter = BindingCloneHelper.GetConverterParameter(boundColumn.Binding);
             }
 
             Func<object, object> valueGetter = null;


### PR DESCRIPTION
## Summary

This change makes DataGrid column behavior consistent for every supported Avalonia binding representation, including runtime `CompiledBinding` instances produced by compiled XAML.

It updates sorting, editability detection, and search formatting to use the existing centralized binding-inspection helper instead of performing incomplete type-specific checks.

## Problem

Several column code paths recognized `Binding` and `CompiledBindingExtension`, but did not consistently recognize `ReflectionBinding` or the runtime `CompiledBinding` representation.

That mismatch could cause columns without an explicit `SortMemberPath` to lose their inferred property path. As a result, clicking a sortable column header could fail to create a sort descriptor even though the column had a valid compiled binding.

The same assumption also affected two related behaviors:

- writable properties bound through compiled or reflection bindings could be treated as read-only because their property path was not discovered;
- search adapters could omit the binding converter, converter parameter, and string format, causing search text to differ from the value displayed by the column.

## Changes

### Sorting

- Resolve an implicit sort property through `BindingCloneHelper.GetPath`.
- Preserve an explicitly configured `SortMemberPath` as the highest-priority value.
- Support `Binding`, `ReflectionBinding`, `CompiledBindingExtension`, and runtime `CompiledBinding` uniformly.
- Add a headless regression test that clicks a header backed by a runtime compiled binding and verifies the row order and sort indicator.

### Read-only evaluation

- Use the centralized binding-path helper when determining whether a bound property is writable.
- Retain the safe read-only fallback for pathless or unsupported bindings such as `MultiBinding`.
- Expand coverage for reflection bindings, compiled binding extensions, and runtime compiled bindings.
- Replace the previous reflection-based test setup with a typed compiled-binding definition.

### Search

- Read string format, converter, and converter parameter through `BindingCloneHelper` in both search adapter implementations.
- Keep search matching aligned with the column's displayed text for runtime compiled bindings.
- Add regression coverage for the standard and accessor-based search paths.

## User impact

- Header sorting works when a bound column relies on its compiled binding path and does not set `SortMemberPath` explicitly.
- Editable compiled-binding columns are no longer incorrectly classified as read-only.
- Search respects the same conversion and formatting metadata used by runtime compiled bindings.
- Existing explicit sort paths and pathless-binding safety behavior remain unchanged.

## Validation

- Targeted sorting, searching, column, and binding-helper suites: 152 passed.
- Complete `Avalonia.Controls.DataGrid.UnitTests` project: 2,362 passed.
- `git diff --check`: clean.
