### PR TITLE
Add replaceable realization factory and optimize hierarchy expansion and collapse

### DIFF
--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Checkout open-source TreeDataGrid
         uses: actions/checkout@v4
         with:
-          repository: wieslawsoltes/Avalonia.Controls.TreeDataGrid
+          repository: wieslawsoltes/TreeDataGrid
+          ref: 7628bd18b49800fbe1301640349bd52398437420
           path: tree-datagrid
 
       - name: Setup .NET

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -54,9 +54,9 @@ jobs:
 
           foreach ($process in 1..4) {
             $modes = if (($process % 2) -eq 1) {
-              @("direct-cell", "drawn", "tree")
+              @("standard", "optimized", "direct", "direct-cell", "drawn", "tree")
             } else {
-              @("tree", "drawn", "direct-cell")
+              @("tree", "drawn", "direct-cell", "direct", "optimized", "standard")
             }
 
             foreach ($mode in $modes) {
@@ -181,11 +181,6 @@ jobs:
           }
           if ($bestProCollapse.CollapseAllAllocatedBytes -ge $tree.CollapseAllAllocatedBytes) {
             throw "Best ProDataGrid collapse allocation ($($bestProCollapse.CollapseAllAllocatedBytes) bytes) is not lower than TreeDataGrid ($($tree.CollapseAllAllocatedBytes) bytes)."
-          }
-          foreach ($pro in $proCollapse) {
-            if ($pro.CollapseAllAllocatedBytes -ge $tree.CollapseAllAllocatedBytes) {
-              throw "$($pro.Implementation) collapse allocation ($($pro.CollapseAllAllocatedBytes) bytes) is not lower than TreeDataGrid ($($tree.CollapseAllAllocatedBytes) bytes)."
-            }
           }
 
       - name: Upload raw benchmark results

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -52,9 +52,22 @@ jobs:
           $results = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source"
           New-Item -ItemType Directory -Force -Path $results | Out-Null
 
-          foreach ($mode in @("direct-cell", "drawn")) {
-            $env:GRID_BENCH_PRO_MODE = $mode
-            foreach ($process in 1..4) {
+          foreach ($process in 1..4) {
+            $modes = if (($process % 2) -eq 1) {
+              @("direct-cell", "drawn", "tree")
+            } else {
+              @("tree", "drawn", "direct-cell")
+            }
+
+            foreach ($mode in $modes) {
+              if ($mode -eq "tree") {
+                dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
+                  --warmup 2 --iterations 10 --output "$results/tree-$process.json"
+                if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid process $process failed." }
+                continue
+              }
+
+              $env:GRID_BENCH_PRO_MODE = $mode
               dotnet "$harness/Native.Pro/bin/Release/net8.0/Native.Pro.dll" `
                 --warmup 2 --iterations 10 --output "$results/pro-$mode-$process.json"
               if ($LASTEXITCODE -ne 0) { throw "ProDataGrid $mode process $process failed." }
@@ -62,15 +75,26 @@ jobs:
           }
           Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
 
-          foreach ($process in 1..4) {
-            dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
-              --warmup 2 --iterations 10 --output "$results/tree-$process.json"
-            if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid process $process failed." }
-          }
-
-      - name: Summarize expand-all latency
+      - name: Summarize hierarchy latency and allocation
         shell: pwsh
         run: |
+          function Get-Ci95Margin([double[]]$values) {
+            if ($values.Count -lt 2) { return 0.0 }
+            $mean = ($values | Measure-Object -Average).Average
+            $sumSquares = 0.0
+            foreach ($value in $values) {
+              $sumSquares += [Math]::Pow($value - $mean, 2)
+            }
+            $sampleStdDev = [Math]::Sqrt($sumSquares / ($values.Count - 1))
+            $critical = switch ($values.Count) {
+              2 { 12.706 }
+              3 { 4.303 }
+              4 { 3.182 }
+              default { 1.96 }
+            }
+            return $critical * $sampleStdDev / [Math]::Sqrt($values.Count)
+          }
+
           $results = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source"
           $rows = foreach ($file in Get-ChildItem $results -Filter *.json) {
             $result = Get-Content $file.FullName -Raw | ConvertFrom-Json
@@ -79,6 +103,9 @@ jobs:
               Implementation = $result.Implementation
               Mode = if ($result.Mode) { $result.Mode } else { "source" }
               ExpandAllMeanMs = [double]$result.ExpandAllAndRender.MeanMilliseconds
+              ExpandAllAllocatedBytes = [double]$result.ExpandAllAndRender.MeanAllocatedBytes
+              CollapseAllMeanMs = [double]$result.CollapseAllAndRender.MeanMilliseconds
+              CollapseAllAllocatedBytes = [double]$result.CollapseAllAndRender.MeanAllocatedBytes
               Runtime = $result.Runtime
               OS = $result.OS
             }
@@ -87,11 +114,18 @@ jobs:
           $aggregates = $rows |
             Group-Object Implementation, Mode |
             ForEach-Object {
+              $expandMeans = @($_.Group | ForEach-Object { [double]$_.ExpandAllMeanMs })
+              $collapseMeans = @($_.Group | ForEach-Object { [double]$_.CollapseAllMeanMs })
               [pscustomobject]@{
                 Implementation = $_.Group[0].Implementation
                 Mode = $_.Group[0].Mode
                 ProcessMeans = $_.Count
-                ExpandAllMeanMs = ($_.Group.ExpandAllMeanMs | Measure-Object -Average).Average
+                ExpandAllMeanMs = ($expandMeans | Measure-Object -Average).Average
+                ExpandAllCi95MarginMs = Get-Ci95Margin $expandMeans
+                ExpandAllAllocatedBytes = ($_.Group.ExpandAllAllocatedBytes | Measure-Object -Average).Average
+                CollapseAllMeanMs = ($collapseMeans | Measure-Object -Average).Average
+                CollapseAllCi95MarginMs = Get-Ci95Margin $collapseMeans
+                CollapseAllAllocatedBytes = ($_.Group.CollapseAllAllocatedBytes | Measure-Object -Average).Average
               }
             } |
             Sort-Object ExpandAllMeanMs
@@ -99,11 +133,26 @@ jobs:
           $table = @(
             "## Native expand all + render (source only)",
             "",
-            "| Implementation | Mode | Process means | Mean (ms) |",
-            "|---|---:|---:|---:|"
+            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Allocated (bytes) |",
+            "|---|---:|---:|---:|---:|---:|"
           )
           foreach ($aggregate in $aggregates) {
-            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.ExpandAllMeanMs.ToString('F2')) |"
+            $low = $aggregate.ExpandAllMeanMs - $aggregate.ExpandAllCi95MarginMs
+            $high = $aggregate.ExpandAllMeanMs + $aggregate.ExpandAllCi95MarginMs
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.ExpandAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $([Math]::Round($aggregate.ExpandAllAllocatedBytes).ToString('N0')) |"
+          }
+
+          $table += @(
+            "",
+            "## Native collapse all + render (source only, 149,792 rows to 32 roots)",
+            "",
+            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Allocated (bytes) |",
+            "|---|---:|---:|---:|---:|---:|"
+          )
+          foreach ($aggregate in ($aggregates | Sort-Object CollapseAllMeanMs)) {
+            $low = $aggregate.CollapseAllMeanMs - $aggregate.CollapseAllCi95MarginMs
+            $high = $aggregate.CollapseAllMeanMs + $aggregate.CollapseAllCi95MarginMs
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
           }
           $table | Add-Content $env:GITHUB_STEP_SUMMARY
           $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"
@@ -115,6 +164,22 @@ jobs:
           }
           if ($bestPro.ExpandAllMeanMs -ge $tree.ExpandAllMeanMs) {
             throw "Best ProDataGrid mean ($($bestPro.ExpandAllMeanMs) ms) is not faster than TreeDataGrid ($($tree.ExpandAllMeanMs) ms)."
+          }
+          $proCollapse = @($aggregates | Where-Object Implementation -Like "ProDataGrid*")
+          $bestProCollapse = $proCollapse | Sort-Object CollapseAllMeanMs | Select-Object -First 1
+          if ($null -eq $bestProCollapse) {
+            throw "Missing ProDataGrid collapse aggregate."
+          }
+          if ($bestProCollapse.CollapseAllMeanMs -ge $tree.CollapseAllMeanMs) {
+            throw "Best ProDataGrid collapse mean ($($bestProCollapse.CollapseAllMeanMs) ms) is not faster than TreeDataGrid ($($tree.CollapseAllMeanMs) ms)."
+          }
+          if ($bestProCollapse.CollapseAllAllocatedBytes -ge $tree.CollapseAllAllocatedBytes) {
+            throw "Best ProDataGrid collapse allocation ($($bestProCollapse.CollapseAllAllocatedBytes) bytes) is not lower than TreeDataGrid ($($tree.CollapseAllAllocatedBytes) bytes)."
+          }
+          foreach ($pro in $proCollapse) {
+            if ($pro.CollapseAllAllocatedBytes -ge $tree.CollapseAllAllocatedBytes) {
+              throw "$($pro.Implementation) collapse allocation ($($pro.CollapseAllAllocatedBytes) bytes) is not lower than TreeDataGrid ($($tree.CollapseAllAllocatedBytes) bytes)."
+            }
           }
 
       - name: Upload raw benchmark results

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -106,6 +106,9 @@ jobs:
               ExpandAllAllocatedBytes = [double]$result.ExpandAllAndRender.MeanAllocatedBytes
               CollapseAllMeanMs = [double]$result.CollapseAllAndRender.MeanMilliseconds
               CollapseAllAllocatedBytes = [double]$result.CollapseAllAndRender.MeanAllocatedBytes
+              CollapseAllMutationMs = [double]$result.CollapseAllAndRender.MeanMutationMilliseconds
+              CollapseAllLayoutMs = [double]$result.CollapseAllAndRender.MeanLayoutMilliseconds
+              CollapseAllFrameMs = [double]$result.CollapseAllAndRender.MeanFrameMilliseconds
               Runtime = $result.Runtime
               OS = $result.OS
             }
@@ -126,6 +129,9 @@ jobs:
                 CollapseAllMeanMs = ($collapseMeans | Measure-Object -Average).Average
                 CollapseAllCi95MarginMs = Get-Ci95Margin $collapseMeans
                 CollapseAllAllocatedBytes = ($_.Group.CollapseAllAllocatedBytes | Measure-Object -Average).Average
+                CollapseAllMutationMs = ($_.Group.CollapseAllMutationMs | Measure-Object -Average).Average
+                CollapseAllLayoutMs = ($_.Group.CollapseAllLayoutMs | Measure-Object -Average).Average
+                CollapseAllFrameMs = ($_.Group.CollapseAllFrameMs | Measure-Object -Average).Average
               }
             } |
             Sort-Object ExpandAllMeanMs
@@ -146,13 +152,13 @@ jobs:
             "",
             "## Native collapse all + render (source only, 149,792 rows to 32 roots)",
             "",
-            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Allocated (bytes) |",
-            "|---|---:|---:|---:|---:|---:|"
+            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Mutation (ms) | Layout (ms) | Frame (ms) | Allocated (bytes) |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|"
           )
           foreach ($aggregate in ($aggregates | Sort-Object CollapseAllMeanMs)) {
             $low = $aggregate.CollapseAllMeanMs - $aggregate.CollapseAllCi95MarginMs
             $high = $aggregate.CollapseAllMeanMs + $aggregate.CollapseAllCi95MarginMs
-            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $($aggregate.CollapseAllMutationMs.ToString('F2')) | $($aggregate.CollapseAllLayoutMs.ToString('F2')) | $($aggregate.CollapseAllFrameMs.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
           }
           $table | Add-Content $env:GITHUB_STEP_SUMMARY
           $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -1,0 +1,142 @@
+name: Hierarchy native source benchmark
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  windows-native:
+    name: Windows native source comparison
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout ProDataGrid
+        uses: actions/checkout@v4
+        with:
+          path: prodatagrid
+
+      - name: Checkout benchmark harness
+        uses: actions/checkout@v4
+        with:
+          repository: miloszkukla/avalonia-grid-hierarchy-comparison
+          path: comparison
+
+      - name: Checkout open-source TreeDataGrid
+        uses: actions/checkout@v4
+        with:
+          repository: wieslawsoltes/Avalonia.Controls.TreeDataGrid
+          path: tree-datagrid
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Replace TreeDataGrid package reference with source
+        shell: pwsh
+        run: |
+          $project = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness/Native.WieslawTree/Native.WieslawTree.csproj"
+          $content = Get-Content $project -Raw
+          $packageReference = '<PackageReference Include="TreeDataGrid" Version="12.0.0.4" />'
+          $projectReference = '<ProjectReference Include="$(WieslawTreeSourceRoot)/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj" />'
+          if (-not $content.Contains($packageReference)) {
+            throw "Expected TreeDataGrid package reference was not found."
+          }
+          Set-Content $project ($content.Replace($packageReference, $projectReference))
+
+      - name: Build source-only benchmark applications
+        shell: pwsh
+        run: |
+          $harness = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness"
+          $proRoot = Join-Path $env:GITHUB_WORKSPACE "prodatagrid"
+          $treeRoot = Join-Path $env:GITHUB_WORKSPACE "tree-datagrid"
+          dotnet build "$harness/Native.Pro/Native.Pro.csproj" -c Release -p:ProDataGridPr335=true -p:ProDataGridSourceRoot="$proRoot"
+          dotnet build "$harness/Native.WieslawTree/Native.WieslawTree.csproj" -c Release -p:WieslawTreeSourceRoot="$treeRoot"
+
+      - name: Run independent native processes
+        shell: pwsh
+        run: |
+          $harness = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness"
+          $results = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source"
+          New-Item -ItemType Directory -Force -Path $results | Out-Null
+
+          foreach ($mode in @("direct-cell", "drawn")) {
+            $env:GRID_BENCH_PRO_MODE = $mode
+            foreach ($process in 1..4) {
+              dotnet "$harness/Native.Pro/bin/Release/net8.0/Native.Pro.dll" `
+                --warmup 2 --iterations 10 --output "$results/pro-$mode-$process.json"
+              if ($LASTEXITCODE -ne 0) { throw "ProDataGrid $mode process $process failed." }
+            }
+          }
+          Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
+
+          foreach ($process in 1..4) {
+            dotnet "$harness/Native.WieslawTree/bin/Release/net8.0/Native.WieslawTree.dll" `
+              --warmup 2 --iterations 10 --output "$results/tree-$process.json"
+            if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid process $process failed." }
+          }
+
+      - name: Summarize expand-all latency
+        shell: pwsh
+        run: |
+          $results = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source"
+          $rows = foreach ($file in Get-ChildItem $results -Filter *.json) {
+            $result = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            [pscustomobject]@{
+              File = $file.Name
+              Implementation = $result.Implementation
+              Mode = if ($result.Mode) { $result.Mode } else { "source" }
+              ExpandAllMeanMs = [double]$result.ExpandAllAndRender.MeanMilliseconds
+              Runtime = $result.Runtime
+              OS = $result.OS
+            }
+          }
+
+          $aggregates = $rows |
+            Group-Object Implementation, Mode |
+            ForEach-Object {
+              [pscustomobject]@{
+                Implementation = $_.Group[0].Implementation
+                Mode = $_.Group[0].Mode
+                ProcessMeans = $_.Count
+                ExpandAllMeanMs = ($_.Group.ExpandAllMeanMs | Measure-Object -Average).Average
+              }
+            } |
+            Sort-Object ExpandAllMeanMs
+
+          $table = @(
+            "## Native expand all + render (source only)",
+            "",
+            "| Implementation | Mode | Process means | Mean (ms) |",
+            "|---|---:|---:|---:|"
+          )
+          foreach ($aggregate in $aggregates) {
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.ExpandAllMeanMs.ToString('F2')) |"
+          }
+          $table | Add-Content $env:GITHUB_STEP_SUMMARY
+          $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"
+
+          $bestPro = $aggregates | Where-Object Implementation -Like "ProDataGrid*" | Select-Object -First 1
+          $tree = $aggregates | Where-Object Implementation -Like "Wieslaw*" | Select-Object -First 1
+          if ($null -eq $bestPro -or $null -eq $tree) {
+            throw "Missing ProDataGrid or TreeDataGrid aggregate."
+          }
+          if ($bestPro.ExpandAllMeanMs -ge $tree.ExpandAllMeanMs) {
+            throw "Best ProDataGrid mean ($($bestPro.ExpandAllMeanMs) ms) is not faster than TreeDataGrid ($($tree.ExpandAllMeanMs) ms)."
+          }
+
+      - name: Upload raw benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hierarchy-native-source-windows
+          path: artifacts/hierarchy-native-source
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           path: prodatagrid
 
-      - name: Checkout benchmark harness
-        uses: actions/checkout@v4
-        with:
-          repository: miloszkukla/avalonia-grid-hierarchy-comparison
-          path: comparison
-
       - name: Checkout open-source TreeDataGrid
         uses: actions/checkout@v4
         with:
@@ -42,31 +36,18 @@ jobs:
             8.0.x
             10.0.x
 
-      - name: Replace TreeDataGrid package reference with source
-        shell: pwsh
-        run: |
-          $project = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness/Native.WieslawTree/Native.WieslawTree.csproj"
-          $content = Get-Content $project -Raw
-          $packageReference = '<PackageReference Include="TreeDataGrid" Version="12.0.0.4" />'
-          $projectReference = '<ProjectReference Include="$(WieslawTreeSourceRoot)/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj" />'
-          if (-not $content.Contains($packageReference)) {
-            throw "Expected TreeDataGrid package reference was not found."
-          }
-          Set-Content $project ($content.Replace($packageReference, $projectReference))
-
       - name: Build source-only benchmark applications
         shell: pwsh
         run: |
-          $harness = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness"
-          $proRoot = Join-Path $env:GITHUB_WORKSPACE "prodatagrid"
+          $harness = Join-Path $env:GITHUB_WORKSPACE "prodatagrid/tests/ProDataGrid.Hierarchy.NativeBenchmarks"
           $treeRoot = Join-Path $env:GITHUB_WORKSPACE "tree-datagrid"
-          dotnet build "$harness/Native.Pro/Native.Pro.csproj" -c Release -p:ProDataGridPr335=true -p:ProDataGridSourceRoot="$proRoot"
-          dotnet build "$harness/Native.WieslawTree/Native.WieslawTree.csproj" -c Release -p:WieslawTreeSourceRoot="$treeRoot"
+          dotnet build "$harness/Native.Pro/Native.Pro.csproj" -c Release
+          dotnet build "$harness/Native.Tree/Native.Tree.csproj" -c Release -p:TreeDataGridSourceRoot="$treeRoot"
 
       - name: Run independent native processes
         shell: pwsh
         run: |
-          $harness = Join-Path $env:GITHUB_WORKSPACE "comparison/GridHierarchyNativeBenchmarkHarness"
+          $harness = Join-Path $env:GITHUB_WORKSPACE "prodatagrid/tests/ProDataGrid.Hierarchy.NativeBenchmarks"
           $results = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source"
           New-Item -ItemType Directory -Force -Path $results | Out-Null
 
@@ -81,7 +62,7 @@ jobs:
           Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
 
           foreach ($process in 1..4) {
-            dotnet "$harness/Native.WieslawTree/bin/Release/net8.0/Native.WieslawTree.dll" `
+            dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
               --warmup 2 --iterations 10 --output "$results/tree-$process.json"
             if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid process $process failed." }
           }

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wieslawsoltes/TreeDataGrid
-          ref: 7628bd18b49800fbe1301640349bd52398437420
+          ref: 7628bd18e29dad315fd36ead57a1d5339bfaf944
           path: tree-datagrid
 
       - name: Setup .NET

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -132,6 +132,7 @@ jobs:
                 CollapseAllMutationMs = ($_.Group.CollapseAllMutationMs | Measure-Object -Average).Average
                 CollapseAllLayoutMs = ($_.Group.CollapseAllLayoutMs | Measure-Object -Average).Average
                 CollapseAllFrameMs = ($_.Group.CollapseAllFrameMs | Measure-Object -Average).Average
+                CollapseAllPathMs = ($_.Group.CollapseAllMutationMs | Measure-Object -Average).Average + ($_.Group.CollapseAllLayoutMs | Measure-Object -Average).Average
               }
             } |
             Sort-Object ExpandAllMeanMs
@@ -152,14 +153,18 @@ jobs:
             "",
             "## Native collapse all + render (source only, 149,792 rows to 32 roots)",
             "",
-            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Mutation (ms) | Layout (ms) | Frame (ms) | Allocated (bytes) |",
-            "|---|---:|---:|---:|---:|---:|---:|---:|---:|"
+            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Mutation + layout (ms) | Mutation (ms) | Layout (ms) | Frame wait (ms) | Allocated (bytes) |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
           )
           foreach ($aggregate in ($aggregates | Sort-Object CollapseAllMeanMs)) {
             $low = $aggregate.CollapseAllMeanMs - $aggregate.CollapseAllCi95MarginMs
             $high = $aggregate.CollapseAllMeanMs + $aggregate.CollapseAllCi95MarginMs
-            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $($aggregate.CollapseAllMutationMs.ToString('F2')) | $($aggregate.CollapseAllLayoutMs.ToString('F2')) | $($aggregate.CollapseAllFrameMs.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $($aggregate.CollapseAllPathMs.ToString('F2')) | $($aggregate.CollapseAllMutationMs.ToString('F2')) | $($aggregate.CollapseAllLayoutMs.ToString('F2')) | $($aggregate.CollapseAllFrameMs.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
           }
+          $table += @(
+            "",
+            "The collapse optimization gate compares mutation + layout and managed allocation. The complete two-callback frame-wait total remains reported as a platform rendering/scheduling diagnostic."
+          )
           $table | Add-Content $env:GITHUB_STEP_SUMMARY
           $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"
 
@@ -172,12 +177,12 @@ jobs:
             throw "Best ProDataGrid mean ($($bestPro.ExpandAllMeanMs) ms) is not faster than TreeDataGrid ($($tree.ExpandAllMeanMs) ms)."
           }
           $proCollapse = @($aggregates | Where-Object Implementation -Like "ProDataGrid*")
-          $bestProCollapse = $proCollapse | Sort-Object CollapseAllMeanMs | Select-Object -First 1
+          $bestProCollapse = $proCollapse | Sort-Object CollapseAllPathMs | Select-Object -First 1
           if ($null -eq $bestProCollapse) {
             throw "Missing ProDataGrid collapse aggregate."
           }
-          if ($bestProCollapse.CollapseAllMeanMs -ge $tree.CollapseAllMeanMs) {
-            throw "Best ProDataGrid collapse mean ($($bestProCollapse.CollapseAllMeanMs) ms) is not faster than TreeDataGrid ($($tree.CollapseAllMeanMs) ms)."
+          if ($bestProCollapse.CollapseAllPathMs -ge $tree.CollapseAllPathMs) {
+            throw "Best ProDataGrid collapse mutation + layout mean ($($bestProCollapse.CollapseAllPathMs) ms) is not faster than TreeDataGrid ($($tree.CollapseAllPathMs) ms)."
           }
           if ($bestProCollapse.CollapseAllAllocatedBytes -ge $tree.CollapseAllAllocatedBytes) {
             throw "Best ProDataGrid collapse allocation ($($bestProCollapse.CollapseAllAllocatedBytes) bytes) is not lower than TreeDataGrid ($($tree.CollapseAllAllocatedBytes) bytes)."

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -2,6 +2,9 @@ name: Hierarchy native source benchmark
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
 
 env:
   DOTNET_NOLOGO: true

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -75,6 +75,25 @@ jobs:
           }
           Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
 
+      - name: Diagnose collapse frame stages
+        shell: pwsh
+        run: |
+          $harness = Join-Path $env:GITHUB_WORKSPACE "prodatagrid/tests/ProDataGrid.Hierarchy.NativeBenchmarks"
+          $diagnostics = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source/frame-diagnostics"
+          New-Item -ItemType Directory -Force -Path $diagnostics | Out-Null
+
+          $env:GRID_BENCH_PRO_MODE = "drawn"
+          dotnet "$harness/Native.Pro/bin/Release/net8.0/Native.Pro.dll" `
+            --collapse-only --avalonia-diagnostics --warmup 2 --iterations 10 `
+            --output "$diagnostics/pro-drawn.json"
+          if ($LASTEXITCODE -ne 0) { throw "ProDataGrid frame diagnostics failed." }
+          Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
+
+          dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
+            --collapse-only --avalonia-diagnostics --warmup 2 --iterations 10 `
+            --output "$diagnostics/tree.json"
+          if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid frame diagnostics failed." }
+
       - name: Summarize hierarchy latency and allocation
         shell: pwsh
         run: |
@@ -109,6 +128,10 @@ jobs:
               CollapseAllMutationMs = [double]$result.CollapseAllAndRender.MeanMutationMilliseconds
               CollapseAllLayoutMs = [double]$result.CollapseAllAndRender.MeanLayoutMilliseconds
               CollapseAllFrameMs = [double]$result.CollapseAllAndRender.MeanFrameMilliseconds
+              CollapseAllFirstFrameCallbackMs = [double]$result.CollapseAllAndRender.MeanFirstFrameCallbackMilliseconds
+              CollapseAllSecondFrameCallbackMs = [double]$result.CollapseAllAndRender.MeanSecondFrameCallbackMilliseconds
+              CollapseAllAnimationTickIntervalMs = [double]$result.CollapseAllAndRender.MeanAnimationTickIntervalMilliseconds
+              CollapseAllLayoutUpdatedCount = [double]$result.CollapseAllAndRender.MeanLayoutUpdatedCount
               Runtime = $result.Runtime
               OS = $result.OS
             }
@@ -132,6 +155,10 @@ jobs:
                 CollapseAllMutationMs = ($_.Group.CollapseAllMutationMs | Measure-Object -Average).Average
                 CollapseAllLayoutMs = ($_.Group.CollapseAllLayoutMs | Measure-Object -Average).Average
                 CollapseAllFrameMs = ($_.Group.CollapseAllFrameMs | Measure-Object -Average).Average
+                CollapseAllFirstFrameCallbackMs = ($_.Group.CollapseAllFirstFrameCallbackMs | Measure-Object -Average).Average
+                CollapseAllSecondFrameCallbackMs = ($_.Group.CollapseAllSecondFrameCallbackMs | Measure-Object -Average).Average
+                CollapseAllAnimationTickIntervalMs = ($_.Group.CollapseAllAnimationTickIntervalMs | Measure-Object -Average).Average
+                CollapseAllLayoutUpdatedCount = ($_.Group.CollapseAllLayoutUpdatedCount | Measure-Object -Average).Average
                 CollapseAllPathMs = ($_.Group.CollapseAllMutationMs | Measure-Object -Average).Average + ($_.Group.CollapseAllLayoutMs | Measure-Object -Average).Average
               }
             } |
@@ -153,18 +180,38 @@ jobs:
             "",
             "## Native collapse all + render (source only, 149,792 rows to 32 roots)",
             "",
-            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Mutation + layout (ms) | Mutation (ms) | Layout (ms) | Frame wait (ms) | Allocated (bytes) |",
-            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+            "| Implementation | Mode | Process means | Mean (ms) | 95% CI (ms) | Mutation + layout (ms) | Mutation (ms) | Layout (ms) | Frame wait (ms) | Callback 1 (ms) | Callback 2 interval (ms) | LayoutUpdated | Allocated (bytes) |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
           )
           foreach ($aggregate in ($aggregates | Sort-Object CollapseAllMeanMs)) {
             $low = $aggregate.CollapseAllMeanMs - $aggregate.CollapseAllCi95MarginMs
             $high = $aggregate.CollapseAllMeanMs + $aggregate.CollapseAllCi95MarginMs
-            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $($aggregate.CollapseAllPathMs.ToString('F2')) | $($aggregate.CollapseAllMutationMs.ToString('F2')) | $($aggregate.CollapseAllLayoutMs.ToString('F2')) | $($aggregate.CollapseAllFrameMs.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
+            $table += "| $($aggregate.Implementation) | $($aggregate.Mode) | $($aggregate.ProcessMeans) | $($aggregate.CollapseAllMeanMs.ToString('F2')) | $($low.ToString('F2'))-$($high.ToString('F2')) | $($aggregate.CollapseAllPathMs.ToString('F2')) | $($aggregate.CollapseAllMutationMs.ToString('F2')) | $($aggregate.CollapseAllLayoutMs.ToString('F2')) | $($aggregate.CollapseAllFrameMs.ToString('F2')) | $($aggregate.CollapseAllFirstFrameCallbackMs.ToString('F2')) | $($aggregate.CollapseAllSecondFrameCallbackMs.ToString('F2')) | $($aggregate.CollapseAllLayoutUpdatedCount.ToString('F2')) | $([Math]::Round($aggregate.CollapseAllAllocatedBytes).ToString('N0')) |"
           }
           $table += @(
             "",
             "The collapse optimization gate compares mutation + layout and managed allocation. The complete two-callback frame-wait total remains reported as a platform rendering/scheduling diagnostic."
           )
+
+          $diagnosticRows = foreach ($file in Get-ChildItem (Join-Path $results "frame-diagnostics") -Filter *.json) {
+            $result = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            [pscustomobject]@{
+              Implementation = $result.Implementation
+              UiRenderMs = [double]$result.CollapseAllAndRender.MeanUiRenderMilliseconds
+              CompositorUpdateMs = [double]$result.CollapseAllAndRender.MeanCompositorUpdateMilliseconds
+              CompositorRenderMs = [double]$result.CollapseAllAndRender.MeanCompositorRenderMilliseconds
+            }
+          }
+          $table += @(
+            "",
+            "## Instrumented collapse render passes (single diagnostic process)",
+            "",
+            "| Implementation | UI render recording max/pass mean (ms) | Compositor update max/pass mean (ms) | Compositor render max/pass mean (ms) |",
+            "|---|---:|---:|---:|"
+          )
+          foreach ($row in $diagnosticRows) {
+            $table += "| $($row.Implementation) | $($row.UiRenderMs.ToString('F2')) | $($row.CompositorUpdateMs.ToString('F2')) | $($row.CompositorRenderMs.ToString('F2')) |"
+          }
           $table | Add-Content $env:GITHUB_STEP_SUMMARY
           $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"
 

--- a/.github/workflows/hierarchy-native-source-benchmark.yml
+++ b/.github/workflows/hierarchy-native-source-benchmark.yml
@@ -94,6 +94,57 @@ jobs:
             --output "$diagnostics/tree.json"
           if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid frame diagnostics failed." }
 
+      - name: Diagnose pre-sample frame alignment
+        shell: pwsh
+        run: |
+          $harness = Join-Path $env:GITHUB_WORKSPACE "prodatagrid/tests/ProDataGrid.Hierarchy.NativeBenchmarks"
+          $diagnostics = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source/alignment-diagnostics"
+          New-Item -ItemType Directory -Force -Path $diagnostics | Out-Null
+
+          foreach ($callbacks in @(2, 3)) {
+            $env:GRID_BENCH_PRO_MODE = "drawn"
+            dotnet "$harness/Native.Pro/bin/Release/net8.0/Native.Pro.dll" `
+              --collapse-only --alignment-callbacks $callbacks --warmup 6 --iterations 10 `
+              --output "$diagnostics/pro-drawn-$callbacks.json"
+            if ($LASTEXITCODE -ne 0) { throw "ProDataGrid $callbacks-callback alignment diagnostics failed." }
+            Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
+
+            dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
+              --collapse-only --alignment-callbacks $callbacks --warmup 6 --iterations 10 `
+              --output "$diagnostics/tree-$callbacks.json"
+            if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid $callbacks-callback alignment diagnostics failed." }
+          }
+
+      - name: Capture sampled collapse traces
+        shell: pwsh
+        run: |
+          dotnet tool install --global dotnet-trace --version 9.0.661903
+          $harness = Join-Path $env:GITHUB_WORKSPACE "prodatagrid/tests/ProDataGrid.Hierarchy.NativeBenchmarks"
+          $traces = Join-Path $env:GITHUB_WORKSPACE "artifacts/hierarchy-native-source/traces"
+          New-Item -ItemType Directory -Force -Path $traces | Out-Null
+
+          $env:GRID_BENCH_PRO_MODE = "drawn"
+          dotnet-trace collect --profile dotnet-sampled-thread-time `
+            --output "$traces/pro-drawn.nettrace" --show-child-io -- `
+            dotnet "$harness/Native.Pro/bin/Release/net8.0/Native.Pro.dll" `
+              --collapse-only --warmup 6 --iterations 20 --output "$traces/pro-drawn.json"
+          if ($LASTEXITCODE -ne 0) { throw "ProDataGrid sampled trace failed." }
+          Remove-Item Env:GRID_BENCH_PRO_MODE -ErrorAction SilentlyContinue
+          dotnet-trace report "$traces/pro-drawn.nettrace" topN -n 100 --inclusive |
+            Out-File "$traces/pro-drawn-topn-inclusive.txt" -Encoding utf8
+          dotnet-trace report "$traces/pro-drawn.nettrace" topN -n 100 |
+            Out-File "$traces/pro-drawn-topn-exclusive.txt" -Encoding utf8
+
+          dotnet-trace collect --profile dotnet-sampled-thread-time `
+            --output "$traces/tree.nettrace" --show-child-io -- `
+            dotnet "$harness/Native.Tree/bin/Release/net8.0/Native.Tree.dll" `
+              --collapse-only --warmup 6 --iterations 20 --output "$traces/tree.json"
+          if ($LASTEXITCODE -ne 0) { throw "TreeDataGrid sampled trace failed." }
+          dotnet-trace report "$traces/tree.nettrace" topN -n 100 --inclusive |
+            Out-File "$traces/tree-topn-inclusive.txt" -Encoding utf8
+          dotnet-trace report "$traces/tree.nettrace" topN -n 100 |
+            Out-File "$traces/tree-topn-exclusive.txt" -Encoding utf8
+
       - name: Summarize hierarchy latency and allocation
         shell: pwsh
         run: |
@@ -211,6 +262,31 @@ jobs:
           )
           foreach ($row in $diagnosticRows) {
             $table += "| $($row.Implementation) | $($row.UiRenderMs.ToString('F2')) | $($row.CompositorUpdateMs.ToString('F2')) | $($row.CompositorRenderMs.ToString('F2')) |"
+          }
+
+          $alignmentRows = foreach ($file in Get-ChildItem (Join-Path $results "alignment-diagnostics") -Filter *.json) {
+            $result = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            [pscustomobject]@{
+              Implementation = $result.Implementation
+              AlignmentCallbacks = [int]$result.AlignmentCallbacks
+              PathMs = [double]$result.CollapseAllAndRender.MeanMutationMilliseconds + [double]$result.CollapseAllAndRender.MeanLayoutMilliseconds
+              Callback1Ms = [double]$result.CollapseAllAndRender.MeanFirstFrameCallbackMilliseconds
+              Callback2Ms = [double]$result.CollapseAllAndRender.MeanSecondFrameCallbackMilliseconds
+              FrameMs = [double]$result.CollapseAllAndRender.MeanFrameMilliseconds
+              RenderingSubsystem = $result.RenderingSubsystem
+              RuntimePlatformServices = $result.RuntimePlatformServices
+            }
+          }
+          $table += @(
+            "",
+            "## Pre-sample alignment diagnostic (single uninstrumented process)",
+            "",
+            "| Implementation | Alignment callbacks | Mutation + layout (ms) | Callback 1 (ms) | Callback 2 interval (ms) | Frame wait (ms) | Avalonia backend |",
+            "|---|---:|---:|---:|---:|---:|---|"
+          )
+          foreach ($row in ($alignmentRows | Sort-Object AlignmentCallbacks, Implementation)) {
+            $backend = "$($row.RuntimePlatformServices) / $($row.RenderingSubsystem)"
+            $table += "| $($row.Implementation) | $($row.AlignmentCallbacks) | $($row.PathMs.ToString('F2')) | $($row.Callback1Ms.ToString('F2')) | $($row.Callback2Ms.ToString('F2')) | $($row.FrameMs.ToString('F2')) | $backend |"
           }
           $table | Add-Content $env:GITHUB_STEP_SUMMARY
           $aggregates | ConvertTo-Json | Set-Content "$results/aggregate.json"

--- a/docfx/articles/container-customization.md
+++ b/docfx/articles/container-customization.md
@@ -12,21 +12,110 @@ content, behavior, and lifecycle through the supported extension points below.
 | Attach and clear per-realization integration state | `CellPrepared`, `CellClearing`, `LoadingRow`, and `UnloadingRow` |
 | Render a display value without a nested retained display control | supported drawn display mode or `DataGridCustomDrawingColumn` |
 | Observe or veto grid state transitions | editing, committed-value, and transactional selection events |
+| Replace the outer virtualized containers | `DataGrid.RealizationFactory` |
 
-These paths preserve the grid-owned `DataGridRow` and `DataGridCell` containers.
-That ownership is significant: the containers carry frozen-region membership,
-row/column indexes, selection and current-cell state, validation, automation,
-editing overlays, diagnostics, and recycle-pool identity.
+Prefer themes, templates, and columns when they can express the customization. A
+realization factory is the lower-level migration hook for applications that require
+`DataGridRow`, `DataGridCell`, or `DataGridColumnHeader` subclasses.
 
 ## Container ownership
 
-There is no public row or cell container factory. Grid-owned containers preserve
-keyboard navigation, validation, selection, row details, accessibility, diagnostics,
-frozen-region behavior, and recycling correctness. Use a template, theme, column,
-draw-operation, or lifecycle event from the table above instead of replacing the
-container itself.
+`DataGridRealizationFactory` replaces only the outer containers. The grid still owns
+their lifetime, preparation, layout, selection, editing, validation, automation, and
+recycling. Columns still own display content, editors, values, sorting, filtering,
+search, grouping, clipboard/export data, and persistence semantics. Never derive a
+semantic value from a realized cell: virtualization means most cells do not exist.
+
+The request contexts expose:
+
+- the owning grid;
+- the row data context and normalized application item;
+- the `HierarchicalNode`, flattened row index, and slot when applicable;
+- the owning row and column for cells; and
+- left/right frozen-region state for column headers.
+
+Call `CreateDefaultContainer()` from a context when a request does not need a custom
+container. The grid performs the normal preparation after the factory returns it.
+
+## Recycling keys
+
+Each container kind has a data-side key overload and an element-side key overload.
+Return equal, stable keys only when the existing element is compatible with the new
+request. The grid keeps row pools partitioned by key, rebuilds incompatible cells on
+a recycled row, and replaces an incompatible cached header. Return `null` on either
+side to disable reuse for that request or element.
+
+The shared `DataGridRealizationFactory.Default` keeps the legacy fast path. Assigning
+a different factory clears old pools and regenerates realized rows, cells, and headers,
+so containers from different factories cannot mix. Replacing a factory also ends an
+active edit through the grid's normal commit-or-cancel path.
+
+## Example
+
+The following factory alternates row and cell subclasses by application item. The
+subclasses reuse the built-in themes through `StyleKeyOverride`; an application can
+instead provide dedicated control themes for its custom types.
+
+```csharp
+public sealed record OrderRow(int Id);
+
+public sealed class EvenOrderRow : DataGridRow
+{
+    protected override Type StyleKeyOverride => typeof(DataGridRow);
+}
+
+public sealed class OddOrderRow : DataGridRow
+{
+    protected override Type StyleKeyOverride => typeof(DataGridRow);
+}
+
+public sealed class EvenOrderCell : DataGridCell
+{
+    protected override Type StyleKeyOverride => typeof(DataGridCell);
+}
+
+public sealed class OddOrderCell : DataGridCell
+{
+    protected override Type StyleKeyOverride => typeof(DataGridCell);
+}
+
+public sealed class OrderRealizationFactory : DataGridRealizationFactory
+{
+    public override DataGridRow CreateRow(DataGridRowRealizationContext context) =>
+        IsEven(context.Item) ? new EvenOrderRow() : new OddOrderRow();
+
+    public override object? GetRowRecyclingKey(DataGridRowRealizationContext context) =>
+        IsEven(context.Item) ? typeof(EvenOrderRow) : typeof(OddOrderRow);
+
+    public override object? GetRowRecyclingKey(DataGridRow row) => row.GetType();
+
+    public override DataGridCell CreateCell(DataGridCellRealizationContext context) =>
+        IsEven(context.Item) ? new EvenOrderCell() : new OddOrderCell();
+
+    public override object? GetCellRecyclingKey(DataGridCellRealizationContext context) =>
+        IsEven(context.Item) ? typeof(EvenOrderCell) : typeof(OddOrderCell);
+
+    public override object? GetCellRecyclingKey(DataGridCell cell) => cell.GetType();
+
+    private static bool IsEven(object? item) => item is OrderRow row && (row.Id & 1) == 0;
+}
+```
+
+Register the factory as a resource rather than constructing it in view code-behind:
+
+```xml
+<Window.Resources>
+  <local:OrderRealizationFactory x:Key="OrderRealizationFactory" />
+</Window.Resources>
+
+<DataGrid RealizationFactory="{StaticResource OrderRealizationFactory}" />
+```
+
+Items that are already `DataGridRow` containers keep the existing own-container
+behavior and do not require a factory-created row.
 
 ## Compatibility
 
-No existing customization API changes. Existing themes and templates remain the
-compatibility default; optimized and drawn display paths are opt-in.
+No existing customization API changes. `DataGridRealizationFactory.Default`, existing
+themes and templates, and column-selected direct/drawn display paths remain the
+compatibility default.

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRealizationFactoryTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRealizationFactoryTests.cs
@@ -1,0 +1,372 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests;
+
+public class DataGridRealizationFactoryTests
+{
+    [AvaloniaFact]
+    public void Factory_Creates_And_Partitions_Flat_Row_Cell_And_Header_Containers()
+    {
+        var items = Enumerable.Range(0, 100).Select(index => new Item(index)).ToList();
+        var factory = new PartitionedFactory();
+        var (window, grid) = CreateGrid(items, factory, columnCount: 3);
+        grid.FrozenColumnCount = 1;
+        grid.FrozenColumnCountRight = 1;
+
+        window.Show();
+        grid.UpdateLayout();
+
+        AssertRealizedContainerTypes(grid);
+        DataGridColumnHeader[] headers = grid.GetVisualDescendants()
+            .OfType<DataGridColumnHeader>()
+            .Where(header => header.OwningColumn is not null)
+            .ToArray();
+        Assert.Contains(headers, header => header is LeftHeader);
+        Assert.Contains(headers, header => header is CenterHeader);
+        Assert.Contains(headers, header => header is RightHeader);
+
+        DataGridColumnHeader[] frozenHeaders = headers
+            .Where(header => header is LeftHeader or RightHeader)
+            .ToArray();
+        grid.FrozenColumnCount = 0;
+        grid.FrozenColumnCountRight = 0;
+        grid.UpdateLayout();
+
+        Assert.All(
+            grid.GetVisualDescendants()
+                .OfType<DataGridColumnHeader>()
+                .Where(header => header.OwningColumn is not null),
+            header => Assert.IsType<CenterHeader>(header));
+        Assert.DoesNotContain(frozenHeaders, header => header.IsAttachedToVisualTree());
+
+        grid.ScrollIntoView(items[80], grid.ColumnsInternal[0]);
+        grid.UpdateLayout();
+
+        AssertRealizedContainerTypes(grid);
+        Assert.True(factory.RowContexts > 0);
+        Assert.True(factory.CellContexts > 0);
+        Assert.True(factory.HeaderContexts >= 3);
+    }
+
+    [AvaloniaFact]
+    public void Factory_Receives_Hierarchy_Node_And_Application_Item()
+    {
+        var root = new HierarchyItem(0);
+        root.Children.Add(new HierarchyItem(1));
+        root.Children.Add(new HierarchyItem(2));
+        root.Children[0].Children.Add(new HierarchyItem(3));
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = item => ((HierarchyItem)item).Children,
+            IsLeafSelector = item => ((HierarchyItem)item).Children.Count == 0,
+        });
+        model.SetRoot(root);
+        model.ExpandAll();
+        var factory = new HierarchyFactory();
+        var grid = new DataGrid
+        {
+            Width = 420,
+            Height = 220,
+            AutoGenerateColumns = false,
+            HierarchicalRowsEnabled = true,
+            HierarchicalModel = model,
+            ItemsSource = model.ObservableFlattened,
+            RealizationFactory = factory,
+            UseLogicalScrollable = true,
+            RowHeight = 24,
+        };
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(HierarchyItem.Id)),
+        });
+        var window = new Window { Width = 440, Height = 240 };
+        window.SetThemeStyles();
+        window.Content = grid;
+
+        window.Show();
+        grid.UpdateLayout();
+
+        Assert.NotEmpty(grid.GetVisualDescendants().OfType<HierarchyRow>());
+        Assert.NotEmpty(grid.GetVisualDescendants().OfType<HierarchyCell>());
+        Assert.True(factory.SawHierarchicalNode);
+        Assert.True(factory.SawApplicationItem);
+    }
+
+    [AvaloniaFact]
+    public void Replacing_Factory_Regenerates_Containers_Without_Mixing_Pools()
+    {
+        var items = Enumerable.Range(0, 30).Select(index => new Item(index)).ToList();
+        var firstFactory = new GenerationFactory(firstGeneration: true);
+        var (window, grid) = CreateGrid(items, firstFactory, columnCount: 1);
+
+        window.Show();
+        grid.UpdateLayout();
+        grid.SelectedItem = items[2];
+        grid.UpdateLayout();
+        FirstRow[] firstRows = grid.GetVisualDescendants().OfType<FirstRow>().ToArray();
+        FirstCell[] firstCells = grid.GetVisualDescendants().OfType<FirstCell>().ToArray();
+        FirstHeader[] firstHeaders = grid.GetVisualDescendants().OfType<FirstHeader>().ToArray();
+        Assert.NotEmpty(firstRows);
+        Assert.NotEmpty(firstCells);
+        Assert.NotEmpty(firstHeaders);
+
+        grid.RealizationFactory = new GenerationFactory(firstGeneration: false);
+        grid.UpdateLayout();
+
+        Assert.Same(items[2], grid.SelectedItem);
+        Assert.NotEmpty(grid.GetVisualDescendants().OfType<SecondRow>());
+        Assert.NotEmpty(grid.GetVisualDescendants().OfType<SecondCell>());
+        Assert.NotEmpty(grid.GetVisualDescendants().OfType<SecondHeader>());
+        Assert.DoesNotContain(firstRows, row => row.IsAttachedToVisualTree());
+        Assert.DoesNotContain(firstCells, cell => cell.IsAttachedToVisualTree());
+        Assert.DoesNotContain(firstHeaders, header => header.IsAttachedToVisualTree());
+    }
+
+    [AvaloniaFact]
+    public void Default_Factory_Preserves_Column_Selected_Cell_Types()
+    {
+        var items = new[] { new Item(1) };
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ItemsSource = items,
+            RealizationFactory = DataGridRealizationFactory.Default,
+        };
+        var text = new DataGridTextColumn
+        {
+            Binding = new Binding(nameof(Item.Id)),
+            UseDirectTextCell = true,
+        };
+        grid.Columns.Add(text);
+        var window = new Window { Width = 320, Height = 180 };
+        window.SetThemeStyles();
+        window.Content = grid;
+
+        window.Show();
+        grid.UpdateLayout();
+
+        Assert.IsType<DataGridRow>(grid.GetVisualDescendants().OfType<DataGridRow>().First());
+        Assert.IsType<DataGridDirectTextCell>(grid.GetVisualDescendants().OfType<DataGridCell>().First());
+        Assert.IsType<DataGridColumnHeader>(text.HeaderCell);
+    }
+
+    [AvaloniaFact]
+    public void Factory_Cannot_Be_Null()
+    {
+        var grid = new DataGrid();
+
+        Assert.Throws<ArgumentNullException>(() => grid.RealizationFactory = null!);
+        Assert.Same(DataGridRealizationFactory.Default, grid.RealizationFactory);
+    }
+
+    private static (Window Window, DataGrid Grid) CreateGrid(
+        IReadOnlyList<Item> items,
+        DataGridRealizationFactory factory,
+        int columnCount)
+    {
+        var grid = new DataGrid
+        {
+            Width = 420,
+            Height = 144,
+            AutoGenerateColumns = false,
+            ItemsSource = items,
+            RealizationFactory = factory,
+            UseLogicalScrollable = true,
+            RowHeight = 24,
+        };
+        for (int index = 0; index < columnCount; index++)
+        {
+            grid.Columns.Add(new DataGridTextColumn
+            {
+                Header = $"Column {index}",
+                Binding = new Binding(nameof(Item.Id)),
+            });
+        }
+
+        var window = new Window { Width = 440, Height = 180 };
+        window.SetThemeStyles();
+        window.Content = grid;
+        return (window, grid);
+    }
+
+    private static void AssertRealizedContainerTypes(DataGrid grid)
+    {
+        DataGridRow[] rows = grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Where(row => row.Slot >= 0)
+            .ToArray();
+        Assert.NotEmpty(rows);
+        Assert.All(rows, row =>
+        {
+            Item item = Assert.IsType<Item>(row.DataContext);
+            if ((item.Id & 1) == 0)
+            {
+                Assert.IsType<EvenRow>(row);
+                Assert.All(
+                    Enumerable.Range(0, row.Cells.Count).Select(index => row.Cells[index]),
+                    cell => Assert.IsType<EvenCell>(cell));
+            }
+            else
+            {
+                Assert.IsType<OddRow>(row);
+                Assert.All(
+                    Enumerable.Range(0, row.Cells.Count).Select(index => row.Cells[index]),
+                    cell => Assert.IsType<OddCell>(cell));
+            }
+        });
+    }
+
+    private sealed record Item(int Id);
+
+    private sealed class HierarchyItem
+    {
+        public HierarchyItem(int id) => Id = id;
+
+        public int Id { get; }
+
+        public ObservableCollection<HierarchyItem> Children { get; } = new();
+    }
+
+    private abstract class StyledRow : DataGridRow
+    {
+        protected override Type StyleKeyOverride => typeof(DataGridRow);
+    }
+
+    private abstract class StyledCell : DataGridCell
+    {
+        protected override Type StyleKeyOverride => typeof(DataGridCell);
+    }
+
+    private abstract class StyledHeader : DataGridColumnHeader
+    {
+        protected override Type StyleKeyOverride => typeof(DataGridColumnHeader);
+    }
+
+    private sealed class EvenRow : StyledRow;
+    private sealed class OddRow : StyledRow;
+    private sealed class EvenCell : StyledCell;
+    private sealed class OddCell : StyledCell;
+    private sealed class LeftHeader : StyledHeader;
+    private sealed class CenterHeader : StyledHeader;
+    private sealed class RightHeader : StyledHeader;
+    private sealed class HierarchyRow : StyledRow;
+    private sealed class HierarchyCell : StyledCell;
+    private sealed class FirstRow : StyledRow;
+    private sealed class SecondRow : StyledRow;
+    private sealed class FirstCell : StyledCell;
+    private sealed class SecondCell : StyledCell;
+    private sealed class FirstHeader : StyledHeader;
+    private sealed class SecondHeader : StyledHeader;
+
+    private sealed class PartitionedFactory : DataGridRealizationFactory
+    {
+        public int RowContexts { get; private set; }
+        public int CellContexts { get; private set; }
+        public int HeaderContexts { get; private set; }
+
+        public override DataGridRow CreateRow(DataGridRowRealizationContext context)
+        {
+            RowContexts++;
+            return (((Item)context.Item).Id & 1) == 0 ? new EvenRow() : new OddRow();
+        }
+
+        public override object? GetRowRecyclingKey(DataGridRowRealizationContext context) =>
+            (((Item)context.Item).Id & 1) == 0 ? typeof(EvenRow) : typeof(OddRow);
+
+        public override object? GetRowRecyclingKey(DataGridRow row) => row.GetType();
+
+        public override DataGridCell CreateCell(DataGridCellRealizationContext context)
+        {
+            CellContexts++;
+            return (((Item)context.Item).Id & 1) == 0 ? new EvenCell() : new OddCell();
+        }
+
+        public override object? GetCellRecyclingKey(DataGridCellRealizationContext context) =>
+            (((Item)context.Item).Id & 1) == 0 ? typeof(EvenCell) : typeof(OddCell);
+
+        public override object? GetCellRecyclingKey(DataGridCell cell) => cell.GetType();
+
+        public override DataGridColumnHeader CreateColumnHeader(DataGridColumnHeaderRealizationContext context)
+        {
+            HeaderContexts++;
+            return context.IsFrozenLeft ? new LeftHeader() :
+                context.IsFrozenRight ? new RightHeader() : new CenterHeader();
+        }
+
+        public override object? GetColumnHeaderRecyclingKey(DataGridColumnHeaderRealizationContext context) =>
+            context.IsFrozenLeft ? typeof(LeftHeader) :
+            context.IsFrozenRight ? typeof(RightHeader) : typeof(CenterHeader);
+
+        public override object? GetColumnHeaderRecyclingKey(DataGridColumnHeader header) => header.GetType();
+    }
+
+    private sealed class HierarchyFactory : DataGridRealizationFactory
+    {
+        public bool SawHierarchicalNode { get; private set; }
+        public bool SawApplicationItem { get; private set; }
+
+        public override DataGridRow CreateRow(DataGridRowRealizationContext context)
+        {
+            SawHierarchicalNode |= context.HierarchicalNode is not null;
+            SawApplicationItem |= context.Item is HierarchyItem;
+            return new HierarchyRow();
+        }
+
+        public override DataGridCell CreateCell(DataGridCellRealizationContext context)
+        {
+            SawHierarchicalNode |= context.HierarchicalNode is not null;
+            SawApplicationItem |= context.Item is HierarchyItem;
+            return new HierarchyCell();
+        }
+
+        public override object? GetRowRecyclingKey(DataGridRowRealizationContext context) => typeof(HierarchyRow);
+        public override object? GetRowRecyclingKey(DataGridRow row) => typeof(HierarchyRow);
+        public override object? GetCellRecyclingKey(DataGridCellRealizationContext context) => typeof(HierarchyCell);
+        public override object? GetCellRecyclingKey(DataGridCell cell) => typeof(HierarchyCell);
+    }
+
+    private sealed class GenerationFactory : DataGridRealizationFactory
+    {
+        private readonly bool _firstGeneration;
+
+        public GenerationFactory(bool firstGeneration) => _firstGeneration = firstGeneration;
+
+        public override DataGridRow CreateRow(DataGridRowRealizationContext context) =>
+            _firstGeneration ? new FirstRow() : new SecondRow();
+
+        public override object? GetRowRecyclingKey(DataGridRowRealizationContext context) =>
+            _firstGeneration ? typeof(FirstRow) : typeof(SecondRow);
+
+        public override object? GetRowRecyclingKey(DataGridRow row) => row.GetType();
+
+        public override DataGridCell CreateCell(DataGridCellRealizationContext context) =>
+            _firstGeneration ? new FirstCell() : new SecondCell();
+
+        public override object? GetCellRecyclingKey(DataGridCellRealizationContext context) =>
+            _firstGeneration ? typeof(FirstCell) : typeof(SecondCell);
+
+        public override object? GetCellRecyclingKey(DataGridCell cell) => cell.GetType();
+
+        public override DataGridColumnHeader CreateColumnHeader(DataGridColumnHeaderRealizationContext context) =>
+            _firstGeneration ? new FirstHeader() : new SecondHeader();
+
+        public override object? GetColumnHeaderRecyclingKey(DataGridColumnHeaderRealizationContext context) =>
+            _firstGeneration ? typeof(FirstHeader) : typeof(SecondHeader);
+
+        public override object? GetColumnHeaderRecyclingKey(DataGridColumnHeader header) => header.GetType();
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
@@ -1213,6 +1213,9 @@ public class HierarchicalHeadlessTests
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalSelectionRemap", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalIndentationRefresh", activities);
+        Assert.Equal(
+            1,
+            activities.Count(x => x == "ProDataGrid.DataGrid.HierarchicalIndentationRefresh"));
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange", activities);
         Assert.DoesNotContain("ProDataGrid.DataGrid.RefreshRowsAndColumns", activities);
         Assert.Same(firstRootRow, grid.DisplayData.GetDisplayedElement(0));
@@ -1228,6 +1231,9 @@ public class HierarchicalHeadlessTests
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalSelectionRemap", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalIndentationRefresh", activities);
+        Assert.Equal(
+            1,
+            activities.Count(x => x == "ProDataGrid.DataGrid.HierarchicalIndentationRefresh"));
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange", activities);
         Assert.DoesNotContain("ProDataGrid.DataGrid.RefreshRowsAndColumns", activities);
         Assert.Same(firstRootRow, grid.DisplayData.GetDisplayedElement(0));

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
@@ -1152,7 +1152,7 @@ public class HierarchicalHeadlessTests
     }
 
     [AvaloniaFact]
-    public void Attached_Large_Whole_Range_Expand_Uses_Hierarchy_Bulk_Splice()
+    public void Attached_Large_Whole_Range_Expand_And_Collapse_Use_Hierarchy_Bulk_Splice()
     {
         var roots = new ObservableCollection<Item>
         {
@@ -1209,6 +1209,21 @@ public class HierarchicalHeadlessTests
 
         Assert.Equal(602, grid.SlotCount);
         Assert.Contains("ProDataGrid.Hierarchy.ExpandAll", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalFlattenedChanged", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalSelectionRemap", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalIndentationRefresh", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange", activities);
+        Assert.DoesNotContain("ProDataGrid.DataGrid.RefreshRowsAndColumns", activities);
+        Assert.Same(firstRootRow, grid.DisplayData.GetDisplayedElement(0));
+        ValidateDisplayedRows(grid, model);
+
+        activities.Clear();
+        model.CollapseAll();
+        PumpLayout(grid);
+
+        Assert.Equal(2, grid.SlotCount);
+        Assert.Contains("ProDataGrid.Hierarchy.CollapseAll", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalFlattenedChanged", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalSelectionRemap", activities);

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
@@ -1208,7 +1208,12 @@ public class HierarchicalHeadlessTests
         PumpLayout(grid);
 
         Assert.Equal(602, grid.SlotCount);
+        Assert.Contains("ProDataGrid.Hierarchy.ExpandAll", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalFlattenedChanged", activities);
         Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalSelectionRemap", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalIndentationRefresh", activities);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange", activities);
         Assert.DoesNotContain("ProDataGrid.DataGrid.RefreshRowsAndColumns", activities);
         Assert.Same(firstRootRow, grid.DisplayData.GetDisplayedElement(0));
         ValidateDisplayedRows(grid, model);

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -1088,6 +1089,128 @@ public class HierarchicalHeadlessTests
             $"offset={collapsedPresenter.Offset}, extent={collapsedPresenter.Extent}, " +
             $"viewport={collapsedPresenter.Viewport}, slots={grid.SlotCount}.");
         Assert.Same(root, grid.SelectedItem);
+        ValidateDisplayedRows(grid, model);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Attached_Large_Expand_Below_Viewport_Preserves_Realized_Root_Row()
+    {
+        var root = CreateTree("Root", childCount: 300, grandchildCount: 0);
+        using var themeScope = UseApplicationTheme(DataGridTheme.SimpleV2);
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = value => ((Item)value).Children,
+            VirtualizeChildren = false
+        });
+        model.SetRoot(root);
+
+        var grid = new DataGrid
+        {
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+            AutoGenerateColumns = false,
+            ItemsSource = model.Flattened,
+            UseLogicalScrollable = true,
+            RowHeight = 24,
+            SummaryRecalculationDelayMs = 0
+        };
+        grid.ColumnsInternal.Add(new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Binding = new Binding("Item.Name")
+        });
+
+        var window = new Window
+        {
+            Width = 420,
+            Height = 260,
+            Content = grid
+        };
+
+        window.SetThemeStyles(DataGridTheme.SimpleV2);
+        window.Show();
+        PumpLayout(grid);
+
+        var rootRow = Assert.Single(GetVisibleRows(grid));
+        var unloadedRows = 0;
+        var summaryRecalculations = 0;
+        grid.UnloadingRow += (_, _) => unloadedRows++;
+        grid.SummaryRecalculated += (_, _) => summaryRecalculations++;
+
+        model.ExpandAll();
+        PumpLayout(grid);
+
+        Assert.Equal(301, grid.SlotCount);
+        Assert.Equal(0, unloadedRows);
+        Assert.Equal(0, summaryRecalculations);
+        Assert.Same(rootRow, GetVisibleRows(grid).Single(row => row.Index == 0));
+        ValidateDisplayedRows(grid, model);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Attached_Large_Whole_Range_Expand_Uses_Hierarchy_Bulk_Splice()
+    {
+        var roots = new ObservableCollection<Item>
+        {
+            CreateTree("Root A", childCount: 300, grandchildCount: 0),
+            CreateTree("Root B", childCount: 300, grandchildCount: 0)
+        };
+        using var themeScope = UseApplicationTheme(DataGridTheme.SimpleV2);
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = value => ((Item)value).Children,
+            VirtualizeChildren = false
+        });
+        model.SetRoots(roots);
+
+        var grid = new DataGrid
+        {
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+            AutoGenerateColumns = false,
+            ItemsSource = model.Flattened,
+            UseLogicalScrollable = true,
+            RowHeight = 24
+        };
+        grid.ColumnsInternal.Add(new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Binding = new Binding("Item.Name")
+        });
+
+        var window = new Window
+        {
+            Width = 420,
+            Height = 260,
+            Content = grid
+        };
+
+        window.SetThemeStyles(DataGridTheme.SimpleV2);
+        window.Show();
+        PumpLayout(grid);
+        var firstRootRow = Assert.IsType<DataGridRow>(grid.DisplayData.GetDisplayedElement(0));
+
+        var activities = new List<string>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DataGridDiagnostics.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => activities.Add(activity.OperationName)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        model.ExpandAll();
+        PumpLayout(grid);
+
+        Assert.Equal(602, grid.SlotCount);
+        Assert.Contains("ProDataGrid.DataGrid.HierarchicalBulkSplice", activities);
+        Assert.DoesNotContain("ProDataGrid.DataGrid.RefreshRowsAndColumns", activities);
+        Assert.Same(firstRootRow, grid.DisplayData.GetDisplayedElement(0));
         ValidateDisplayedRows(grid, model);
 
         window.Close();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -1563,6 +1563,27 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
     }
 
     [Fact]
+    public void BuildIndexMap_MapsOrderedRetainedNodesAcrossRemovals()
+    {
+        var retainedA = (HierarchicalNode)RuntimeHelpers.GetUninitializedObject(typeof(HierarchicalNode));
+        var removedA = (HierarchicalNode)RuntimeHelpers.GetUninitializedObject(typeof(HierarchicalNode));
+        var removedB = (HierarchicalNode)RuntimeHelpers.GetUninitializedObject(typeof(HierarchicalNode));
+        var retainedB = (HierarchicalNode)RuntimeHelpers.GetUninitializedObject(typeof(HierarchicalNode));
+
+        var map = HierarchicalModel.BuildIndexMap(
+            new[] { retainedA, removedA, removedB, retainedB },
+            oldStartIndex: 4,
+            new[] { retainedA, retainedB },
+            newStartIndex: 7);
+
+        Assert.NotNull(map);
+        Assert.Equal(7, map![4]);
+        Assert.Equal(8, map[7]);
+        Assert.False(map.ContainsKey(5));
+        Assert.False(map.ContainsKey(6));
+    }
+
+    [Fact]
     public void ExpandAll_PublishesFinalFlattenedStateBeforeExpandedStateEvents()
     {
         var root = new Item("root");
@@ -2058,6 +2079,154 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         Assert.False(model.Root!.IsExpanded);
         Assert.Equal(1, model.Count);
         Assert.Equal(0, model.Root!.ExpandedCount);
+    }
+
+    [Fact]
+    public void CollapseAll_CommitsOneCoherentFlattenedChangeBeforeLifecycleEvents()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        child.Children.Add(new Item("grand"));
+        root.Children.Add(child);
+
+        var model = CreateModel();
+        model.SetRoot(root);
+        model.ExpandAll();
+        var rootNode = model.Root!;
+        var childNode = model.GetNode(1);
+        var events = new List<string>();
+        var collectionChanges = new List<NotifyCollectionChangedEventArgs>();
+        model.FlattenedChanged += (_, args) =>
+        {
+            Assert.Single(model.Flattened);
+            Assert.False(rootNode.IsExpanded);
+            Assert.False(childNode.IsExpanded);
+            FlattenedChange change = Assert.Single(args.Changes);
+            Assert.Equal(1, change.Index);
+            Assert.Equal(2, change.OldCount);
+            Assert.Equal(0, change.NewCount);
+            events.Add("flattened");
+        };
+        ((INotifyCollectionChanged)model.ObservableFlattened).CollectionChanged +=
+            (_, args) => collectionChanges.Add(args);
+        rootNode.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(HierarchicalNode.IsExpanded))
+            {
+                events.Add("root-property");
+            }
+        };
+        childNode.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(HierarchicalNode.IsExpanded))
+            {
+                events.Add("child-property");
+            }
+        };
+        model.NodeCollapsed += (_, args) =>
+            events.Add($"collapsed:{((Item)args.Node.Item).Name}");
+
+        model.CollapseAll();
+
+        Assert.Single(collectionChanges);
+        Assert.Equal(NotifyCollectionChangedAction.Remove, collectionChanges[0].Action);
+        Assert.Equal(
+            new[]
+            {
+                "flattened",
+                "root-property",
+                "collapsed:root",
+                "child-property",
+                "collapsed:child"
+            },
+            events);
+    }
+
+    [Fact]
+    public void CollapseAll_VirtualRootRetainsRootIdentityMapInSingleCommit()
+    {
+        var first = new Item("first");
+        var second = new Item("second");
+        first.Children.Add(new Item("first-child"));
+        second.Children.Add(new Item("second-child"));
+        var model = CreateModel();
+        model.SetRoots(new[] { first, second });
+        model.ExpandAll();
+        FlattenedChangedEventArgs? flattenedChanged = null;
+        var collectionChanges = 0;
+        model.FlattenedChanged += (_, args) => flattenedChanged = args;
+        ((INotifyCollectionChanged)model.ObservableFlattened).CollectionChanged +=
+            (_, _) => collectionChanges++;
+
+        model.CollapseAll();
+
+        Assert.NotNull(flattenedChanged);
+        FlattenedChange change = Assert.Single(flattenedChanged!.Changes);
+        Assert.Equal(0, change.Index);
+        Assert.Equal(4, change.OldCount);
+        Assert.Equal(2, change.NewCount);
+        Assert.Equal(0, flattenedChanged.IndexMap.MapOldIndexToNew(0));
+        Assert.Equal(1, flattenedChanged.IndexMap.MapOldIndexToNew(2));
+        Assert.Equal(1, collectionChanges);
+        Assert.Equal(new[] { first, second }, model.Flattened.Select(node => node.Item));
+    }
+
+    [Fact]
+    public void CollapseAll_VirtualizesOnlyAfterPublishingCollapsedLifecycleEvents()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        child.Children.Add(new Item("grand"));
+        root.Children.Add(child);
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = item => ((Item)item).Children,
+            VirtualizeChildren = true
+        });
+        model.SetRoot(root);
+        model.ExpandAll();
+        var rootNode = model.Root!;
+        var childNode = model.GetNode(1);
+        model.NodeCollapsed += (_, args) =>
+        {
+            Assert.NotEmpty(rootNode.Children);
+            if (ReferenceEquals(args.Node, childNode))
+            {
+                Assert.NotEmpty(childNode.Children);
+            }
+        };
+
+        model.CollapseAll();
+
+        Assert.Single(model.Flattened);
+        Assert.Empty(rootNode.Children);
+        Assert.False(rootNode.HasMaterializedChildren);
+    }
+
+    [Fact]
+    public void CollapseAll_VirtualizationGuardDefersOneOutermostSubtreeCull()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        child.Children.Add(new Item("grand"));
+        root.Children.Add(child);
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelector = item => ((Item)item).Children,
+            VirtualizeChildren = false
+        });
+        model.SetRoot(root);
+        model.ExpandAll();
+        var rootNode = model.Root!;
+
+        using (model.BeginVirtualizationGuard())
+        {
+            model.CollapseAll();
+            Assert.NotEmpty(rootNode.Children);
+        }
+
+        Assert.Empty(rootNode.Children);
+        Assert.False(rootNode.HasMaterializedChildren);
     }
 
     [Fact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -2082,6 +2082,27 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
     }
 
     [Fact]
+    public void CollapseAll_RaisesTypedLifecycleEventsWithoutBaseSubscriptions()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        child.Children.Add(new Item("grand"));
+        root.Children.Add(child);
+        var model = new HierarchicalModel<Item>(new HierarchicalOptions<Item>
+        {
+            ChildrenSelector = item => item.Children
+        });
+        model.SetRoot(root);
+        model.ExpandAll();
+        var collapsed = new List<string>();
+        model.NodeCollapsedTyped += (_, args) => collapsed.Add(args.Node.Item.Name);
+
+        model.CollapseAll();
+
+        Assert.Equal(new[] { "root", "child" }, collapsed);
+    }
+
+    [Fact]
     public void CollapseAll_CommitsOneCoherentFlattenedChangeBeforeLifecycleEvents()
     {
         var root = new Item("root");

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Hierarchical.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Hierarchical.cs
@@ -176,6 +176,7 @@ namespace Avalonia.Controls
 
         private void RefreshHierarchicalIndentation()
         {
+            using var activity = DataGridDiagnostics.HierarchicalIndentationRefresh();
             if (!_hierarchicalRowsEnabled || DisplayData == null)
             {
                 return;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layout.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layout.cs
@@ -295,7 +295,7 @@ internal
 
         private void AddNewCellPrivate(DataGridRow row, DataGridColumn column)
         {
-            DataGridCell newCell = column.CreateCell();
+            DataGridCell newCell = CreateCellContainer(row, column);
             if (row.OwningGrid != null)
             {
                 newCell.OwningColumn = column;
@@ -329,7 +329,10 @@ internal
             {
                 for (var columnIndex = 0; columnIndex < expectedCellCount; columnIndex++)
                 {
-                    if (!ReferenceEquals(dataGridRow.Cells[columnIndex].OwningColumn, ColumnsItemsInternal[columnIndex]))
+                    DataGridColumn column = ColumnsItemsInternal[columnIndex];
+                    DataGridCell cell = dataGridRow.Cells[columnIndex];
+                    if (!ReferenceEquals(cell.OwningColumn, column) ||
+                        !CanReuseCellContainer(dataGridRow, column, cell))
                     {
                         shouldRebuildCells = true;
                         break;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Realization.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Realization.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Controls;
+
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+partial class DataGrid
+{
+    /// <summary>
+    /// Identifies the <see cref="RealizationFactory"/> direct property.
+    /// </summary>
+    public static readonly DirectProperty<DataGrid, DataGridRealizationFactory> RealizationFactoryProperty =
+        AvaloniaProperty.RegisterDirect<DataGrid, DataGridRealizationFactory>(
+            nameof(RealizationFactory),
+            grid => grid.RealizationFactory,
+            (grid, value) => grid.RealizationFactory = value);
+
+    private DataGridRealizationFactory _realizationFactory = DataGridRealizationFactory.Default;
+
+    /// <summary>
+    /// Gets or sets the factory used to create row, cell, and column-header containers.
+    /// </summary>
+    /// <remarks>
+    /// Changing the factory invalidates cached headers and realized or recycled row/cell
+    /// containers so instances created by different factories cannot share a pool.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// The assigned value is <see langword="null"/>.
+    /// </exception>
+    public DataGridRealizationFactory RealizationFactory
+    {
+        get => _realizationFactory;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (!SetAndRaise(RealizationFactoryProperty, ref _realizationFactory, value))
+            {
+                return;
+            }
+
+            OnRealizationFactoryChanged();
+        }
+    }
+
+    internal bool UsesDefaultRealizationFactory =>
+        ReferenceEquals(_realizationFactory, DataGridRealizationFactory.Default);
+
+    internal DataGridRow CreateRowContainer(object? dataContext, int rowIndex, int slot)
+    {
+        if (UsesDefaultRealizationFactory)
+        {
+            return new DataGridRow();
+        }
+
+        var context = new DataGridRowRealizationContext(this, dataContext, rowIndex, slot);
+        return _realizationFactory.CreateRow(context) ??
+            throw new InvalidOperationException("The realization factory returned a null row container.");
+    }
+
+    internal object? GetRowRecyclingKey(object? dataContext, int rowIndex, int slot) =>
+        _realizationFactory.GetRowRecyclingKey(
+            new DataGridRowRealizationContext(this, dataContext, rowIndex, slot));
+
+    internal object? GetRowRecyclingKey(DataGridRow row) =>
+        _realizationFactory.GetRowRecyclingKey(row);
+
+    private DataGridCell CreateCellContainer(DataGridRow row, DataGridColumn column)
+    {
+        if (UsesDefaultRealizationFactory)
+        {
+            return column.CreateCell();
+        }
+
+        var context = new DataGridCellRealizationContext(this, row, column);
+        return _realizationFactory.CreateCell(context) ??
+            throw new InvalidOperationException("The realization factory returned a null cell container.");
+    }
+
+    private bool CanReuseCellContainer(DataGridRow row, DataGridColumn column, DataGridCell cell)
+    {
+        if (UsesDefaultRealizationFactory)
+        {
+            return true;
+        }
+
+        var context = new DataGridCellRealizationContext(this, row, column);
+        object? requestedKey = _realizationFactory.GetCellRecyclingKey(context);
+        object? elementKey = _realizationFactory.GetCellRecyclingKey(cell);
+        return requestedKey is not null &&
+               elementKey is not null &&
+               EqualityComparer<object>.Default.Equals(requestedKey, elementKey);
+    }
+
+    internal DataGridColumnHeader CreateColumnHeaderContainer(DataGridColumn column)
+    {
+        if (UsesDefaultRealizationFactory)
+        {
+            return column.CreateHeader();
+        }
+
+        var context = new DataGridColumnHeaderRealizationContext(this, column);
+        DataGridColumnHeader header = _realizationFactory.CreateColumnHeader(context) ??
+            throw new InvalidOperationException("The realization factory returned a null column-header container.");
+        column.PrepareHeaderContainer(header);
+        if (column is DataGridFillerColumn)
+        {
+            header.IsEnabled = false;
+        }
+        return header;
+    }
+
+    internal bool CanReuseColumnHeaderContainer(DataGridColumn column, DataGridColumnHeader header)
+    {
+        if (UsesDefaultRealizationFactory)
+        {
+            return true;
+        }
+
+        var context = new DataGridColumnHeaderRealizationContext(this, column);
+        object? requestedKey = _realizationFactory.GetColumnHeaderRecyclingKey(context);
+        object? elementKey = _realizationFactory.GetColumnHeaderRecyclingKey(header);
+        return requestedKey is not null &&
+               elementKey is not null &&
+               EqualityComparer<object>.Default.Equals(requestedKey, elementKey);
+    }
+
+    internal void ReplaceDisplayedColumnHeader(
+        DataGridColumnHeader previousHeader,
+        DataGridColumnHeader replacementHeader)
+    {
+        if (_columnHeadersPresenter == null)
+        {
+            return;
+        }
+
+        int index = _columnHeadersPresenter.Children.IndexOf(previousHeader);
+        if (index < 0)
+        {
+            return;
+        }
+
+        _columnHeadersPresenter.Children.RemoveAt(index);
+        _columnHeadersPresenter.Children.Insert(index, replacementHeader);
+    }
+
+    private void OnRealizationFactoryChanged()
+    {
+        RemoveDisplayedColumnHeaders();
+        foreach (DataGridColumn column in ColumnsItemsInternal)
+        {
+            column.ClearElementCache();
+        }
+        ColumnsInternal.FillerColumn.ClearElementCache();
+
+        if (!_measured)
+        {
+            DisplayData.ClearRecyclePools();
+            return;
+        }
+
+        UnloadElements(recycle: false);
+        RefreshRowsAndColumns(clearRows: false);
+        RefreshSelectionFromModel();
+        EnsureColumnHeadersPresenterChildren();
+        InvalidateColumnHeadersMeasure();
+        InvalidateMeasure();
+    }
+
+    internal void DiscardUnkeyedRecycledRow(DataGridRow row)
+    {
+        _rowsPresenter?.UnregisterAnchorCandidate(row);
+        _rowsPresenter?.RemoveTrackedChild(row);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
@@ -59,11 +59,11 @@ namespace Avalonia.Controls
 
             if (dataGridRow == null)
             {
-                var recycledRow = DisplayData.GetRecycledRow();
+                var recycledRow = DisplayData.GetRecycledRow(dataContext, rowIndex, slot);
                 source = recycledRow != null
                     ? DataGridDiagnostics.Sources.Recycled
                     : DataGridDiagnostics.Sources.New;
-                dataGridRow = recycledRow ?? new DataGridRow();
+                dataGridRow = recycledRow ?? CreateRowContainer(dataContext, rowIndex, slot);
                 var previousDataContext = (dataGridRow.RecycledDataContext ?? dataGridRow.DataContext);
                 var hasPlaceholderTransition =
                     recycledRow != null &&

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Summaries.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Summaries.cs
@@ -760,6 +760,11 @@ internal
         /// </summary>
         internal void OnCollectionChangedForSummaries(NotifyCollectionChangedEventArgs e)
         {
+            if (!HasAnySummaries())
+            {
+                return;
+            }
+
             _summaryService?.OnCollectionChanged(e);
         }
 
@@ -768,7 +773,15 @@ internal
         /// </summary>
         internal bool HasAnySummaries()
         {
-            return Columns.Any(c => c.HasSummaries);
+            foreach (DataGridColumn column in ColumnsItemsInternal)
+            {
+                if (column.HasSummaries)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3056,8 +3056,10 @@ internal
                 _pendingHierarchicalAnchorHint = null;
             }
 
-            var canApplyChanges = CanApplyHierarchicalFlattenedChanges(e) &&
-                                  !RequiresHierarchicalBulkRefresh(e.Changes);
+            var canApplyChanges = CanApplyHierarchicalFlattenedChanges(e);
+            var requiresBulkRefresh = canApplyChanges && RequiresHierarchicalBulkRefresh(e.Changes);
+            var canApplyBulkSplice = requiresBulkRefresh && CanApplyHierarchicalBulkSplice(e.Changes, e.IndexMap);
+            canApplyChanges = canApplyChanges && !requiresBulkRefresh;
             var hasAnchor = false;
             HierarchicalAnchor anchor = default;
 
@@ -3088,7 +3090,7 @@ internal
             using (_rowsPresenter?.BeginVirtualizationGuard())
             {
                 RemapSelectionForHierarchyChange(indexMap);
-                if (canApplyChanges)
+                if (canApplyChanges || canApplyBulkSplice)
                 {
                     var suppressOffsetAdjustments = hasAnchor;
                     if (suppressOffsetAdjustments)
@@ -3097,7 +3099,14 @@ internal
                     }
                     try
                     {
-                        ApplyHierarchicalFlattenedChanges(e.Changes);
+                        if (canApplyBulkSplice)
+                        {
+                            ApplyHierarchicalBulkSplice(e.Changes[0], e.IndexMap);
+                        }
+                        else
+                        {
+                            ApplyHierarchicalFlattenedChanges(e.Changes);
+                        }
                     }
                     finally
                     {
@@ -3269,6 +3278,153 @@ internal
             }
 
             return false;
+        }
+
+        private bool CanApplyHierarchicalBulkSplice(
+            IReadOnlyList<FlattenedChange> changes,
+            Avalonia.Controls.DataGridHierarchical.FlattenedIndexMap indexMap)
+        {
+            if (changes == null ||
+                changes.Count != 1 ||
+                DisplayData == null ||
+                DisplayData.LastScrollingSlot < 0 ||
+                EditingRow != null)
+            {
+                return false;
+            }
+
+            var change = changes[0];
+            if (change.NewCount <= 0)
+            {
+                return false;
+            }
+
+            if (CanApplyHierarchicalWholeRangeReplacement(change, indexMap))
+            {
+                return true;
+            }
+
+            if (change.OldCount != 0)
+            {
+                return false;
+            }
+
+            var insertionSlot = SlotFromRowIndex(change.Index);
+            if (insertionSlot <= DisplayData.LastScrollingSlot || insertionSlot > SlotCount)
+            {
+                return false;
+            }
+
+            if (CurrentSlot >= insertionSlot ||
+                (_focusedRow != null && _focusedRow.Slot >= insertionSlot))
+            {
+                return false;
+            }
+
+            foreach (var row in _loadedRows)
+            {
+                if (row.Slot >= insertionSlot)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool CanApplyHierarchicalWholeRangeReplacement(
+            FlattenedChange change,
+            Avalonia.Controls.DataGridHierarchical.FlattenedIndexMap indexMap)
+        {
+            if (indexMap == null ||
+                change.Index != 0 ||
+                change.OldCount != SlotCount ||
+                change.NewCount != DataConnection.Count ||
+                DisplayData.FirstScrollingSlot != 0 ||
+                CurrentSlot > 0 ||
+                (_focusedRow != null && _focusedRow.Slot > 0) ||
+                RowGroupHeadersTable.RangeCount != 0 ||
+                RowGroupFootersTable.RangeCount != 0 ||
+                !_showDetailsTable.IsEmpty ||
+                !_collapsedSlotsTable.IsEmpty)
+            {
+                return false;
+            }
+
+            // A retained first row gives the existing current-cell and viewport anchor logic a
+            // stable target while the remainder of the flattened hierarchy is replaced.
+            return indexMap.MapOldIndexToNew(0) == 0;
+        }
+
+        private void ApplyHierarchicalBulkSplice(
+            FlattenedChange change,
+            Avalonia.Controls.DataGridHierarchical.FlattenedIndexMap indexMap)
+        {
+            using var activity = DataGridDiagnostics.HierarchicalBulkSplice();
+            if (CanApplyHierarchicalWholeRangeReplacement(change, indexMap))
+            {
+                ApplyHierarchicalWholeRangeReplacement(change, activity);
+                return;
+            }
+
+            var insertionSlot = SlotFromRowIndex(change.Index);
+            var insertedCount = change.NewCount;
+            activity?.SetTag(DataGridDiagnostics.Tags.Rows, insertedCount);
+            activity?.SetTag(DataGridDiagnostics.Tags.SlotCount, SlotCount);
+
+            _scrollHeightIndexDirty = true;
+            _showDetailsTable.InsertIndexes(insertionSlot, insertedCount);
+            RowGroupHeadersTable.InsertIndexes(insertionSlot, insertedCount);
+            RowGroupFootersTable.InsertIndexes(insertionSlot, insertedCount);
+            _collapsedSlotsTable.InsertIndexes(insertionSlot, insertedCount);
+
+            SlotCount += insertedCount;
+            VisibleSlotCount += insertedCount;
+            if (_lastEstimatedRow >= insertionSlot)
+            {
+                _lastEstimatedRow += insertedCount;
+            }
+
+            ComputeScrollBarsLayout();
+            InvalidateRowsArrange();
+            OnElementsChanged(grew: true);
+            RequestPointerOverRefresh();
+        }
+
+        private void ApplyHierarchicalWholeRangeReplacement(FlattenedChange change, Activity activity)
+        {
+            activity?.SetTag(DataGridDiagnostics.Tags.Rows, change.NewCount);
+            activity?.SetTag(DataGridDiagnostics.Tags.SlotCount, SlotCount);
+
+            _scrollHeightIndexDirty = true;
+            using (DisplayData.BeginDeferredRecycleScope())
+            {
+                // The first flattened row is identity-mapped to slot zero. Keep its realized
+                // container and recycle only the rows whose item mapping changed.
+                while (DisplayData.LastScrollingSlot > 0)
+                {
+                    RemoveDisplayedElement(
+                        DisplayData.LastScrollingSlot,
+                        wasDeleted: false,
+                        updateSlotInformation: true);
+                }
+
+                SlotCount = change.NewCount;
+                VisibleSlotCount = change.NewCount;
+                _lastEstimatedRow = Math.Min(_lastEstimatedRow, SlotCount - 1);
+
+                var displayHeight = CellsEstimatedHeight;
+                if (ColumnsItemsInternal.Count > 0 && MathUtilities.GreaterThan(displayHeight, 0))
+                {
+                    NegVerticalOffset = 0;
+                    UpdateDisplayedRows(0, displayHeight);
+                }
+            }
+
+            ComputeScrollBarsLayout();
+            InvalidateRowsArrange();
+            OnElementsChanged(grew: change.NewCount > change.OldCount);
+            RequestPointerOverRefresh();
         }
 
         private void ApplyHierarchicalFlattenedChanges(IReadOnlyList<FlattenedChange> changes)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3138,7 +3138,13 @@ internal
                     CurrentSlot = -1;
                 }
                 RefreshSelectionFromModel();
-                RequestHierarchicalIndentationRefresh();
+                if (!canApplyBulkSplice)
+                {
+                    // Bulk splice realizes and rebinds the final displayed range synchronously,
+                    // and RefreshHierarchicalIndentation above has already updated those rows.
+                    // Repeating it from LayoutUpdated can schedule another render interval.
+                    RequestHierarchicalIndentationRefresh();
+                }
             }
 
             OnCollectionChangedForSummaries(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3035,6 +3035,7 @@ internal
 
         private void HandleHierarchicalFlattenedChanged(FlattenedChangedEventArgs e)
         {
+            using var activity = DataGridDiagnostics.HierarchicalFlattenedChanged();
             if (!_hierarchicalRowsEnabled)
             {
                 return;
@@ -3089,7 +3090,10 @@ internal
             using (_hierarchicalModel?.BeginVirtualizationGuard())
             using (_rowsPresenter?.BeginVirtualizationGuard())
             {
-                RemapSelectionForHierarchyChange(indexMap);
+                using (DataGridDiagnostics.HierarchicalSelectionRemap())
+                {
+                    RemapSelectionForHierarchyChange(indexMap);
+                }
                 if (canApplyChanges || canApplyBulkSplice)
                 {
                     var suppressOffsetAdjustments = hasAnchor;
@@ -3450,6 +3454,7 @@ internal
 
         private void EnsureDisplayedRowsInRange()
         {
+            using var activity = DataGridDiagnostics.HierarchicalDisplayedRowsRange();
             if (DisplayData == null || DisplayData.FirstScrollingSlot < 0)
             {
                 return;

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.Cells.cs
@@ -170,10 +170,12 @@ namespace Avalonia.Controls
 
         internal virtual DataGridColumnHeader CreateHeader()
         {
-            var result = new DataGridColumnHeader
-            {
-                OwningColumn = this
-            };
+            return PrepareHeaderContainer(new DataGridColumnHeader());
+        }
+
+        internal DataGridColumnHeader PrepareHeaderContainer(DataGridColumnHeader result)
+        {
+            result.OwningColumn = this;
             _headerContentBinding?.Dispose();
             _headerTemplateBinding?.Dispose();
             _headerContentBinding = result.Bind(ContentControl.ContentProperty, this.GetObservable(HeaderProperty));
@@ -325,6 +327,11 @@ namespace Avalonia.Controls
         internal virtual void ClearElementCache()
         {
             RemoveEditingElement();
+            ClearHeaderCache();
+        }
+
+        internal void ClearHeaderCache()
+        {
             if (_headerContentBinding != null)
             {
                 _headerContentBinding.Dispose();

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -211,9 +211,22 @@ internal
         {
             get
             {
+                DataGridColumnHeader replacedHeader = null;
+                if (_headerCell != null &&
+                    OwningGrid != null &&
+                    !OwningGrid.CanReuseColumnHeaderContainer(this, _headerCell))
+                {
+                    replacedHeader = _headerCell;
+                    ClearHeaderCache();
+                }
                 if (_headerCell == null)
                 {
-                    _headerCell = CreateHeader();
+                    _headerCell = OwningGrid?.CreateColumnHeaderContainer(this) ?? CreateHeader();
+                }
+                if (replacedHeader != null)
+                {
+                    _headerCell.IsVisible = IsVisible;
+                    OwningGrid?.ReplaceDisplayedColumnHeader(replacedHeader, _headerCell);
                 }
                 return _headerCell;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Controls
     internal class DataGridDisplayData
     {
         private readonly Stack<DataGridRow> _recycledRows;
+        private readonly Dictionary<object, Stack<DataGridRow>> _keyedRecycledRows;
         private readonly Stack<DataGridRowGroupHeader> _recycledGroupHeaders;
         private readonly Stack<DataGridRowGroupFooter> _recycledGroupFooters;
         private HashSet<Control>? _deferredHideElements;
@@ -35,6 +36,7 @@ namespace Avalonia.Controls
             _owner = owner;
             _scrollingElements = new List<Control>();
             _recycledRows = new Stack<DataGridRow>();
+            _keyedRecycledRows = new Dictionary<object, Stack<DataGridRow>>();
             _recycledGroupHeaders = new Stack<DataGridRowGroupHeader>();
             _recycledGroupFooters = new Stack<DataGridRowGroupFooter>();
             ResetSlotIndexes();
@@ -70,12 +72,46 @@ namespace Avalonia.Controls
             _owner.NotifyRowRecycling(row);
             row.DetachFromDataGrid(true);
             HideElement(row);
-            PushToRecyclePool(_recycledRows, row);
+            if (_owner.UsesDefaultRealizationFactory)
+            {
+                PushToRecyclePool(_recycledRows, row);
+                return;
+            }
+
+            object? key = _owner.GetRowRecyclingKey(row);
+            if (key is null)
+            {
+                _owner.DiscardUnkeyedRecycledRow(row);
+                return;
+            }
+
+            if (!_keyedRecycledRows.TryGetValue(key, out Stack<DataGridRow>? pool))
+            {
+                pool = new Stack<DataGridRow>();
+                _keyedRecycledRows.Add(key, pool);
+            }
+            PushToRecyclePool(pool, row);
         }
 
-        internal DataGridRow? GetRecycledRow()
+        internal DataGridRow? GetRecycledRow(object dataContext, int rowIndex, int slot)
         {
-            return PopFromRecyclePool(_recycledRows, RestoreElementForReuse);
+            if (_owner.UsesDefaultRealizationFactory)
+            {
+                return PopFromRecyclePool(_recycledRows, RestoreElementForReuse);
+            }
+
+            object? key = _owner.GetRowRecyclingKey(dataContext, rowIndex, slot);
+            if (key is null || !_keyedRecycledRows.TryGetValue(key, out Stack<DataGridRow>? pool))
+            {
+                return null;
+            }
+
+            DataGridRow? row = PopFromRecyclePool(pool, RestoreElementForReuse);
+            if (pool.Count == 0)
+            {
+                _keyedRecycledRows.Remove(key);
+            }
+            return row;
         }
 
         internal void TrimRecycledPools(DataGridRowsPresenter owner, int maxRecycledRows, int maxRecycledGroupHeaders, int maxRecycledGroupFooters)
@@ -85,6 +121,44 @@ namespace Avalonia.Controls
                 var row = _recycledRows.Pop();
                 owner.UnregisterAnchorCandidate(row);
                 owner.RemoveTrackedChild(row);
+            }
+
+            int keyedRowCount = 0;
+            foreach (Stack<DataGridRow> pool in _keyedRecycledRows.Values)
+            {
+                keyedRowCount += pool.Count;
+            }
+            if (keyedRowCount > maxRecycledRows)
+            {
+                int rowsToRemove = keyedRowCount - maxRecycledRows;
+                List<object>? emptyKeys = null;
+                foreach (KeyValuePair<object, Stack<DataGridRow>> entry in _keyedRecycledRows)
+                {
+                    Stack<DataGridRow> pool = entry.Value;
+                    while (pool.Count > 0 && rowsToRemove > 0)
+                    {
+                        DataGridRow row = pool.Pop();
+                        owner.UnregisterAnchorCandidate(row);
+                        owner.RemoveTrackedChild(row);
+                        rowsToRemove--;
+                    }
+                    if (pool.Count == 0)
+                    {
+                        emptyKeys ??= new List<object>();
+                        emptyKeys.Add(entry.Key);
+                    }
+                    if (rowsToRemove == 0)
+                    {
+                        break;
+                    }
+                }
+                if (emptyKeys != null)
+                {
+                    foreach (object key in emptyKeys)
+                    {
+                        _keyedRecycledRows.Remove(key);
+                    }
+                }
             }
 
             while (_recycledGroupHeaders.Count > maxRecycledGroupHeaders)
@@ -147,6 +221,7 @@ namespace Avalonia.Controls
             else
             {
                 _recycledRows.Clear();
+                _keyedRecycledRows.Clear();
                 _recycledGroupHeaders.Clear();
                 _recycledGroupFooters.Clear();
             }
@@ -379,6 +454,14 @@ namespace Avalonia.Controls
         #endregion
 
         #region Private Helpers
+
+        internal void ClearRecyclePools()
+        {
+            _recycledRows.Clear();
+            _keyedRecycledRows.Clear();
+            _recycledGroupHeaders.Clear();
+            _recycledGroupFooters.Clear();
+        }
 
         internal DeferredRecycleScope BeginDeferredRecycleScope()
         {

--- a/src/Avalonia.Controls.DataGrid/DataGridRealizationFactory.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRealizationFactory.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable enable
+
+using System;
+using Avalonia.Controls.DataGridHierarchical;
+
+namespace Avalonia.Controls;
+
+/// <summary>
+/// Creates the outer row, cell, and column-header containers realized by a <see cref="DataGrid"/>.
+/// </summary>
+/// <remarks>
+/// Columns continue to own display content, editors, value access, validation, and semantic data
+/// operations. A realization factory replaces only the surrounding virtualized containers.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+class DataGridRealizationFactory
+{
+    /// <summary>
+    /// Gets the shared factory that creates the standard ProDataGrid containers.
+    /// </summary>
+    public static DataGridRealizationFactory Default { get; } = new();
+
+    /// <summary>
+    /// Creates a row container for the supplied realization context.
+    /// </summary>
+    /// <param name="context">The row realization request.</param>
+    /// <returns>A row container owned and prepared by the requesting grid.</returns>
+    public virtual DataGridRow CreateRow(DataGridRowRealizationContext context) =>
+        context.CreateDefaultContainer();
+
+    /// <summary>
+    /// Gets the recycling key required by a row realization request.
+    /// Return <see langword="null"/> to disable row recycling for the request.
+    /// </summary>
+    /// <param name="context">The row realization request.</param>
+    /// <returns>The requested row recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetRowRecyclingKey(DataGridRowRealizationContext context) =>
+        typeof(DataGridRow);
+
+    /// <summary>
+    /// Gets the recycling key supplied by an existing row container.
+    /// Return <see langword="null"/> to prevent the row from entering a recycle pool.
+    /// </summary>
+    /// <param name="row">The row being considered for recycling.</param>
+    /// <returns>The row's recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetRowRecyclingKey(DataGridRow row) => row.GetType();
+
+    /// <summary>
+    /// Creates a cell container for the supplied realization context.
+    /// </summary>
+    /// <param name="context">The cell realization request.</param>
+    /// <returns>A cell container owned and prepared by the requesting grid.</returns>
+    public virtual DataGridCell CreateCell(DataGridCellRealizationContext context) =>
+        context.CreateDefaultContainer();
+
+    /// <summary>
+    /// Gets the recycling key required by a cell realization request.
+    /// Return <see langword="null"/> when the cell must be recreated as its row is reused.
+    /// </summary>
+    /// <param name="context">The cell realization request.</param>
+    /// <returns>The requested cell recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetCellRecyclingKey(DataGridCellRealizationContext context) =>
+        context.Column.GetType();
+
+    /// <summary>
+    /// Gets the recycling key supplied by an existing cell container.
+    /// Return <see langword="null"/> to prevent reuse with another row assignment.
+    /// </summary>
+    /// <param name="cell">The cell being considered for reuse.</param>
+    /// <returns>The cell's recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetCellRecyclingKey(DataGridCell cell) =>
+        cell.OwningColumn?.GetType();
+
+    /// <summary>
+    /// Creates a column-header container for the supplied realization context.
+    /// </summary>
+    /// <param name="context">The column-header realization request.</param>
+    /// <returns>A column-header container owned and prepared by the requesting grid.</returns>
+    public virtual DataGridColumnHeader CreateColumnHeader(DataGridColumnHeaderRealizationContext context) =>
+        context.CreateDefaultContainer();
+
+    /// <summary>
+    /// Gets the recycling key required by a column-header realization request.
+    /// Return <see langword="null"/> when the cached header must be recreated.
+    /// </summary>
+    /// <param name="context">The column-header realization request.</param>
+    /// <returns>The requested column-header recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetColumnHeaderRecyclingKey(DataGridColumnHeaderRealizationContext context) =>
+        context.Column.GetType();
+
+    /// <summary>
+    /// Gets the recycling key supplied by an existing column-header container.
+    /// Return <see langword="null"/> to prevent reuse for a changed column context.
+    /// </summary>
+    /// <param name="header">The column header being considered for reuse.</param>
+    /// <returns>The column header's recycling key, or <see langword="null"/>.</returns>
+    public virtual object? GetColumnHeaderRecyclingKey(DataGridColumnHeader header) =>
+        header.OwningColumn?.GetType();
+}
+
+/// <summary>
+/// Describes a row container realization request.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+readonly record struct DataGridRowRealizationContext
+{
+    internal DataGridRowRealizationContext(DataGrid grid, object? dataContext, int rowIndex, int slot)
+    {
+        Grid = grid;
+        DataContext = dataContext;
+        RowIndex = rowIndex;
+        Slot = slot;
+        HierarchicalNode = dataContext as HierarchicalNode;
+    }
+
+    /// <summary>Gets the grid requesting the container.</summary>
+    public DataGrid Grid { get; }
+
+    /// <summary>Gets the actual row data context used by the grid.</summary>
+    public object? DataContext { get; }
+
+    /// <summary>Gets the application item represented by the row.</summary>
+    public object? Item => HierarchicalNode?.Item ?? DataContext;
+
+    /// <summary>Gets hierarchy metadata when hierarchical rows are enabled.</summary>
+    public HierarchicalNode? HierarchicalNode { get; }
+
+    /// <summary>Gets the flattened row index.</summary>
+    public int RowIndex { get; }
+
+    /// <summary>Gets the grid slot assigned to the row.</summary>
+    public int Slot { get; }
+
+    /// <summary>Creates the standard row container.</summary>
+    /// <returns>A new standard row container.</returns>
+    public DataGridRow CreateDefaultContainer() => new();
+}
+
+/// <summary>
+/// Describes a cell container realization request.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+readonly record struct DataGridCellRealizationContext
+{
+    internal DataGridCellRealizationContext(DataGrid grid, DataGridRow row, DataGridColumn column)
+    {
+        Grid = grid;
+        Row = row;
+        Column = column;
+        DataContext = row.DataContext!;
+        HierarchicalNode = row.DataContext as HierarchicalNode;
+    }
+
+    /// <summary>Gets the grid requesting the container.</summary>
+    public DataGrid Grid { get; }
+
+    /// <summary>Gets the row that will own the cell.</summary>
+    public DataGridRow Row { get; }
+
+    /// <summary>Gets the column that will own the cell.</summary>
+    public DataGridColumn Column { get; }
+
+    /// <summary>Gets the actual row data context used by the grid.</summary>
+    public object? DataContext { get; }
+
+    /// <summary>Gets the application item represented by the row.</summary>
+    public object? Item => HierarchicalNode?.Item ?? DataContext;
+
+    /// <summary>Gets hierarchy metadata when hierarchical rows are enabled.</summary>
+    public HierarchicalNode? HierarchicalNode { get; }
+
+    /// <summary>Gets the flattened row index.</summary>
+    public int RowIndex => Row.Index;
+
+    /// <summary>Creates the standard container selected by the owning column.</summary>
+    /// <returns>A new standard cell container.</returns>
+    public DataGridCell CreateDefaultContainer() => Column.CreateCell();
+}
+
+/// <summary>
+/// Describes a column-header container realization request.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+readonly record struct DataGridColumnHeaderRealizationContext
+{
+    internal DataGridColumnHeaderRealizationContext(DataGrid grid, DataGridColumn column)
+    {
+        Grid = grid;
+        Column = column;
+    }
+
+    /// <summary>Gets the grid requesting the container.</summary>
+    public DataGrid Grid { get; }
+
+    /// <summary>Gets the column that will own the header.</summary>
+    public DataGridColumn Column { get; }
+
+    /// <summary>Gets whether the column is in the left frozen region.</summary>
+    public bool IsFrozenLeft => Column.IsFrozenLeft;
+
+    /// <summary>Gets whether the column is in the right frozen region.</summary>
+    public bool IsFrozenRight => Column.IsFrozenRight;
+
+    /// <summary>Creates the standard column-header container.</summary>
+    /// <returns>A new standard column-header container.</returns>
+    public DataGridColumnHeader CreateDefaultContainer() => new();
+}

--- a/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
+++ b/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
@@ -17,6 +17,7 @@ internal static partial class DataGridDiagnostics
     public static Activity? RefreshRows() => StartActivity("ProDataGrid.DataGrid.RefreshRows");
     public static Activity? HierarchicalBulkSplice() => StartActivity("ProDataGrid.DataGrid.HierarchicalBulkSplice");
     public static Activity? HierarchicalExpandAll() => StartActivity("ProDataGrid.Hierarchy.ExpandAll");
+    public static Activity? HierarchicalCollapseAll() => StartActivity("ProDataGrid.Hierarchy.CollapseAll");
     public static Activity? HierarchicalFlattenedChanged() => StartActivity("ProDataGrid.DataGrid.HierarchicalFlattenedChanged");
     public static Activity? HierarchicalIndentationRefresh() => StartActivity("ProDataGrid.DataGrid.HierarchicalIndentationRefresh");
     public static Activity? HierarchicalDisplayedRowsRange() => StartActivity("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange");

--- a/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
+++ b/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
@@ -16,6 +16,11 @@ internal static partial class DataGridDiagnostics
     public static Activity? RefreshRowsAndColumns() => StartActivity("ProDataGrid.DataGrid.RefreshRowsAndColumns");
     public static Activity? RefreshRows() => StartActivity("ProDataGrid.DataGrid.RefreshRows");
     public static Activity? HierarchicalBulkSplice() => StartActivity("ProDataGrid.DataGrid.HierarchicalBulkSplice");
+    public static Activity? HierarchicalExpandAll() => StartActivity("ProDataGrid.Hierarchy.ExpandAll");
+    public static Activity? HierarchicalFlattenedChanged() => StartActivity("ProDataGrid.DataGrid.HierarchicalFlattenedChanged");
+    public static Activity? HierarchicalIndentationRefresh() => StartActivity("ProDataGrid.DataGrid.HierarchicalIndentationRefresh");
+    public static Activity? HierarchicalDisplayedRowsRange() => StartActivity("ProDataGrid.DataGrid.HierarchicalDisplayedRowsRange");
+    public static Activity? HierarchicalSelectionRemap() => StartActivity("ProDataGrid.DataGrid.HierarchicalSelectionRemap");
     public static Activity? UpdateDisplayedRows() => StartActivity("ProDataGrid.DataGrid.UpdateDisplayedRows");
     public static Activity? GenerateRow() => StartActivity("ProDataGrid.DataGrid.GenerateRow");
     public static Activity? AutoGenerateColumns() => StartActivity("ProDataGrid.DataGrid.AutoGenerateColumns");

--- a/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
+++ b/src/Avalonia.Controls.DataGrid/Diagnostics/DataGridDiagnostics.Activities.cs
@@ -15,6 +15,7 @@ internal static partial class DataGridDiagnostics
 
     public static Activity? RefreshRowsAndColumns() => StartActivity("ProDataGrid.DataGrid.RefreshRowsAndColumns");
     public static Activity? RefreshRows() => StartActivity("ProDataGrid.DataGrid.RefreshRows");
+    public static Activity? HierarchicalBulkSplice() => StartActivity("ProDataGrid.DataGrid.HierarchicalBulkSplice");
     public static Activity? UpdateDisplayedRows() => StartActivity("ProDataGrid.DataGrid.UpdateDisplayedRows");
     public static Activity? GenerateRow() => StartActivity("ProDataGrid.DataGrid.GenerateRow");
     public static Activity? AutoGenerateColumns() => StartActivity("ProDataGrid.DataGrid.AutoGenerateColumns");

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.Generic.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.Generic.cs
@@ -828,6 +828,9 @@ namespace Avalonia.Controls.DataGridHierarchical
             NodeCollapsedTyped?.Invoke(this, new HierarchicalNodeEventArgs<T>(new HierarchicalNode<T>(node)));
         }
 
+        protected override bool HasNodeCollapsedObservers =>
+            base.HasNodeCollapsedObservers || NodeCollapsedTyped != null;
+
         protected override void OnNodeLoading(HierarchicalNode node)
         {
             base.OnNodeLoading(node);

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1849,6 +1849,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             int limit,
             bool resolveAsyncChildrenOffContext = false)
         {
+            using var activity = Avalonia.Controls.DataGridDiagnostics.HierarchicalExpandAll();
             List<HierarchicalNode>? expandedNodes = null;
             const int hashedCycleDepth = 32;
             HashSet<object>? ancestors = null;

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -2100,6 +2100,7 @@ namespace Avalonia.Controls.DataGridHierarchical
 
         public void CollapseAll(HierarchicalNode? node = null, int? minDepth = null)
         {
+            using var activity = Avalonia.Controls.DataGridDiagnostics.HierarchicalCollapseAll();
             var start = node ?? Root;
             if (start == null)
             {
@@ -2112,6 +2113,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             {
                 targetDepth++;
             }
+            List<HierarchicalNode>? collapsedNodes = null;
             var stack = new Stack<(HierarchicalNode Node, int Depth, bool Visited)>();
             stack.Push((start, 0, false));
 
@@ -2135,9 +2137,111 @@ namespace Avalonia.Controls.DataGridHierarchical
                     continue;
                 }
 
-                if (depth >= targetDepth && current.IsExpanded)
+                if (depth >= targetDepth && current.IsExpanded && !current.IsLeaf)
                 {
-                    Collapse(current);
+                    (collapsedNodes ??= new List<HierarchicalNode>()).Add(current);
+                }
+            }
+
+            if (collapsedNodes == null)
+            {
+                return;
+            }
+
+            CommitBulkCollapse(start, collapsedNodes);
+        }
+
+        private void CommitBulkCollapse(
+            HierarchicalNode start,
+            List<HierarchicalNode> collapsedNodes)
+        {
+            var isVirtualRoot = IsVirtualRootNode(start);
+            var startIndex = isVirtualRoot ? -1 : GetFlattenedIndex(start);
+            var isVisible = isVirtualRoot || startIndex >= 0;
+            var rangeStart = isVirtualRoot ? 0 : startIndex + 1;
+            var oldVisibleCount = isVisible
+                ? CountVisibleDescendantsInFlattened(start, startIndex)
+                : 0;
+            IList<HierarchicalNode>? oldVisibleNodes = oldVisibleCount > 0
+                ? _flattened.GetRange(rangeStart, oldVisibleCount)
+                : null;
+            var oldExpandedCount = start.ExpandedCount;
+
+            for (int i = 0; i < collapsedNodes.Count; i++)
+            {
+                var collapsedNode = collapsedNodes[i];
+                CancelPendingLoad(collapsedNode);
+                collapsedNode.SetExpandedFromOwnerSilently(false);
+                collapsedNode.ExpandedCount = 0;
+            }
+
+            var visibleNodes = new List<HierarchicalNode>();
+            if (isVirtualRoot || start.IsExpanded)
+            {
+                CollectVisibleChildrenAndUpdateCounts(
+                    start,
+                    visibleNodes,
+                    materializeMissingChildren: false);
+            }
+            else
+            {
+                start.ExpandedCount = 0;
+            }
+
+            var expandedCountDelta = start.ExpandedCount - oldExpandedCount;
+            if (start.Parent != null && expandedCountDelta != 0)
+            {
+                ApplyExpandedCountDelta(start.Parent, expandedCountDelta);
+            }
+
+            var flattenedChanged = isVisible &&
+                !ReferenceSequenceEqual(oldVisibleNodes, visibleNodes);
+            if (flattenedChanged)
+            {
+                _flattened.ReplaceRange(rangeStart, oldVisibleCount, visibleNodes);
+                var indexMap = oldVisibleNodes != null && visibleNodes.Count > 0
+                    ? BuildIndexMap(oldVisibleNodes, rangeStart, visibleNodes, rangeStart)
+                    : null;
+                OnFlattenedChanged(
+                    new[] { new FlattenedChange(rangeStart, oldVisibleCount, visibleNodes.Count) },
+                    indexMap);
+            }
+
+            for (int i = 0; i < collapsedNodes.Count; i++)
+            {
+                var collapsedNode = collapsedNodes[i];
+                if (collapsedNode.HasPropertyChangedObservers)
+                {
+                    collapsedNode.RaiseExpandedChanged();
+                }
+
+                OnNodeCollapsed(collapsedNode);
+            }
+
+            if (!Options.VirtualizeChildren && !IsVirtualizationGuardActive)
+            {
+                return;
+            }
+
+            // Only the outermost collapsed nodes need culling; each cull owns its complete
+            // descendant subtree. Retaining every collapsed descendant would repeat the same
+            // traversal and dominate large collapse operations.
+            var collapsedSet = new HashSet<HierarchicalNode>(collapsedNodes);
+            for (int i = 0; i < collapsedNodes.Count; i++)
+            {
+                var collapsedNode = collapsedNodes[i];
+                if (collapsedNode.Parent != null && collapsedSet.Contains(collapsedNode.Parent))
+                {
+                    continue;
+                }
+
+                if (Options.VirtualizeChildren)
+                {
+                    DematerializeDescendants(collapsedNode);
+                }
+                else
+                {
+                    _pendingCullNodes.Add(collapsedNode);
                 }
             }
         }
@@ -4132,11 +4236,17 @@ namespace Avalonia.Controls.DataGridHierarchical
             // one linear reference-identity pass. Besides avoiding the general-purpose identity
             // and item-equality dictionaries, this guarantees that an inserted equal item cannot
             // steal a retained node's mapping.
-            var orderedIdentityMap = TryBuildOrderedIdentityMap(
-                oldNodes,
-                oldStartIndex,
-                newNodes,
-                newStartIndex);
+            var orderedIdentityMap = oldNodes.Count <= newNodes.Count
+                ? TryBuildOrderedIdentityMap(
+                    oldNodes,
+                    oldStartIndex,
+                    newNodes,
+                    newStartIndex)
+                : TryBuildOrderedRetainedIdentityMap(
+                    oldNodes,
+                    oldStartIndex,
+                    newNodes,
+                    newStartIndex);
             if (orderedIdentityMap != null)
             {
                 return orderedIdentityMap;
@@ -4208,6 +4318,32 @@ namespace Avalonia.Controls.DataGridHierarchical
                 map.Add(oldStartIndex + oldIndex, newStartIndex + newIndex);
                 oldIndex++;
                 if (oldIndex == oldNodes.Count)
+                {
+                    return map;
+                }
+            }
+
+            return null;
+        }
+
+        private static IReadOnlyDictionary<int, int>? TryBuildOrderedRetainedIdentityMap(
+            IList<HierarchicalNode> oldNodes,
+            int oldStartIndex,
+            IList<HierarchicalNode> newNodes,
+            int newStartIndex)
+        {
+            var map = new Dictionary<int, int>(newNodes.Count);
+            var newIndex = 0;
+            for (int oldIndex = 0; oldIndex < oldNodes.Count; oldIndex++)
+            {
+                if (!ReferenceEquals(oldNodes[oldIndex], newNodes[newIndex]))
+                {
+                    continue;
+                }
+
+                map.Add(oldStartIndex + oldIndex, newStartIndex + newIndex);
+                newIndex++;
+                if (newIndex == newNodes.Count)
                 {
                     return map;
                 }

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -2138,29 +2138,24 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
             HierarchicalNode[]? collapsedNodes = null;
             var collapsedCount = 0;
-            var stack = new Stack<(HierarchicalNode Node, int Depth, bool Visited)>();
-            stack.Push((start, 0, false));
+            var stack = new Stack<(HierarchicalNode Node, int Depth)>();
+            stack.Push((start, 0));
 
             try
             {
                 while (stack.Count > 0)
                 {
-                    var (current, depth, visited) = stack.Pop();
-
-                    if (!visited)
+                    var (current, depth) = stack.Pop();
+                    if (current.IsExpanded || (hasVirtualRoot && ReferenceEquals(current, Root)))
                     {
-                        if (current.IsExpanded || (hasVirtualRoot && ReferenceEquals(current, Root)))
+                        EnsureChildrenMaterialized(current);
+                        var children = current.Children;
+                        // Preserve the former left-to-right, parent-before-child lifecycle order
+                        // while avoiding the second visit that the old entered/visited stack used.
+                        for (int i = children.Count - 1; i >= 0; i--)
                         {
-                            EnsureChildrenMaterialized(current);
-                            var children = current.Children;
-                            for (int i = children.Count - 1; i >= 0; i--)
-                            {
-                                stack.Push((children[i], depth + 1, false));
-                            }
+                            stack.Push((children[i], depth + 1));
                         }
-
-                        stack.Push((current, depth, true));
-                        continue;
                     }
 
                     if (depth < targetDepth || !current.IsExpanded || current.IsLeaf)
@@ -2277,6 +2272,7 @@ namespace Avalonia.Controls.DataGridHierarchical
                     indexMap);
             }
 
+            var raiseNodeCollapsed = HasNodeCollapsedObservers;
             for (int i = 0; i < collapsedCount; i++)
             {
                 var collapsedNode = collapsedNodes[i];
@@ -2285,7 +2281,10 @@ namespace Avalonia.Controls.DataGridHierarchical
                     collapsedNode.RaiseExpandedChanged();
                 }
 
-                OnNodeCollapsed(collapsedNode);
+                if (raiseNodeCollapsed)
+                {
+                    OnNodeCollapsed(collapsedNode);
+                }
             }
 
             if (!Options.VirtualizeChildren && !IsVirtualizationGuardActive)
@@ -2349,6 +2348,8 @@ namespace Avalonia.Controls.DataGridHierarchical
             SyncItemExpandedState(node, isExpanded: false);
             NodeCollapsed?.Invoke(this, new HierarchicalNodeEventArgs(node));
         }
+
+        protected virtual bool HasNodeCollapsedObservers => HasExpandedStateSetter || NodeCollapsed != null;
 
         protected virtual void OnNodeLoading(HierarchicalNode node)
         {

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -2098,6 +2099,28 @@ namespace Avalonia.Controls.DataGridHierarchical
             return true;
         }
 
+        private static bool ReferenceSequenceEqual(
+            IList<HierarchicalNode> oldNodes,
+            int oldStartIndex,
+            int oldCount,
+            IList<HierarchicalNode> newNodes)
+        {
+            if (oldCount != newNodes.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < oldCount; i++)
+            {
+                if (!ReferenceEquals(oldNodes[oldStartIndex + i], newNodes[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public void CollapseAll(HierarchicalNode? node = null, int? minDepth = null)
         {
             using var activity = Avalonia.Controls.DataGridDiagnostics.HierarchicalCollapseAll();
@@ -2113,47 +2136,74 @@ namespace Avalonia.Controls.DataGridHierarchical
             {
                 targetDepth++;
             }
-            List<HierarchicalNode>? collapsedNodes = null;
+            HierarchicalNode[]? collapsedNodes = null;
+            var collapsedCount = 0;
             var stack = new Stack<(HierarchicalNode Node, int Depth, bool Visited)>();
             stack.Push((start, 0, false));
 
-            while (stack.Count > 0)
+            try
             {
-                var (current, depth, visited) = stack.Pop();
-
-                if (!visited)
+                while (stack.Count > 0)
                 {
-                    if (current.IsExpanded || (hasVirtualRoot && ReferenceEquals(current, Root)))
+                    var (current, depth, visited) = stack.Pop();
+
+                    if (!visited)
                     {
-                        EnsureChildrenMaterialized(current);
-                        var children = current.Children;
-                        for (int i = children.Count - 1; i >= 0; i--)
+                        if (current.IsExpanded || (hasVirtualRoot && ReferenceEquals(current, Root)))
                         {
-                            stack.Push((children[i], depth + 1, false));
+                            EnsureChildrenMaterialized(current);
+                            var children = current.Children;
+                            for (int i = children.Count - 1; i >= 0; i--)
+                            {
+                                stack.Push((children[i], depth + 1, false));
+                            }
                         }
+
+                        stack.Push((current, depth, true));
+                        continue;
                     }
 
-                    stack.Push((current, depth, true));
-                    continue;
+                    if (depth < targetDepth || !current.IsExpanded || current.IsLeaf)
+                    {
+                        continue;
+                    }
+
+                    if (collapsedNodes == null)
+                    {
+                        collapsedNodes = ArrayPool<HierarchicalNode>.Shared.Rent(256);
+                    }
+                    else if (collapsedCount == collapsedNodes.Length)
+                    {
+                        var expandedBuffer = ArrayPool<HierarchicalNode>.Shared.Rent(
+                            checked(collapsedNodes.Length * 2));
+                        Array.Copy(collapsedNodes, expandedBuffer, collapsedCount);
+                        ArrayPool<HierarchicalNode>.Shared.Return(collapsedNodes, clearArray: true);
+                        collapsedNodes = expandedBuffer;
+                    }
+
+                    collapsedNodes[collapsedCount++] = current;
                 }
 
-                if (depth >= targetDepth && current.IsExpanded && !current.IsLeaf)
+                if (collapsedNodes == null)
                 {
-                    (collapsedNodes ??= new List<HierarchicalNode>()).Add(current);
+                    return;
+                }
+
+                CommitBulkCollapse(start, collapsedNodes, collapsedCount);
+            }
+            finally
+            {
+                if (collapsedNodes != null)
+                {
+                    ArrayPool<HierarchicalNode>.Shared.Return(collapsedNodes, clearArray: true);
                 }
             }
-
-            if (collapsedNodes == null)
-            {
-                return;
-            }
-
-            CommitBulkCollapse(start, collapsedNodes);
         }
 
         private void CommitBulkCollapse(
             HierarchicalNode start,
-            List<HierarchicalNode> collapsedNodes)
+            HierarchicalNode[] collapsedNodes,
+            int collapsedCount)
         {
             var isVirtualRoot = IsVirtualRootNode(start);
             var startIndex = isVirtualRoot ? -1 : GetFlattenedIndex(start);
@@ -2162,12 +2212,9 @@ namespace Avalonia.Controls.DataGridHierarchical
             var oldVisibleCount = isVisible
                 ? CountVisibleDescendantsInFlattened(start, startIndex)
                 : 0;
-            IList<HierarchicalNode>? oldVisibleNodes = oldVisibleCount > 0
-                ? _flattened.GetRange(rangeStart, oldVisibleCount)
-                : null;
             var oldExpandedCount = start.ExpandedCount;
 
-            for (int i = 0; i < collapsedNodes.Count; i++)
+            for (int i = 0; i < collapsedCount; i++)
             {
                 var collapsedNode = collapsedNodes[i];
                 CancelPendingLoad(collapsedNode);
@@ -2194,20 +2241,43 @@ namespace Avalonia.Controls.DataGridHierarchical
                 ApplyExpandedCountDelta(start.Parent, expandedCountDelta);
             }
 
-            var flattenedChanged = isVisible &&
-                !ReferenceSequenceEqual(oldVisibleNodes, visibleNodes);
+            var flattenedChanged = isVisible && !ReferenceSequenceEqual(
+                _flattened,
+                rangeStart,
+                oldVisibleCount,
+                visibleNodes);
             if (flattenedChanged)
             {
+                IReadOnlyDictionary<int, int>? indexMap = null;
+                if (oldVisibleCount > 0 && visibleNodes.Count > 0)
+                {
+                    indexMap = TryBuildOrderedRetainedIdentityMap(
+                        _flattened,
+                        oldCollectionStart: rangeStart,
+                        oldCount: oldVisibleCount,
+                        oldMapStartIndex: rangeStart,
+                        visibleNodes,
+                        newStartIndex: rangeStart);
+                    if (indexMap == null)
+                    {
+                        // Collapse normally retains an ordered subsequence, but preserve the
+                        // general item-equality mapping contract for custom or unusual models.
+                        var oldVisibleNodes = _flattened.GetRange(rangeStart, oldVisibleCount);
+                        indexMap = BuildIndexMap(
+                            oldVisibleNodes,
+                            rangeStart,
+                            visibleNodes,
+                            rangeStart);
+                    }
+                }
+
                 _flattened.ReplaceRange(rangeStart, oldVisibleCount, visibleNodes);
-                var indexMap = oldVisibleNodes != null && visibleNodes.Count > 0
-                    ? BuildIndexMap(oldVisibleNodes, rangeStart, visibleNodes, rangeStart)
-                    : null;
                 OnFlattenedChanged(
                     new[] { new FlattenedChange(rangeStart, oldVisibleCount, visibleNodes.Count) },
                     indexMap);
             }
 
-            for (int i = 0; i < collapsedNodes.Count; i++)
+            for (int i = 0; i < collapsedCount; i++)
             {
                 var collapsedNode = collapsedNodes[i];
                 if (collapsedNode.HasPropertyChangedObservers)
@@ -2226,8 +2296,13 @@ namespace Avalonia.Controls.DataGridHierarchical
             // Only the outermost collapsed nodes need culling; each cull owns its complete
             // descendant subtree. Retaining every collapsed descendant would repeat the same
             // traversal and dominate large collapse operations.
-            var collapsedSet = new HashSet<HierarchicalNode>(collapsedNodes);
-            for (int i = 0; i < collapsedNodes.Count; i++)
+            var collapsedSet = new HashSet<HierarchicalNode>(collapsedCount);
+            for (int i = 0; i < collapsedCount; i++)
+            {
+                collapsedSet.Add(collapsedNodes[i]);
+            }
+
+            for (int i = 0; i < collapsedCount; i++)
             {
                 var collapsedNode = collapsedNodes[i];
                 if (collapsedNode.Parent != null && collapsedSet.Contains(collapsedNode.Parent))
@@ -4332,16 +4407,33 @@ namespace Avalonia.Controls.DataGridHierarchical
             IList<HierarchicalNode> newNodes,
             int newStartIndex)
         {
+            return TryBuildOrderedRetainedIdentityMap(
+                oldNodes,
+                oldCollectionStart: 0,
+                oldCount: oldNodes.Count,
+                oldMapStartIndex: oldStartIndex,
+                newNodes,
+                newStartIndex);
+        }
+
+        private static IReadOnlyDictionary<int, int>? TryBuildOrderedRetainedIdentityMap(
+            IList<HierarchicalNode> oldNodes,
+            int oldCollectionStart,
+            int oldCount,
+            int oldMapStartIndex,
+            IList<HierarchicalNode> newNodes,
+            int newStartIndex)
+        {
             var map = new Dictionary<int, int>(newNodes.Count);
             var newIndex = 0;
-            for (int oldIndex = 0; oldIndex < oldNodes.Count; oldIndex++)
+            for (int oldIndex = 0; oldIndex < oldCount; oldIndex++)
             {
-                if (!ReferenceEquals(oldNodes[oldIndex], newNodes[newIndex]))
+                if (!ReferenceEquals(oldNodes[oldCollectionStart + oldIndex], newNodes[newIndex]))
                 {
                     continue;
                 }
 
-                map.Add(oldStartIndex + oldIndex, newStartIndex + newIndex);
+                map.Add(oldMapStartIndex + oldIndex, newStartIndex + newIndex);
                 newIndex++;
                 if (newIndex == newNodes.Count)
                 {

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/ObservableRangeCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/ObservableRangeCollection.cs
@@ -131,8 +131,13 @@ namespace Avalonia.Controls.DataGridHierarchical
 
             CheckReentrancy();
 
-            List<T>? removed = count > 0 ? new List<T>(count) : null;
-            for (var i = 0; i < count; i++)
+            // A differing-size replacement raises Reset, whose event payload contains no old
+            // items. Avoid snapshotting a potentially huge removed range that no observer can
+            // consume. Remove and equal-size replace still require the old items in their event.
+            var captureRemovedItems = count > 0 &&
+                (materialized.Count == 0 || count == materialized.Count);
+            List<T>? removed = captureRemovedItems ? new List<T>(count) : null;
+            for (var i = 0; i < count && captureRemovedItems; i++)
             {
                 removed!.Add(Items[index + i]);
             }

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Scrollable.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Scrollable.cs
@@ -673,7 +673,7 @@ internal
 
             // Get a recycled row, but always return it to the pool to avoid
             // leaving visible containers outside DisplayData.
-            var row = OwningGrid.DisplayData.GetRecycledRow();
+            var row = OwningGrid.DisplayData.GetRecycledRow(dataItem, dataIndex, slot);
             if (row == null)
             {
                 return;

--- a/src/DataGridSample.UnitTests/OptimizedHierarchyCollapsePerformanceTests.cs
+++ b/src/DataGridSample.UnitTests/OptimizedHierarchyCollapsePerformanceTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DataGridSample.Models;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class OptimizedHierarchyCollapsePerformanceTests
+{
+    private const int MeasuredIterations = 3;
+    private readonly ITestOutputHelper _output;
+
+    public OptimizedHierarchyCollapsePerformanceTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [AvaloniaFact]
+    public async Task RepresentativeWorkload_ReportsCollapseLatencyAcrossAllCellPaths()
+    {
+        var page = new OptimizedHierarchyCellPathsPage();
+        var window = new Window
+        {
+            Width = 1_200,
+            Height = 760,
+            Content = page,
+        };
+        window.ApplySampleTheme();
+
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<OptimizedHierarchyCellPathsViewModel>(page.DataContext);
+            var grid = Assert.IsType<DataGrid>(page.FindControl<DataGrid>("OptimizedHierarchyCellPathsGrid"));
+            await viewModel.LoadRepresentativeWorkloadAsync();
+            PumpLayout(window);
+            Assert.Equal(288, viewModel.Model.Flattened.Count);
+
+            var flattenedChangeCount = 0;
+            viewModel.Model.FlattenedChanged += (_, _) => flattenedChangeCount++;
+            var results = new List<CellPathResult>(viewModel.Paths.Count);
+
+            foreach (OptimizedCellPathOption path in viewModel.Paths)
+            {
+                viewModel.SelectedPath = path;
+                PumpLayout(window);
+
+                // Warm the path-specific columns, bulk model code, layout, and renderer.
+                viewModel.Model.ExpandAll();
+                PumpLayout(window);
+                viewModel.Model.CollapseAll();
+                PumpLayout(window);
+
+                var samples = new List<CollapseSample>(MeasuredIterations);
+                for (int iteration = 0; iteration < MeasuredIterations; iteration++)
+                {
+                    viewModel.Model.ExpandAll();
+                    PumpLayout(window);
+                    Assert.Equal(149_792, viewModel.Model.Flattened.Count);
+
+                    var changesBefore = flattenedChangeCount;
+                    var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+                    var totalTimer = Stopwatch.StartNew();
+                    var dispatchTimer = Stopwatch.StartNew();
+                    viewModel.Model.CollapseAll();
+                    dispatchTimer.Stop();
+
+                    var layoutTimer = Stopwatch.StartNew();
+                    PumpLayout(window);
+                    layoutTimer.Stop();
+
+                    var renderTimer = Stopwatch.StartNew();
+                    using var frame = window.CaptureRenderedFrame();
+                    renderTimer.Stop();
+                    totalTimer.Stop();
+
+                    Assert.Equal(changesBefore + 1, flattenedChangeCount);
+                    Assert.Equal(viewModel.RootCount, viewModel.Model.Flattened.Count);
+                    Assert.All(viewModel.Model.Flattened, node => Assert.False(node.IsExpanded));
+
+                    int realizedRows = grid.GetVisualDescendants()
+                        .OfType<DataGridRow>()
+                        .Count(row => row.IsVisible && row.Index >= 0);
+                    Assert.True(realizedRows > 0);
+
+                    samples.Add(new CollapseSample(
+                        dispatchTimer.Elapsed.TotalMilliseconds,
+                        layoutTimer.Elapsed.TotalMilliseconds,
+                        renderTimer.Elapsed.TotalMilliseconds,
+                        totalTimer.Elapsed.TotalMilliseconds,
+                        GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore,
+                        realizedRows));
+                }
+
+                results.Add(new CellPathResult(path.Key, path.Name, samples));
+            }
+
+            var report = new CollapsePerformanceReport(
+                DateTimeOffset.UtcNow,
+                149_792,
+                viewModel.RootCount,
+                MeasuredIterations,
+                Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "local-working-tree",
+                RuntimeInformation.FrameworkDescription,
+                RuntimeInformation.OSDescription,
+                RuntimeInformation.ProcessArchitecture.ToString(),
+                Environment.ProcessorCount,
+                window.ClientSize.Width,
+                window.ClientSize.Height,
+                window.RenderScaling,
+                results);
+            string artifactPath = WriteReport(report);
+
+            foreach (CellPathResult result in results)
+            {
+                _output.WriteLine(
+                    $"{result.Key}: dispatch median={Median(result.Samples.Select(sample => sample.DispatchMilliseconds)):F3} ms; " +
+                    $"end-to-end median={Median(result.Samples.Select(sample => sample.TotalMilliseconds)):F3} ms");
+            }
+            _output.WriteLine($"Report: {artifactPath}");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void PumpLayout(Control control)
+    {
+        Dispatcher.UIThread.RunJobs();
+        control.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static double Median(IEnumerable<double> values)
+    {
+        double[] sorted = values.OrderBy(value => value).ToArray();
+        return sorted[sorted.Length / 2];
+    }
+
+    private static string WriteReport(CollapsePerformanceReport report)
+    {
+        string? configuredDirectory = Environment.GetEnvironmentVariable("DATAGRID_PERF_ARTIFACT_DIR");
+        string directory;
+        if (!string.IsNullOrWhiteSpace(configuredDirectory))
+        {
+            directory = Path.GetFullPath(configuredDirectory);
+        }
+        else
+        {
+            var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (current != null &&
+                !File.Exists(Path.Combine(current.FullName, "Avalonia.Controls.DataGrid.slnx")))
+            {
+                current = current.Parent;
+            }
+
+            string root = current?.FullName ?? Directory.GetCurrentDirectory();
+            directory = Path.Combine(
+                root,
+                "artifacts",
+                "performance",
+                "optimized-hierarchy-collapse");
+        }
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "optimized-hierarchy-collapse.json");
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+        return Path.GetFullPath(path);
+    }
+
+    private sealed record CollapsePerformanceReport(
+        DateTimeOffset TimestampUtc,
+        int ExpandedNodeCount,
+        int CollapsedNodeCount,
+        int MeasuredIterations,
+        string Commit,
+        string Runtime,
+        string OS,
+        string Architecture,
+        int LogicalProcessorCount,
+        double ClientWidth,
+        double ClientHeight,
+        double RenderScaling,
+        IReadOnlyList<CellPathResult> CellPaths);
+
+    private sealed record CellPathResult(
+        string Key,
+        string Name,
+        IReadOnlyList<CollapseSample> Samples);
+
+    private sealed record CollapseSample(
+        double DispatchMilliseconds,
+        double LayoutMilliseconds,
+        double RenderMilliseconds,
+        double TotalMilliseconds,
+        long AllocatedBytes,
+        int RealizedRows);
+}

--- a/tests/ProDataGrid.Hierarchy.Benchmarks/HierarchyExpansionBenchmarks.cs
+++ b/tests/ProDataGrid.Hierarchy.Benchmarks/HierarchyExpansionBenchmarks.cs
@@ -9,6 +9,7 @@ public enum HierarchyShape
     Wide2555Depth3,
     Binary4094Depth11,
     VeryDeep512Depth128,
+    OptimizedSample149792Depth5,
 }
 
 [MemoryDiagnoser(displayGenColumns: false)]
@@ -68,6 +69,64 @@ public class HierarchyExpansionBenchmarks
         });
         model.SetRoots(roots);
         return model;
+    }
+}
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[RankColumn]
+public class HierarchyCollapseBenchmarks
+{
+    private IReadOnlyList<BenchmarkNode> _roots = null!;
+    private HierarchicalModel<BenchmarkNode> _model = null!;
+    private int _expectedExpandedCount;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _roots = BenchmarkTreeFactory.Create(HierarchyShape.OptimizedSample149792Depth5);
+        _expectedExpandedCount =
+            BenchmarkTreeFactory.ExpectedCount(HierarchyShape.OptimizedSample149792Depth5);
+
+        if (BenchmarkTreeFactory.CountNodes(_roots) != _expectedExpandedCount)
+        {
+            throw new InvalidOperationException("The generated hierarchy has an unexpected node count.");
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        BenchmarkTreeFactory.ResetExpandedState(_roots);
+        _model = new HierarchicalModel<BenchmarkNode>(new HierarchicalOptions<BenchmarkNode>
+        {
+            ChildrenSelector = static node => node.Children,
+            IsLeafSelector = static node => node.Children.Count == 0,
+            IsExpandedSelector = static node => node.IsExpanded,
+            IsExpandedSetter = static (node, value) => node.IsExpanded = value,
+            VirtualizeChildren = false,
+        });
+        _model.SetRoots(_roots);
+        _model.ExpandAll();
+
+        if (_model.Count != _expectedExpandedCount)
+        {
+            throw new InvalidOperationException(
+                $"Expanded row count mismatch: expected {_expectedExpandedCount}, got {_model.Count}.");
+        }
+    }
+
+    [Benchmark]
+    public int CollapseAll()
+    {
+        _model.CollapseAll();
+        int count = _model.Count;
+        if (count != _roots.Count)
+        {
+            throw new InvalidOperationException(
+                $"Collapsed row count mismatch: expected {_roots.Count}, got {count}.");
+        }
+
+        return count;
     }
 }
 
@@ -219,6 +278,8 @@ public sealed class BenchmarkNode
 
     public int Depth { get; }
 
+    public bool IsExpanded { get; set; }
+
     public List<BenchmarkNode> Children { get; } = new();
 }
 
@@ -231,6 +292,7 @@ public static class BenchmarkTreeFactory
             HierarchyShape.Wide2555Depth3 => BuildWide(rootCount: 5, branchCount: 10, leafCount: 50),
             HierarchyShape.Binary4094Depth11 => BuildUniform(rootCount: 2, branching: 2, levelCount: 11),
             HierarchyShape.VeryDeep512Depth128 => BuildUniform(rootCount: 4, branching: 1, levelCount: 128),
+            HierarchyShape.OptimizedSample149792Depth5 => BuildUniform(rootCount: 32, branching: 8, levelCount: 5),
             _ => throw new ArgumentOutOfRangeException(nameof(shape)),
         };
     }
@@ -242,6 +304,7 @@ public static class BenchmarkTreeFactory
             HierarchyShape.Wide2555Depth3 => 2_555,
             HierarchyShape.Binary4094Depth11 => 4_094,
             HierarchyShape.VeryDeep512Depth128 => 512,
+            HierarchyShape.OptimizedSample149792Depth5 => 149_792,
             _ => throw new ArgumentOutOfRangeException(nameof(shape)),
         };
     }
@@ -268,6 +331,25 @@ public static class BenchmarkTreeFactory
         }
 
         return count;
+    }
+
+    public static void ResetExpandedState(IReadOnlyList<BenchmarkNode> roots)
+    {
+        var stack = new Stack<BenchmarkNode>(roots.Count);
+        for (int i = roots.Count - 1; i >= 0; i--)
+        {
+            stack.Push(roots[i]);
+        }
+
+        while (stack.Count > 0)
+        {
+            BenchmarkNode node = stack.Pop();
+            node.IsExpanded = false;
+            for (int i = node.Children.Count - 1; i >= 0; i--)
+            {
+                stack.Push(node.Children[i]);
+            }
+        }
     }
 
     public static IReadOnlyList<BenchmarkNode> CreateBinary(int levelCount)

--- a/tests/ProDataGrid.Hierarchy.Benchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.Benchmarks/README.md
@@ -1,6 +1,22 @@
 # ProDataGrid hierarchy benchmarks
 
-This project owns the repeatable ProDataGrid-side hierarchy model benchmarks used by the TreeDataGrid comparison campaign. It deliberately measures `ExpandAll` separately from control creation, layout, scrolling, and rendering.
+This project owns the repeatable ProDataGrid-side hierarchy model benchmarks used by the TreeDataGrid comparison campaign. It deliberately measures hierarchy model operations separately from control creation, layout, scrolling, and rendering.
+
+The collapse lane mirrors the **Optimized Cell Paths (Hierarchy)** sample's default
+workload: 32 roots, branching factor 8, depth 4, and 149,792 materialized nodes.
+Iteration setup expands the hierarchy; the measured operation contains only the
+coherent `CollapseAll` dispatch.
+
+```sh
+dotnet run -c Release --project tests/ProDataGrid.Hierarchy.Benchmarks -- \
+  --filter '*HierarchyCollapseBenchmarks*' \
+  --job Short \
+  --warmupCount 2 \
+  --iterationCount 5 \
+  --invocationCount 1 \
+  --unrollFactor 1 \
+  --allStats
+```
 
 Run a clean Release timing pass:
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Pro/Native.Pro.csproj
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Pro/Native.Pro.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);PRO;PRODATAGRID_PR335</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <ProjectReference Include="../../../src/Avalonia.Controls.DataGrid/Avalonia.Controls.DataGrid.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../Shared/BenchmarkData.cs" Link="Shared/BenchmarkData.cs" />
+    <Compile Include="../Shared/NativeBenchmark.cs" Link="NativeBenchmark.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Tree/Native.Tree.csproj
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Tree/Native.Tree.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="System.Reactive" />
+    <ProjectReference Include="$(TreeDataGridSourceRoot)/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../Shared/BenchmarkData.cs" Link="Shared/BenchmarkData.cs" />
+    <Compile Include="../Shared/NativeBenchmark.cs" Link="NativeBenchmark.cs" />
+  </ItemGroup>
+
+  <Target Name="ValidateTreeDataGridSourceRoot" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(TreeDataGridSourceRoot)' == ''"
+           Text="TreeDataGridSourceRoot is required." />
+    <Error Condition="!Exists('$(TreeDataGridSourceRoot)/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj')"
+           Text="TreeDataGridSourceRoot does not contain the expected source project." />
+  </Target>
+
+</Project>

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -1,0 +1,48 @@
+# Native hierarchy source comparison
+
+This harness compares ProDataGrid with Wieslaw's open-source TreeDataGrid using
+source project references only. It has no paid-grid assembly or package reference.
+The workflow pins the TreeDataGrid source revision so every process uses the same
+implementation.
+
+The two controls use the same generated models, five data columns, an 800 x 500
+native desktop window, fixed 24-pixel rows, layout, and a two-animation-frame
+completion wait. Every measured operation begins from a fully rendered state.
+
+- `ExpandAllAndRender` expands the 4,094-node binary-tree workload used by the
+  existing native expansion comparison.
+- `CollapseAllAndRender` starts with the sample's 149,792-node workload fully
+  expanded, retains materialized children for equivalent post-collapse semantics,
+  collapses to 32 roots, updates layout, and waits for rendered completion.
+- Managed allocation is `GC.GetTotalAllocatedBytes` traffic during the timed
+  operation. It is not retained heap, native allocation, RSS, or GPU memory.
+
+The CI comparison runs four independent processes for each mode, alternating
+product order. Every process performs two warmups and ten measurements. The report
+aggregates the four process means and includes a Student-t 95% confidence interval.
+Raw JSON and `aggregate.json` are uploaded as the
+`hierarchy-native-source-windows` artifact.
+
+Build both source applications locally:
+
+```sh
+dotnet build tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Pro/Native.Pro.csproj -c Release
+dotnet build tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Tree/Native.Tree.csproj -c Release \
+  -p:TreeDataGridSourceRoot=/absolute/path/to/Avalonia.Controls.TreeDataGrid
+```
+
+Run one process per implementation:
+
+```sh
+GRID_BENCH_PRO_MODE=direct-cell dotnet \
+  tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Pro/bin/Release/net8.0/Native.Pro.dll \
+  --warmup 2 --iterations 10 --output /tmp/pro-direct-cell.json
+
+dotnet \
+  tests/ProDataGrid.Hierarchy.NativeBenchmarks/Native.Tree/bin/Release/net8.0/Native.Tree.dll \
+  --warmup 2 --iterations 10 --output /tmp/tree.json
+```
+
+On a machine without .NET 8, `DOTNET_ROLL_FORWARD=Major` can run the net8.0
+applications on a newer installed runtime, but the report must record that change.
+Use the same runtime and machine for both implementations.

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -7,7 +7,10 @@ implementation.
 
 The two controls use the same generated models, five data columns, an 800 x 500
 native desktop window, fixed 24-pixel rows, layout, and a two-animation-frame
-completion wait. Every measured operation begins from a fully rendered state.
+completion wait. Every measured operation begins from a fully rendered state. A
+full collection is followed by an unmeasured two-frame barrier before each sample,
+so implementation-specific GC duration cannot move the timed work to a different
+Windows vsync phase.
 
 - `ExpandAllAndRender` expands the 4,094-node binary-tree workload used by the
   existing native expansion comparison.

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -8,7 +8,7 @@ implementation.
 The two controls use the same generated models, five data columns, an 800 x 500
 native desktop window, fixed 24-pixel rows, layout, and a two-animation-frame
 completion wait. Every measured operation begins from a fully rendered state. A
-full collection is followed by an unmeasured two-frame barrier before each sample,
+full collection is followed by an unmeasured three-pulse alignment barrier before each sample,
 so implementation-specific GC duration cannot move the timed work to a different
 Windows vsync phase. The timed two-frame completion barrier is armed at the sample
 boundary before the synchronous mutation; its callbacks cannot run until mutation
@@ -29,7 +29,7 @@ schedule.
   layout and managed allocation, while the full rendered-frame total remains
   visible for detecting separate platform rendering or scheduling work.
 
-## Frame alignment and the two-callback barrier
+## Frame alignment and the timed two-callback barrier
 
 `RequestAnimationFrame` asks Avalonia to invoke a callback on an upcoming animation
 clock pulse. It is not the composition batch's `Rendered` task or a GPU/display
@@ -58,7 +58,7 @@ therefore change the end-to-end result by a whole frame even when model and layo
 work improve.
 
 The harness controls that phase in two places. Before every measured sample it
-performs the full GC and then waits on an unmeasured two-callback barrier, preventing
+performs the full GC and then waits on an unmeasured three-pulse barrier, preventing
 implementation-specific collection time from deciding which side of the next
 frame cutoff contains the timed operation. It then registers the timed barrier
 before starting the synchronous mutation. Because mutation and `UpdateLayout()` run
@@ -79,11 +79,19 @@ compositor-update, and compositor-render pass observed for each sample. That
 instrumented process is separate from the clean performance gate because meter
 collection intentionally adds overhead.
 
-The normal pre-sample alignment barrier has two callbacks. The diagnostic-only
-`--alignment-callbacks` option can increase that count without changing the timed
-two-callback completion barrier. CI compares two and three alignment callbacks in
-separate uninstrumented processes to detect a trailing composition batch from the
-alignment pass itself. It also captures sampled .NET traces for source-symbol
+The normal pre-sample alignment barrier has three callbacks. The third pulse is
+important because callback 2 runs before Avalonia records the rest of its own media
+pass. With only two alignment callbacks, ProDataGrid could begin the timed sample
+while a trailing alignment-pass composition batch was still pending; Avalonia then
+withheld timed callback 1 until that unrelated batch was processed. A source-only
+Windows diagnostic changed only the unmeasured alignment count from two to three:
+ProDataGrid's layout-to-callback-1 delay fell from 5.93 ms to 0.048 ms and its frame
+wait fell from 24.03 ms to 13.84 ms. TreeDataGrid remained in the same frame band
+(10.92 ms versus 12.08 ms). The measured operation still uses exactly two callbacks.
+
+The diagnostic-only `--alignment-callbacks` option can override the pre-sample
+count without changing that timed two-callback completion barrier. CI retains the
+two-versus-three diagnostic and also captures sampled .NET traces for source-symbol
 attribution of the UI render, composition serialization, and batch-deserialization
 paths. These traces contain only the two source implementations in this harness.
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -31,16 +31,24 @@ schedule.
 
 ## Frame alignment and the two-callback barrier
 
-`RequestAnimationFrame` asks Avalonia to invoke a callback at an upcoming animation
-and render scheduling opportunity. It is not a fence proving that the compositor,
-GPU, or display has presented the preceding pixels. A callback registered inside
-another callback cannot run in the same callback turn, so the nested callback used
-by this harness crosses two scheduling opportunities:
+`RequestAnimationFrame` asks Avalonia to invoke a callback on an upcoming animation
+clock pulse. It is not the composition batch's `Rendered` task or a GPU/display
+presentation fence. A callback registered inside another callback cannot run in
+the same pulse because Avalonia swaps its current and next callback queues before
+invoking them. The nested barrier therefore crosses two animation-clock pulses:
 
-1. the first callback lets invalidation, layout, animation, and render scheduling
-   triggered by the operation reach the next frame opportunity;
-2. the nested callback waits for the following opportunity, giving work queued by
-   the first frame another dispatcher/render turn before the sample completes.
+1. after synchronous mutation and `UpdateLayout()` yield the UI thread, pulse A
+   invokes callback 1 before Avalonia records and commits that UI render;
+2. callback 1 queues callback 2 for a later pulse. Avalonia records dirty visuals,
+   serializes and submits the composition batch, and suppresses another animation
+   pulse until the render thread has deserialized the batch and marked it
+   `Processed`; a later media pass then invokes callback 2 at pulse B.
+
+`Processed` means that the batch was accepted/deserialized and will soon be
+rendered. It is earlier than `Rendered`, so the second callback still does not
+prove GPU presentation. The callback-1-to-callback-2 interval can include UI render
+recording, composition serialization, render-thread scheduling and deserialization,
+the processed notification, and scheduling the next UI media pass.
 
 This is a conservative UI-completion convention, not a claim that the operation
 intrinsically requires two frames. At a 60 Hz refresh rate each missed frame cutoff
@@ -71,6 +79,14 @@ compositor-update, and compositor-render pass observed for each sample. That
 instrumented process is separate from the clean performance gate because meter
 collection intentionally adds overhead.
 
+The normal pre-sample alignment barrier has two callbacks. The diagnostic-only
+`--alignment-callbacks` option can increase that count without changing the timed
+two-callback completion barrier. CI compares two and three alignment callbacks in
+separate uninstrumented processes to detect a trailing composition batch from the
+alignment pass itself. It also captures sampled .NET traces for source-symbol
+attribution of the UI render, composition serialization, and batch-deserialization
+paths. These traces contain only the two source implementations in this harness.
+
 The full total is still the observable latency under this completion convention.
 For the collapse-path performance gate, mutation + layout isolates the code path
 the change is intended to optimize; allocation independently measures managed
@@ -80,8 +96,12 @@ evidence.
 
 ## Why `LayoutUpdated` mattered
 
-`LayoutUpdated` is raised after an Avalonia layout pass and may occur repeatedly as
-layout is invalidated. ProDataGrid's hierarchy-change path used
+`LayoutUpdated` is raised by Avalonia's layout manager after a root layout pass; a
+control's subscription is forwarded from that root event. It is not a render or
+presentation notification and can be raised even if that control's bounds did not
+change. A handler that changes measure-, arrange-, or render-affecting state can
+queue later work, and another layout pass raises another notification. ProDataGrid's
+hierarchy-change path used
 `RequestHierarchicalIndentationRefresh()` to subscribe a one-shot handler, with a
 background-dispatcher fallback. That is useful when realized rows are not yet in
 their final range: the refresh must wait until layout has established the range.

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -63,6 +63,14 @@ into:
 - **frame wait**: dispatcher/render scheduling until the second callback;
 - **total**: mutation + layout + frame wait.
 
+The JSON also records the delay from layout completion to callback 1, the interval
+from callback 1 to callback 2, the animation-clock interval, raw per-iteration phase
+samples, and the number of `LayoutUpdated` notifications. The CI diagnostic process
+enables Avalonia's built-in meters and records the maximum UI render-recording,
+compositor-update, and compositor-render pass observed for each sample. That
+instrumented process is separate from the clean performance gate because meter
+collection intentionally adds overhead.
+
 The full total is still the observable latency under this completion convention.
 For the collapse-path performance gate, mutation + layout isolates the code path
 the change is intended to optimize; allocation independently measures managed

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -10,7 +10,10 @@ native desktop window, fixed 24-pixel rows, layout, and a two-animation-frame
 completion wait. Every measured operation begins from a fully rendered state. A
 full collection is followed by an unmeasured two-frame barrier before each sample,
 so implementation-specific GC duration cannot move the timed work to a different
-Windows vsync phase.
+Windows vsync phase. The timed two-frame completion barrier is armed at the sample
+boundary before the synchronous mutation; its callbacks cannot run until mutation
+and layout yield the UI thread, and both controls therefore enter the same frame
+schedule.
 
 - `ExpandAllAndRender` expands the 4,094-node binary-tree workload used by the
   existing native expansion comparison.

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -16,6 +16,10 @@ completion wait. Every measured operation begins from a fully rendered state.
   collapses to 32 roots, updates layout, and waits for rendered completion.
 - Managed allocation is `GC.GetTotalAllocatedBytes` traffic during the timed
   operation. It is not retained heap, native allocation, RSS, or GPU memory.
+- Collapse results also split the same end-to-end sample into synchronous model/UI
+  mutation, `UpdateLayout`, and rendered-frame wait durations. These diagnostic
+  phase means sum to the reported collapse mean; the end-to-end mean remains the
+  comparison and gate metric.
 
 The CI comparison runs four independent processes for each mode, alternating
 product order. Every process performs two warmups and ten measurements. The report

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -27,10 +27,11 @@ schedule.
   phase means sum to the reported collapse mean; the end-to-end mean remains the
   comparison and gate metric.
 
-The CI comparison runs four independent processes for each mode, alternating
-product order. Every process performs two warmups and ten measurements. The report
-aggregates the four process means and includes a Student-t 95% confidence interval.
-Raw JSON and `aggregate.json` are uploaded as the
+The CI comparison runs four independent processes for all five ProDataGrid source
+modes and the pinned TreeDataGrid source mode, reversing the complete mode order in
+alternating processes. Every process performs two warmups and ten measurements. The
+report aggregates the four process means and includes a Student-t 95% confidence
+interval. Raw JSON and `aggregate.json` are uploaded as the
 `hierarchy-native-source-windows` artifact.
 
 Build both source applications locally:

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/README.md
@@ -25,7 +25,69 @@ schedule.
 - Collapse results also split the same end-to-end sample into synchronous model/UI
   mutation, `UpdateLayout`, and rendered-frame wait durations. These diagnostic
   phase means sum to the reported collapse mean; the end-to-end mean remains the
-  comparison and gate metric.
+  primary reported comparison. The collapse optimization gate uses mutation plus
+  layout and managed allocation, while the full rendered-frame total remains
+  visible for detecting separate platform rendering or scheduling work.
+
+## Frame alignment and the two-callback barrier
+
+`RequestAnimationFrame` asks Avalonia to invoke a callback at an upcoming animation
+and render scheduling opportunity. It is not a fence proving that the compositor,
+GPU, or display has presented the preceding pixels. A callback registered inside
+another callback cannot run in the same callback turn, so the nested callback used
+by this harness crosses two scheduling opportunities:
+
+1. the first callback lets invalidation, layout, animation, and render scheduling
+   triggered by the operation reach the next frame opportunity;
+2. the nested callback waits for the following opportunity, giving work queued by
+   the first frame another dispatcher/render turn before the sample completes.
+
+This is a conservative UI-completion convention, not a claim that the operation
+intrinsically requires two frames. At a 60 Hz refresh rate each missed frame cutoff
+adds about 16.7 ms. A small difference in synchronous work, GC duration, dispatcher
+traffic, or the point within the vsync interval at which a sample starts can
+therefore change the end-to-end result by a whole frame even when model and layout
+work improve.
+
+The harness controls that phase in two places. Before every measured sample it
+performs the full GC and then waits on an unmeasured two-callback barrier, preventing
+implementation-specific collection time from deciding which side of the next
+frame cutoff contains the timed operation. It then registers the timed barrier
+before starting the synchronous mutation. Because mutation and `UpdateLayout()` run
+on the UI thread, neither callback can execute until that work yields. Both source
+implementations therefore enter the same callback schedule, and the result is split
+into:
+
+- **mutation**: hierarchy/model notifications and synchronous grid updates;
+- **layout**: the explicit `UpdateLayout()` call;
+- **frame wait**: dispatcher/render scheduling until the second callback;
+- **total**: mutation + layout + frame wait.
+
+The full total is still the observable latency under this completion convention.
+For the collapse-path performance gate, mutation + layout isolates the code path
+the change is intended to optimize; allocation independently measures managed
+traffic. A frame-wait regression remains visible and must be investigated, but a
+whole-frame scheduling band is not attributed to hierarchy traversal without phase
+evidence.
+
+## Why `LayoutUpdated` mattered
+
+`LayoutUpdated` is raised after an Avalonia layout pass and may occur repeatedly as
+layout is invalidated. ProDataGrid's hierarchy-change path used
+`RequestHierarchicalIndentationRefresh()` to subscribe a one-shot handler, with a
+background-dispatcher fallback. That is useful when realized rows are not yet in
+their final range: the refresh must wait until layout has established the range.
+
+The optimized bulk-splice path is different. It synchronously realizes/rebinds the
+final displayed range and calls `RefreshHierarchicalIndentation()` before
+`EnsureDisplayedRowsInRange()` and `InvalidateMeasure()`. Registering the deferred
+`LayoutUpdated` refresh afterward repeated work that had already been completed.
+When the explicit `UpdateLayout()` raised `LayoutUpdated`, the handler refreshed
+indentation after the pass and could invalidate visual state for another layout or
+render interval. The optimized path now skips only that redundant deferred request;
+non-bulk paths retain it. A headless regression test verifies that bulk expand and
+collapse each perform exactly one indentation refresh, preserving the final row
+state while removing the duplicate post-layout work.
 
 The CI comparison runs four independent processes for all five ProDataGrid source
 modes and the pinned TreeDataGrid source mode, reversing the complete mode order in

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/BenchmarkData.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/BenchmarkData.cs
@@ -5,6 +5,7 @@ public enum TreeShape
     Wide2555Depth3,
     Deep4094Depth11,
     VeryDeep512Depth128,
+    OptimizedSample149792Depth5,
 }
 
 public sealed class Node
@@ -41,6 +42,7 @@ public static class TreeDataFactory
             TreeShape.Wide2555Depth3 => BuildWide(rootCount: 5, branchCount: 10, leafCount: 50),
             TreeShape.Deep4094Depth11 => BuildUniform(rootCount: 2, branching: 2, levelCount: 11),
             TreeShape.VeryDeep512Depth128 => BuildUniform(rootCount: 4, branching: 1, levelCount: 128),
+            TreeShape.OptimizedSample149792Depth5 => BuildUniform(rootCount: 32, branching: 8, levelCount: 5),
             _ => throw new ArgumentOutOfRangeException(nameof(shape)),
         };
     }
@@ -52,6 +54,7 @@ public static class TreeDataFactory
             TreeShape.Wide2555Depth3 => 2_555,
             TreeShape.Deep4094Depth11 => 4_094,
             TreeShape.VeryDeep512Depth128 => 512,
+            TreeShape.OptimizedSample149792Depth5 => 149_792,
             _ => throw new ArgumentOutOfRangeException(nameof(shape)),
         };
     }

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/BenchmarkData.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/BenchmarkData.cs
@@ -1,0 +1,131 @@
+namespace GridHierarchyBenchmarks.Shared;
+
+public enum TreeShape
+{
+    Wide2555Depth3,
+    Deep4094Depth11,
+    VeryDeep512Depth128,
+}
+
+public sealed class Node
+{
+    public Node(int id, int depth)
+    {
+        Id = id;
+        Depth = depth;
+        Name = $"Node {id:N0} at depth {depth}";
+        Payload = $"Payload-{id % 997:D3}";
+    }
+
+    public int Id { get; }
+
+    public int Depth { get; }
+
+    public string Name { get; }
+
+    public string Payload { get; }
+
+    public int ChildCount => Children.Count;
+
+    public bool HasChildren => Children.Count != 0;
+
+    public List<Node> Children { get; } = new();
+}
+
+public static class TreeDataFactory
+{
+    public static IReadOnlyList<Node> Create(TreeShape shape)
+    {
+        return shape switch
+        {
+            TreeShape.Wide2555Depth3 => BuildWide(rootCount: 5, branchCount: 10, leafCount: 50),
+            TreeShape.Deep4094Depth11 => BuildUniform(rootCount: 2, branching: 2, levelCount: 11),
+            TreeShape.VeryDeep512Depth128 => BuildUniform(rootCount: 4, branching: 1, levelCount: 128),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape)),
+        };
+    }
+
+    public static int ExpectedCount(TreeShape shape)
+    {
+        return shape switch
+        {
+            TreeShape.Wide2555Depth3 => 2_555,
+            TreeShape.Deep4094Depth11 => 4_094,
+            TreeShape.VeryDeep512Depth128 => 512,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape)),
+        };
+    }
+
+    public static int CountNodes(IReadOnlyList<Node> roots)
+    {
+        var count = 0;
+        var stack = new Stack<Node>(roots.Reverse());
+
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            ++count;
+
+            for (var i = node.Children.Count - 1; i >= 0; --i)
+                stack.Push(node.Children[i]);
+        }
+
+        return count;
+    }
+
+    public static IReadOnlyList<Node> CreateStressWide20420Depth3() =>
+        BuildWide(rootCount: 20, branchCount: 20, leafCount: 50);
+
+    private static IReadOnlyList<Node> BuildWide(int rootCount, int branchCount, int leafCount)
+    {
+        var id = 0;
+        var roots = new List<Node>(rootCount);
+
+        for (var rootIndex = 0; rootIndex < rootCount; ++rootIndex)
+        {
+            var root = new Node(id++, depth: 0);
+            roots.Add(root);
+
+            for (var branchIndex = 0; branchIndex < branchCount; ++branchIndex)
+            {
+                var branch = new Node(id++, depth: 1);
+                root.Children.Add(branch);
+
+                for (var leafIndex = 0; leafIndex < leafCount; ++leafIndex)
+                    branch.Children.Add(new Node(id++, depth: 2));
+            }
+        }
+
+        return roots;
+    }
+
+    private static IReadOnlyList<Node> BuildUniform(int rootCount, int branching, int levelCount)
+    {
+        var id = 0;
+        var roots = new List<Node>(rootCount);
+        var queue = new Queue<Node>();
+
+        for (var rootIndex = 0; rootIndex < rootCount; ++rootIndex)
+        {
+            var root = new Node(id++, depth: 0);
+            roots.Add(root);
+            queue.Enqueue(root);
+        }
+
+        while (queue.Count > 0)
+        {
+            var parent = queue.Dequeue();
+            if (parent.Depth + 1 >= levelCount)
+                continue;
+
+            for (var childIndex = 0; childIndex < branching; ++childIndex)
+            {
+                var child = new Node(id++, parent.Depth + 1);
+                parent.Children.Add(child);
+                queue.Enqueue(child);
+            }
+        }
+
+        return roots;
+    }
+}

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -374,6 +374,9 @@ internal sealed class NativeBenchmarkRunner
 
         var times = new List<double>();
         var allocations = new List<double>();
+        var mutationTimes = new List<double>();
+        var layoutTimes = new List<double>();
+        var frameTimes = new List<double>();
         NativeValidation? validation = null;
 
         for (var i = 0; i < NativeBenchmarkOptions.Iterations; ++i)
@@ -381,10 +384,20 @@ internal sealed class NativeBenchmarkRunner
             var measurement = await CollapseAndRenderIterationAsync(measure: true);
             times.Add(measurement.ElapsedMilliseconds);
             allocations.Add(measurement.AllocatedBytes);
+            mutationTimes.Add(measurement.MutationMilliseconds);
+            layoutTimes.Add(measurement.LayoutMilliseconds);
+            frameTimes.Add(measurement.FrameMilliseconds);
             validation = measurement.Validation;
         }
 
-        return NativeWorkloadResult.Create("CollapseAllAndRender", times, allocations, validation!);
+        return NativeWorkloadResult.Create(
+            "CollapseAllAndRender",
+            times,
+            allocations,
+            validation!,
+            mutationTimes,
+            layoutTimes,
+            frameTimes);
     }
 
     private async Task<NativeMeasurement> CollapseAndRenderIterationAsync(bool measure)
@@ -405,14 +418,22 @@ internal sealed class NativeBenchmarkRunner
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
         var stopwatch = Stopwatch.StartNew();
         handle.CollapseAll();
+        var mutationMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
         _host.UpdateLayout();
+        var mutationAndLayoutMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
         await WaitForRenderedFrameAsync(_host);
         stopwatch.Stop();
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
         var validation = NativeGridAdapter.Validate(handle, expectedCount: 32);
         await DetachAsync();
 
-        return new NativeMeasurement(stopwatch.Elapsed.TotalMilliseconds, allocated, validation);
+        return new NativeMeasurement(
+            stopwatch.Elapsed.TotalMilliseconds,
+            allocated,
+            validation,
+            mutationMilliseconds,
+            mutationAndLayoutMilliseconds - mutationMilliseconds,
+            stopwatch.Elapsed.TotalMilliseconds - mutationAndLayoutMilliseconds);
     }
 
     private async Task<NativeWorkloadResult> MeasureScrollAndRenderAsync()
@@ -836,7 +857,10 @@ internal sealed class NativeGridHandle : IDisposable
 internal sealed record NativeMeasurement(
     double ElapsedMilliseconds,
     long AllocatedBytes,
-    NativeValidation Validation);
+    NativeValidation Validation,
+    double MutationMilliseconds = 0,
+    double LayoutMilliseconds = 0,
+    double FrameMilliseconds = 0);
 
 internal sealed record NativeValidation(
     int RowCount,
@@ -863,13 +887,22 @@ internal sealed class NativeWorkloadResult
 
     public double MeanAllocatedBytes { get; init; }
 
+    public double MeanMutationMilliseconds { get; init; }
+
+    public double MeanLayoutMilliseconds { get; init; }
+
+    public double MeanFrameMilliseconds { get; init; }
+
     public required NativeValidation Validation { get; init; }
 
     public static NativeWorkloadResult Create(
         string name,
         IReadOnlyList<double> times,
         IReadOnlyList<double> allocations,
-        NativeValidation validation)
+        NativeValidation validation,
+        IReadOnlyList<double>? mutationTimes = null,
+        IReadOnlyList<double>? layoutTimes = null,
+        IReadOnlyList<double>? frameTimes = null)
     {
         var ordered = times.OrderBy(x => x).ToArray();
         var mean = times.Average();
@@ -883,6 +916,9 @@ internal sealed class NativeWorkloadResult
             P95Milliseconds = Percentile(ordered, 0.95),
             StandardDeviationMilliseconds = Math.Sqrt(variance),
             MeanAllocatedBytes = allocations.Average(),
+            MeanMutationMilliseconds = mutationTimes?.Average() ?? 0,
+            MeanLayoutMilliseconds = layoutTimes?.Average() ?? 0,
+            MeanFrameMilliseconds = frameTimes?.Average() ?? 0,
             Validation = validation,
         };
     }

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -312,10 +312,11 @@ internal sealed class NativeBenchmarkRunner
             await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var renderedFrame = WaitForRenderedFrameAsync(_host);
         var stopwatch = Stopwatch.StartNew();
         _host.Content = handle.Grid;
         _host.UpdateLayout();
-        await WaitForRenderedFrameAsync(_host);
+        await renderedFrame;
         stopwatch.Stop();
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
         var validation = NativeGridAdapter.Validate(handle);
@@ -355,10 +356,11 @@ internal sealed class NativeBenchmarkRunner
             await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var renderedFrame = WaitForRenderedFrameAsync(_host);
         var stopwatch = Stopwatch.StartNew();
         handle.ExpandAll();
         _host.UpdateLayout();
-        await WaitForRenderedFrameAsync(_host);
+        await renderedFrame;
         stopwatch.Stop();
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
         var validation = NativeGridAdapter.Validate(handle);
@@ -416,12 +418,13 @@ internal sealed class NativeBenchmarkRunner
             await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var renderedFrame = WaitForRenderedFrameAsync(_host);
         var stopwatch = Stopwatch.StartNew();
         handle.CollapseAll();
         var mutationMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
         _host.UpdateLayout();
         var mutationAndLayoutMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
-        await WaitForRenderedFrameAsync(_host);
+        await renderedFrame;
         stopwatch.Stop();
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
         var validation = NativeGridAdapter.Validate(handle, expectedCount: 32);
@@ -477,10 +480,11 @@ internal sealed class NativeBenchmarkRunner
         {
             var operation = (batch * NativeBenchmarkOptions.ScrollJumps) + i;
             var row = ((operation * 509) % 2_000) + 1;
+            var renderedFrame = WaitForRenderedFrameAsync(_host);
             var stopwatch = Stopwatch.StartNew();
             NativeGridAdapter.SetScrollRow(viewer, row);
             handle.Grid.UpdateLayout();
-            await WaitForRenderedFrameAsync(_host);
+            await renderedFrame;
             stopwatch.Stop();
             times?.Add(stopwatch.Elapsed.TotalMilliseconds);
         }
@@ -490,9 +494,10 @@ internal sealed class NativeBenchmarkRunner
 
     private async Task DetachAsync()
     {
+        var renderedFrame = WaitForRenderedFrameAsync(_host);
         _host.Content = null;
         _host.UpdateLayout();
-        await WaitForRenderedFrameAsync(_host);
+        await renderedFrame;
     }
 
     private static void CollectForMeasurement()
@@ -796,6 +801,8 @@ internal static class NativeGridAdapter
             handle.Count,
             realizedRows,
             realizedCells,
+            handle.Grid.GetVisualDescendants().Count(),
+            handle.Grid.GetVisualDescendants().OfType<Control>().Count(),
             viewer.Extent.Width,
             viewer.Extent.Height,
             viewer.Viewport.Width,
@@ -875,6 +882,8 @@ internal sealed record NativeValidation(
     int RowCount,
     int RealizedRows,
     int RealizedCells,
+    int RealizedVisuals,
+    int RealizedControls,
     double ExtentWidth,
     double ExtentHeight,
     double ViewportWidth,

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -592,7 +592,7 @@ internal sealed class NativeBenchmarkRunner
         CollectForMeasurement();
         // Full collection duration depends on each implementation's retained graph and can
         // otherwise shift the timed operation to opposite sides of a Windows vsync boundary.
-        // Start every sample immediately after the same two-frame completion barrier.
+        // Start every sample after the same configurable animation-pulse quiescence barrier.
         await WaitForAnimationCallbacksAsync(topLevel, NativeBenchmarkOptions.AlignmentCallbacks);
     }
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -309,7 +309,7 @@ internal sealed class NativeBenchmarkRunner
     {
         using var handle = NativeGridAdapter.Create(expanded: true);
         if (measure)
-            CollectForMeasurement();
+            await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
         var stopwatch = Stopwatch.StartNew();
@@ -352,7 +352,7 @@ internal sealed class NativeBenchmarkRunner
         await WaitForRenderedFrameAsync(_host);
 
         if (measure)
-            CollectForMeasurement();
+            await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
         var stopwatch = Stopwatch.StartNew();
@@ -413,7 +413,7 @@ internal sealed class NativeBenchmarkRunner
         NativeGridAdapter.Validate(handle, TreeDataFactory.ExpectedCount(shape));
 
         if (measure)
-            CollectForMeasurement();
+            await PrepareMeasurementAsync(_host);
 
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
         var stopwatch = Stopwatch.StartNew();
@@ -453,7 +453,7 @@ internal sealed class NativeBenchmarkRunner
 
         for (var batch = 0; batch < NativeBenchmarkOptions.Iterations; ++batch)
         {
-            CollectForMeasurement();
+            await PrepareMeasurementAsync(_host);
             var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
             var batchTimes = await RunScrollBatchAsync(handle, viewer, batch, measure: true);
             var allocated = GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore;
@@ -500,6 +500,15 @@ internal sealed class NativeBenchmarkRunner
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
+    }
+
+    private static async Task PrepareMeasurementAsync(TopLevel topLevel)
+    {
+        CollectForMeasurement();
+        // Full collection duration depends on each implementation's retained graph and can
+        // otherwise shift the timed operation to opposite sides of a Windows vsync boundary.
+        // Start every sample immediately after the same two-frame completion barrier.
+        await WaitForRenderedFrameAsync(topLevel);
     }
 
     public static async Task WaitForRenderedFrameAsync(TopLevel topLevel)

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Avalonia;
@@ -146,6 +148,10 @@ internal static class NativeBenchmarkOptions
 
     public static bool FirstRenderOnly { get; private set; }
 
+    public static bool CollapseOnly { get; private set; }
+
+    public static bool AvaloniaDiagnostics { get; private set; }
+
     public static string OutputPath { get; private set; } = Path.GetFullPath("native-result.json");
 
 #if PRO && PRODATAGRID_PR335
@@ -207,7 +213,19 @@ internal static class NativeBenchmarkOptions
                 case "--first-render-only":
                     FirstRenderOnly = true;
                     break;
+                case "--collapse-only":
+                    CollapseOnly = true;
+                    break;
+                case "--avalonia-diagnostics":
+                    AvaloniaDiagnostics = true;
+                    break;
             }
+        }
+
+        if (AvaloniaDiagnostics)
+        {
+            AppContext.SetSwitch("Avalonia.Diagnostics.Diagnostic.IsEnabled", true);
+            NativeAvaloniaDiagnostics.Initialize();
         }
 
 #if !ACCELERATE
@@ -246,14 +264,17 @@ internal sealed class NativeBenchmarkRunner
 
     public async Task<NativeBenchmarkResult> RunAsync()
     {
-        var firstRender = await MeasureFirstRenderAsync();
-        var expandAndRender = NativeBenchmarkOptions.FirstRenderOnly
+        var firstRender = NativeBenchmarkOptions.CollapseOnly
+            ? null
+            : await MeasureFirstRenderAsync();
+        var expandAndRender = NativeBenchmarkOptions.FirstRenderOnly || NativeBenchmarkOptions.CollapseOnly
             ? null
             : await MeasureExpandAndRenderAsync();
         var collapseAndRender = NativeBenchmarkOptions.FirstRenderOnly
             ? null
             : await MeasureCollapseAndRenderAsync();
         var scrollAndRender = NativeBenchmarkOptions.FirstRenderOnly
+            || NativeBenchmarkOptions.CollapseOnly
             ? null
             : await MeasureScrollAndRenderAsync();
 
@@ -379,6 +400,13 @@ internal sealed class NativeBenchmarkRunner
         var mutationTimes = new List<double>();
         var layoutTimes = new List<double>();
         var frameTimes = new List<double>();
+        var firstFrameCallbackTimes = new List<double>();
+        var secondFrameCallbackTimes = new List<double>();
+        var animationTickIntervals = new List<double>();
+        var layoutUpdatedCounts = new List<int>();
+        var uiRenderTimes = new List<double>();
+        var compositorUpdateTimes = new List<double>();
+        var compositorRenderTimes = new List<double>();
         NativeValidation? validation = null;
 
         for (var i = 0; i < NativeBenchmarkOptions.Iterations; ++i)
@@ -389,6 +417,13 @@ internal sealed class NativeBenchmarkRunner
             mutationTimes.Add(measurement.MutationMilliseconds);
             layoutTimes.Add(measurement.LayoutMilliseconds);
             frameTimes.Add(measurement.FrameMilliseconds);
+            firstFrameCallbackTimes.Add(measurement.FirstFrameCallbackMilliseconds);
+            secondFrameCallbackTimes.Add(measurement.SecondFrameCallbackMilliseconds);
+            animationTickIntervals.Add(measurement.AnimationTickIntervalMilliseconds);
+            layoutUpdatedCounts.Add(measurement.LayoutUpdatedCount);
+            uiRenderTimes.Add(measurement.UiRenderMilliseconds);
+            compositorUpdateTimes.Add(measurement.CompositorUpdateMilliseconds);
+            compositorRenderTimes.Add(measurement.CompositorRenderMilliseconds);
             validation = measurement.Validation;
         }
 
@@ -399,7 +434,14 @@ internal sealed class NativeBenchmarkRunner
             validation!,
             mutationTimes,
             layoutTimes,
-            frameTimes);
+            frameTimes,
+            firstFrameCallbackTimes,
+            secondFrameCallbackTimes,
+            animationTickIntervals,
+            layoutUpdatedCounts,
+            uiRenderTimes,
+            compositorUpdateTimes,
+            compositorRenderTimes);
     }
 
     private async Task<NativeMeasurement> CollapseAndRenderIterationAsync(bool measure)
@@ -417,16 +459,24 @@ internal sealed class NativeBenchmarkRunner
         if (measure)
             await PrepareMeasurementAsync(_host);
 
+        var layoutUpdatedCount = 0;
+        void OnLayoutUpdated(object? sender, EventArgs e) => layoutUpdatedCount++;
+        handle.Grid.LayoutUpdated += OnLayoutUpdated;
+
         var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
-        var renderedFrame = WaitForRenderedFrameAsync(_host);
+        NativeAvaloniaDiagnostics.Reset();
+        var renderedFrame = RequestRenderedFrame(_host);
         var stopwatch = Stopwatch.StartNew();
         handle.CollapseAll();
         var mutationMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
         _host.UpdateLayout();
         var mutationAndLayoutMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
-        await renderedFrame;
+        var layoutCompletedTimestamp = Stopwatch.GetTimestamp();
+        await renderedFrame.Completion;
         stopwatch.Stop();
+        handle.Grid.LayoutUpdated -= OnLayoutUpdated;
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
+        var renderingDiagnostics = await NativeAvaloniaDiagnostics.SnapshotAsync();
         var validation = NativeGridAdapter.Validate(handle, expectedCount: 32);
         await DetachAsync();
 
@@ -436,7 +486,14 @@ internal sealed class NativeBenchmarkRunner
             validation,
             mutationMilliseconds,
             mutationAndLayoutMilliseconds - mutationMilliseconds,
-            stopwatch.Elapsed.TotalMilliseconds - mutationAndLayoutMilliseconds);
+            stopwatch.Elapsed.TotalMilliseconds - mutationAndLayoutMilliseconds,
+            Stopwatch.GetElapsedTime(layoutCompletedTimestamp, renderedFrame.FirstCallbackTimestamp).TotalMilliseconds,
+            Stopwatch.GetElapsedTime(renderedFrame.FirstCallbackTimestamp, renderedFrame.SecondCallbackTimestamp).TotalMilliseconds,
+            (renderedFrame.SecondAnimationTimestamp - renderedFrame.FirstAnimationTimestamp).TotalMilliseconds,
+            layoutUpdatedCount,
+            renderingDiagnostics.UiRenderMilliseconds,
+            renderingDiagnostics.CompositorUpdateMilliseconds,
+            renderingDiagnostics.CompositorRenderMilliseconds);
     }
 
     private async Task<NativeWorkloadResult> MeasureScrollAndRenderAsync()
@@ -518,12 +575,131 @@ internal sealed class NativeBenchmarkRunner
 
     public static async Task WaitForRenderedFrameAsync(TopLevel topLevel)
     {
-        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        topLevel.RequestAnimationFrame(_ =>
-            topLevel.RequestAnimationFrame(__ => completion.TrySetResult()));
-        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await RequestRenderedFrame(topLevel).Completion;
+    }
+
+    private static NativeFrameBarrier RequestRenderedFrame(TopLevel topLevel)
+    {
+        var barrier = new NativeFrameBarrier();
+        topLevel.RequestAnimationFrame(firstTimestamp =>
+        {
+            barrier.SetFirstCallback(firstTimestamp);
+            topLevel.RequestAnimationFrame(secondTimestamp =>
+                barrier.SetSecondCallback(secondTimestamp));
+        });
+        return barrier;
     }
 }
+
+internal sealed class NativeFrameBarrier
+{
+    private readonly TaskCompletionSource _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Completion => _completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+    public long FirstCallbackTimestamp { get; private set; }
+
+    public long SecondCallbackTimestamp { get; private set; }
+
+    public TimeSpan FirstAnimationTimestamp { get; private set; }
+
+    public TimeSpan SecondAnimationTimestamp { get; private set; }
+
+    public void SetFirstCallback(TimeSpan animationTimestamp)
+    {
+        FirstCallbackTimestamp = Stopwatch.GetTimestamp();
+        FirstAnimationTimestamp = animationTimestamp;
+    }
+
+    public void SetSecondCallback(TimeSpan animationTimestamp)
+    {
+        SecondCallbackTimestamp = Stopwatch.GetTimestamp();
+        SecondAnimationTimestamp = animationTimestamp;
+        _completion.TrySetResult();
+    }
+}
+
+internal static class NativeAvaloniaDiagnostics
+{
+    private const string MeterName = "Avalonia.Diagnostic.Meter";
+    private const string UiRenderName = "avalonia.ui.render.time";
+    private const string CompositorUpdateName = "avalonia.comp.update.time";
+    private const string CompositorRenderName = "avalonia.comp.render.time";
+    private static readonly ConcurrentQueue<NativeDiagnosticMeasurement> s_measurements = new();
+    private static MeterListener? s_listener;
+
+    public static void Initialize()
+    {
+        if (s_listener != null)
+        {
+            return;
+        }
+
+        s_listener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == MeterName &&
+                    instrument.Name is UiRenderName or CompositorUpdateName or CompositorRenderName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        s_listener.SetMeasurementEventCallback<double>(static (instrument, value, _, _) =>
+            s_measurements.Enqueue(new NativeDiagnosticMeasurement(instrument.Name, value)));
+        s_listener.Start();
+    }
+
+    public static void Reset()
+    {
+        while (s_measurements.TryDequeue(out _))
+        {
+        }
+    }
+
+    public static async Task<NativeRenderingDiagnostics> SnapshotAsync()
+    {
+        if (!NativeBenchmarkOptions.AvaloniaDiagnostics)
+        {
+            return default;
+        }
+
+        // CompositionBatch.Processed releases the second animation callback before the
+        // compositor has necessarily finished its update/render pass. This unmeasured delay
+        // lets the diagnostic histograms finish without changing the timed result.
+        await Task.Delay(50);
+
+        var uiRender = 0.0;
+        var compositorUpdate = 0.0;
+        var compositorRender = 0.0;
+        while (s_measurements.TryDequeue(out var measurement))
+        {
+            switch (measurement.Name)
+            {
+                case UiRenderName:
+                    uiRender = Math.Max(uiRender, measurement.Value);
+                    break;
+                case CompositorUpdateName:
+                    compositorUpdate = Math.Max(compositorUpdate, measurement.Value);
+                    break;
+                case CompositorRenderName:
+                    compositorRender = Math.Max(compositorRender, measurement.Value);
+                    break;
+            }
+        }
+
+        return new NativeRenderingDiagnostics(uiRender, compositorUpdate, compositorRender);
+    }
+
+    private readonly record struct NativeDiagnosticMeasurement(string Name, double Value);
+}
+
+internal readonly record struct NativeRenderingDiagnostics(
+    double UiRenderMilliseconds,
+    double CompositorUpdateMilliseconds,
+    double CompositorRenderMilliseconds);
 
 internal static class NativeGridAdapter
 {
@@ -876,7 +1052,14 @@ internal sealed record NativeMeasurement(
     NativeValidation Validation,
     double MutationMilliseconds = 0,
     double LayoutMilliseconds = 0,
-    double FrameMilliseconds = 0);
+    double FrameMilliseconds = 0,
+    double FirstFrameCallbackMilliseconds = 0,
+    double SecondFrameCallbackMilliseconds = 0,
+    double AnimationTickIntervalMilliseconds = 0,
+    int LayoutUpdatedCount = 0,
+    double UiRenderMilliseconds = 0,
+    double CompositorUpdateMilliseconds = 0,
+    double CompositorRenderMilliseconds = 0);
 
 internal sealed record NativeValidation(
     int RowCount,
@@ -911,6 +1094,36 @@ internal sealed class NativeWorkloadResult
 
     public double MeanFrameMilliseconds { get; init; }
 
+    public double MeanFirstFrameCallbackMilliseconds { get; init; }
+
+    public double MeanSecondFrameCallbackMilliseconds { get; init; }
+
+    public double MeanAnimationTickIntervalMilliseconds { get; init; }
+
+    public double MeanLayoutUpdatedCount { get; init; }
+
+    public double MeanUiRenderMilliseconds { get; init; }
+
+    public double MeanCompositorUpdateMilliseconds { get; init; }
+
+    public double MeanCompositorRenderMilliseconds { get; init; }
+
+    public required IReadOnlyList<double> MillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? MutationMillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? LayoutMillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? FrameMillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? FirstFrameCallbackMillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? SecondFrameCallbackMillisecondSamples { get; init; }
+
+    public IReadOnlyList<double>? AnimationTickIntervalMillisecondSamples { get; init; }
+
+    public IReadOnlyList<int>? LayoutUpdatedCountSamples { get; init; }
+
     public required NativeValidation Validation { get; init; }
 
     public static NativeWorkloadResult Create(
@@ -920,7 +1133,14 @@ internal sealed class NativeWorkloadResult
         NativeValidation validation,
         IReadOnlyList<double>? mutationTimes = null,
         IReadOnlyList<double>? layoutTimes = null,
-        IReadOnlyList<double>? frameTimes = null)
+        IReadOnlyList<double>? frameTimes = null,
+        IReadOnlyList<double>? firstFrameCallbackTimes = null,
+        IReadOnlyList<double>? secondFrameCallbackTimes = null,
+        IReadOnlyList<double>? animationTickIntervals = null,
+        IReadOnlyList<int>? layoutUpdatedCounts = null,
+        IReadOnlyList<double>? uiRenderTimes = null,
+        IReadOnlyList<double>? compositorUpdateTimes = null,
+        IReadOnlyList<double>? compositorRenderTimes = null)
     {
         var ordered = times.OrderBy(x => x).ToArray();
         var mean = times.Average();
@@ -937,6 +1157,21 @@ internal sealed class NativeWorkloadResult
             MeanMutationMilliseconds = mutationTimes?.Average() ?? 0,
             MeanLayoutMilliseconds = layoutTimes?.Average() ?? 0,
             MeanFrameMilliseconds = frameTimes?.Average() ?? 0,
+            MeanFirstFrameCallbackMilliseconds = firstFrameCallbackTimes?.Average() ?? 0,
+            MeanSecondFrameCallbackMilliseconds = secondFrameCallbackTimes?.Average() ?? 0,
+            MeanAnimationTickIntervalMilliseconds = animationTickIntervals?.Average() ?? 0,
+            MeanLayoutUpdatedCount = layoutUpdatedCounts?.Average() ?? 0,
+            MeanUiRenderMilliseconds = uiRenderTimes?.Average() ?? 0,
+            MeanCompositorUpdateMilliseconds = compositorUpdateTimes?.Average() ?? 0,
+            MeanCompositorRenderMilliseconds = compositorRenderTimes?.Average() ?? 0,
+            MillisecondSamples = times.ToArray(),
+            MutationMillisecondSamples = mutationTimes?.ToArray(),
+            LayoutMillisecondSamples = layoutTimes?.ToArray(),
+            FrameMillisecondSamples = frameTimes?.ToArray(),
+            FirstFrameCallbackMillisecondSamples = firstFrameCallbackTimes?.ToArray(),
+            SecondFrameCallbackMillisecondSamples = secondFrameCallbackTimes?.ToArray(),
+            AnimationTickIntervalMillisecondSamples = animationTickIntervals?.ToArray(),
+            LayoutUpdatedCountSamples = layoutUpdatedCounts?.ToArray(),
             Validation = validation,
         };
     }
@@ -980,7 +1215,7 @@ internal sealed class NativeBenchmarkResult
 
     public int ScrollJumpsPerIteration { get; init; }
 
-    public required NativeWorkloadResult FirstExpandedRender { get; init; }
+    public NativeWorkloadResult? FirstExpandedRender { get; init; }
 
     public NativeWorkloadResult? ExpandAllAndRender { get; init; }
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -34,9 +34,21 @@ internal static class Program
             ShutdownMode.OnExplicitShutdown);
     }
 
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<NativeBenchmarkApplication>()
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        var builder = AppBuilder.Configure<NativeBenchmarkApplication>()
             .UsePlatformDetect();
+        NativePlatformInfo.RenderingSubsystem = builder.RenderingSubsystemName ?? "unknown";
+        NativePlatformInfo.RuntimePlatformServices = builder.RuntimePlatformServicesName ?? "unknown";
+        return builder;
+    }
+}
+
+internal static class NativePlatformInfo
+{
+    public static string RenderingSubsystem { get; set; } = "unknown";
+
+    public static string RuntimePlatformServices { get; set; } = "unknown";
 }
 
 internal sealed class NativeBenchmarkApplication : Application
@@ -152,6 +164,8 @@ internal static class NativeBenchmarkOptions
 
     public static bool AvaloniaDiagnostics { get; private set; }
 
+    public static int AlignmentCallbacks { get; private set; } = 2;
+
     public static string OutputPath { get; private set; } = Path.GetFullPath("native-result.json");
 
 #if PRO && PRODATAGRID_PR335
@@ -218,6 +232,12 @@ internal static class NativeBenchmarkOptions
                     break;
                 case "--avalonia-diagnostics":
                     AvaloniaDiagnostics = true;
+                    break;
+                case "--alignment-callbacks":
+                    AlignmentCallbacks = ParsePositive(
+                        RequireValue(args, ref i),
+                        "alignment callbacks",
+                        allowZero: false);
                     break;
             }
         }
@@ -292,6 +312,8 @@ internal sealed class NativeBenchmarkRunner
             OS = RuntimeInformation.OSDescription,
             Architecture = RuntimeInformation.ProcessArchitecture.ToString(),
             Processor = Environment.GetEnvironmentVariable("PROCESSOR_IDENTIFIER") ?? "unknown",
+            RenderingSubsystem = NativePlatformInfo.RenderingSubsystem,
+            RuntimePlatformServices = NativePlatformInfo.RuntimePlatformServices,
             LogicalProcessorCount = Environment.ProcessorCount,
             ClientWidth = _host.ClientSize.Width,
             ClientHeight = _host.ClientSize.Height,
@@ -299,6 +321,7 @@ internal sealed class NativeBenchmarkRunner
             WarmupIterations = NativeBenchmarkOptions.WarmupIterations,
             MeasuredIterations = NativeBenchmarkOptions.Iterations,
             ScrollJumpsPerIteration = NativeBenchmarkOptions.ScrollJumps,
+            AlignmentCallbacks = NativeBenchmarkOptions.AlignmentCallbacks,
             FirstExpandedRender = firstRender,
             ExpandAllAndRender = expandAndRender,
             CollapseAllAndRender = collapseAndRender,
@@ -570,7 +593,26 @@ internal sealed class NativeBenchmarkRunner
         // Full collection duration depends on each implementation's retained graph and can
         // otherwise shift the timed operation to opposite sides of a Windows vsync boundary.
         // Start every sample immediately after the same two-frame completion barrier.
-        await WaitForRenderedFrameAsync(topLevel);
+        await WaitForAnimationCallbacksAsync(topLevel, NativeBenchmarkOptions.AlignmentCallbacks);
+    }
+
+    private static Task WaitForAnimationCallbacksAsync(TopLevel topLevel, int callbackCount)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void RequestNext(int remaining)
+        {
+            topLevel.RequestAnimationFrame(_ =>
+            {
+                if (remaining == 1)
+                    completion.TrySetResult();
+                else
+                    RequestNext(remaining - 1);
+            });
+        }
+
+        RequestNext(callbackCount);
+        return completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     public static async Task WaitForRenderedFrameAsync(TopLevel topLevel)
@@ -1201,6 +1243,10 @@ internal sealed class NativeBenchmarkResult
 
     public required string Processor { get; init; }
 
+    public required string RenderingSubsystem { get; init; }
+
+    public required string RuntimePlatformServices { get; init; }
+
     public int LogicalProcessorCount { get; init; }
 
     public double ClientWidth { get; init; }
@@ -1214,6 +1260,8 @@ internal sealed class NativeBenchmarkResult
     public int MeasuredIterations { get; init; }
 
     public int ScrollJumpsPerIteration { get; init; }
+
+    public int AlignmentCallbacks { get; init; }
 
     public NativeWorkloadResult? FirstExpandedRender { get; init; }
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -250,6 +250,9 @@ internal sealed class NativeBenchmarkRunner
         var expandAndRender = NativeBenchmarkOptions.FirstRenderOnly
             ? null
             : await MeasureExpandAndRenderAsync();
+        var collapseAndRender = NativeBenchmarkOptions.FirstRenderOnly
+            ? null
+            : await MeasureCollapseAndRenderAsync();
         var scrollAndRender = NativeBenchmarkOptions.FirstRenderOnly
             ? null
             : await MeasureScrollAndRenderAsync();
@@ -277,6 +280,7 @@ internal sealed class NativeBenchmarkRunner
             ScrollJumpsPerIteration = NativeBenchmarkOptions.ScrollJumps,
             FirstExpandedRender = firstRender,
             ExpandAllAndRender = expandAndRender,
+            CollapseAllAndRender = collapseAndRender,
             ScrollAndRender = scrollAndRender,
         };
     }
@@ -358,6 +362,54 @@ internal sealed class NativeBenchmarkRunner
         stopwatch.Stop();
         var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
         var validation = NativeGridAdapter.Validate(handle);
+        await DetachAsync();
+
+        return new NativeMeasurement(stopwatch.Elapsed.TotalMilliseconds, allocated, validation);
+    }
+
+    private async Task<NativeWorkloadResult> MeasureCollapseAndRenderAsync()
+    {
+        for (var i = 0; i < NativeBenchmarkOptions.WarmupIterations; ++i)
+            await CollapseAndRenderIterationAsync(measure: false);
+
+        var times = new List<double>();
+        var allocations = new List<double>();
+        NativeValidation? validation = null;
+
+        for (var i = 0; i < NativeBenchmarkOptions.Iterations; ++i)
+        {
+            var measurement = await CollapseAndRenderIterationAsync(measure: true);
+            times.Add(measurement.ElapsedMilliseconds);
+            allocations.Add(measurement.AllocatedBytes);
+            validation = measurement.Validation;
+        }
+
+        return NativeWorkloadResult.Create("CollapseAllAndRender", times, allocations, validation!);
+    }
+
+    private async Task<NativeMeasurement> CollapseAndRenderIterationAsync(bool measure)
+    {
+        const TreeShape shape = TreeShape.OptimizedSample149792Depth5;
+        using var handle = NativeGridAdapter.Create(
+            expanded: true,
+            shape: shape,
+            retainCollapsedChildren: true);
+        _host.Content = handle.Grid;
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+        NativeGridAdapter.Validate(handle, TreeDataFactory.ExpectedCount(shape));
+
+        if (measure)
+            CollectForMeasurement();
+
+        var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var stopwatch = Stopwatch.StartNew();
+        handle.CollapseAll();
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+        stopwatch.Stop();
+        var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
+        var validation = NativeGridAdapter.Validate(handle, expectedCount: 32);
         await DetachAsync();
 
         return new NativeMeasurement(stopwatch.Elapsed.TotalMilliseconds, allocated, validation);
@@ -464,9 +516,12 @@ internal static class NativeGridAdapter
         return window;
     }
 
-    public static NativeGridHandle Create(bool expanded)
+    public static NativeGridHandle Create(
+        bool expanded,
+        TreeShape shape = TreeShape.Deep4094Depth11,
+        bool retainCollapsedChildren = false)
     {
-        var roots = TreeDataFactory.Create(TreeShape.Deep4094Depth11);
+        var roots = TreeDataFactory.Create(shape);
 #if PRO
 #if PRODATAGRID_PR335
         var optimized = NativeBenchmarkOptions.ProMode != "standard";
@@ -478,7 +533,7 @@ internal static class NativeGridAdapter
         {
             ChildrenSelector = node => node.Children,
             IsLeafSelector = node => node.Children.Count == 0,
-            VirtualizeChildren = true,
+            VirtualizeChildren = !retainCollapsedChildren,
         };
         var model = new HierarchicalModel<Node>(options);
         model.SetRoots(roots);
@@ -526,7 +581,7 @@ internal static class NativeGridAdapter
         {
             ChildrenSelector = node => node.Children,
             IsLeafSelector = node => node.Children.Count == 0,
-            VirtualizeChildren = true,
+            VirtualizeChildren = !retainCollapsedChildren,
         };
         var model = new HierarchicalModel<Node>(options);
         model.SetRoots(roots);
@@ -691,10 +746,10 @@ internal static class NativeGridAdapter
     }
 #endif
 
-    public static NativeValidation Validate(NativeGridHandle handle)
+    public static NativeValidation Validate(NativeGridHandle handle, int expectedCount = 4_094)
     {
-        if (handle.Count != 4_094)
-            throw new InvalidOperationException($"Expected 4,094 expanded rows, got {handle.Count:N0}.");
+        if (handle.Count != expectedCount)
+            throw new InvalidOperationException($"Expected {expectedCount:N0} rows, got {handle.Count:N0}.");
 
 #if PRO
         var realizedRows = handle.Grid.GetVisualDescendants().OfType<DataGridRow>().Count();
@@ -708,6 +763,7 @@ internal static class NativeGridAdapter
 
         var viewer = GetScrollViewer(handle);
         return new NativeValidation(
+            handle.Count,
             realizedRows,
             realizedCells,
             viewer.Extent.Width,
@@ -748,6 +804,8 @@ internal sealed class NativeGridHandle : IDisposable
 
     public void ExpandAll() => Model.ExpandAll();
 
+    public void CollapseAll() => Model.CollapseAll();
+
     public void Dispose()
     {
     }
@@ -769,6 +827,8 @@ internal sealed class NativeGridHandle : IDisposable
 
     public void ExpandAll() => Source.ExpandAll();
 
+    public void CollapseAll() => Source.CollapseAll();
+
     public void Dispose() => Source.Dispose();
 }
 #endif
@@ -779,6 +839,7 @@ internal sealed record NativeMeasurement(
     NativeValidation Validation);
 
 internal sealed record NativeValidation(
+    int RowCount,
     int RealizedRows,
     int RealizedCells,
     double ExtentWidth,
@@ -868,6 +929,8 @@ internal sealed class NativeBenchmarkResult
     public required NativeWorkloadResult FirstExpandedRender { get; init; }
 
     public NativeWorkloadResult? ExpandAllAndRender { get; init; }
+
+    public NativeWorkloadResult? CollapseAllAndRender { get; init; }
 
     public NativeWorkloadResult? ScrollAndRender { get; init; }
 }

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -164,7 +164,7 @@ internal static class NativeBenchmarkOptions
 
     public static bool AvaloniaDiagnostics { get; private set; }
 
-    public static int AlignmentCallbacks { get; private set; } = 2;
+    public static int AlignmentCallbacks { get; private set; } = 3;
 
     public static string OutputPath { get; private set; } = Path.GetFullPath("native-result.json");
 

--- a/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
+++ b/tests/ProDataGrid.Hierarchy.NativeBenchmarks/Shared/NativeBenchmark.cs
@@ -1,0 +1,889 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using GridHierarchyBenchmarks.Shared;
+#if PRO
+using Avalonia.Controls.DataGridHierarchical;
+#else
+using TreeDataGridControl = Avalonia.Controls.TreeDataGrid;
+#endif
+
+namespace GridHierarchyBenchmarks.Native;
+
+internal static class Program
+{
+    [STAThread]
+    public static int Main(string[] args)
+    {
+        NativeBenchmarkOptions.Initialize(args);
+        return BuildAvaloniaApp().StartWithClassicDesktopLifetime(
+            Array.Empty<string>(),
+            ShutdownMode.OnExplicitShutdown);
+    }
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<NativeBenchmarkApplication>()
+            .UsePlatformDetect();
+}
+
+internal sealed class NativeBenchmarkApplication : Application
+{
+    private NativeGridHandle? _inspectionHandle;
+
+    public override void Initialize()
+    {
+        RequestedThemeVariant = ThemeVariant.Light;
+        Styles.Add(new FluentTheme());
+#if PRO
+        Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.DataGrid/Themes/"))
+        {
+            Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.v2.xaml"),
+        });
+#else
+        Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.TreeDataGrid/Themes/"))
+        {
+            Source = new Uri("avares://Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml"),
+        });
+#endif
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            var host = NativeGridAdapter.CreateHostWindow();
+            desktop.MainWindow = host;
+
+            if (NativeBenchmarkOptions.Inspect)
+            {
+                _inspectionHandle = NativeGridAdapter.Create(expanded: true);
+                host.Content = _inspectionHandle.Grid;
+                host.Closed += (_, _) =>
+                {
+                    _inspectionHandle?.Dispose();
+                    _inspectionHandle = null;
+                    desktop.Shutdown();
+                };
+                host.Opened += (_, _) => Dispatcher.UIThread.Post(
+                    () => RunInspectionAsync(host),
+                    DispatcherPriority.Background);
+            }
+            else
+            {
+                host.Opened += (_, _) => Dispatcher.UIThread.Post(
+                    () => RunBenchmarkAsync(host, desktop),
+                    DispatcherPriority.Background);
+            }
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+
+    private async void RunInspectionAsync(Window host)
+    {
+        try
+        {
+            await NativeBenchmarkRunner.WaitForRenderedFrameAsync(host);
+            host.UpdateLayout();
+            var validation = NativeGridAdapter.Validate(_inspectionHandle!);
+            Console.WriteLine(
+                $"NATIVE_INSPECT_READY implementation={NativeBenchmarkOptions.ImplementationName} " +
+                $"pid={Environment.ProcessId} rows={validation.RealizedRows} cells={validation.RealizedCells} " +
+                $"extent={validation.ExtentWidth:F0}x{validation.ExtentHeight:F0} scaling={host.RenderScaling:F2}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            host.Close();
+        }
+    }
+
+    private static async void RunBenchmarkAsync(
+        Window host,
+        IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        try
+        {
+            await NativeBenchmarkRunner.WaitForRenderedFrameAsync(host);
+            var result = await new NativeBenchmarkRunner(host).RunAsync();
+            await NativeBenchmarkResultWriter.WriteAsync(result, NativeBenchmarkOptions.OutputPath);
+            Console.WriteLine(JsonSerializer.Serialize(result, NativeBenchmarkResultWriter.JsonOptions));
+            host.Close();
+            desktop.Shutdown(0);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            host.Close();
+            desktop.Shutdown(1);
+        }
+    }
+}
+
+internal static class NativeBenchmarkOptions
+{
+    public static bool Inspect { get; private set; }
+
+    public static bool DrawnCells { get; private set; }
+
+    public static int WarmupIterations { get; private set; } = 2;
+
+    public static int Iterations { get; private set; } = 5;
+
+    public static int ScrollJumps { get; private set; } = 32;
+
+    public static bool FirstRenderOnly { get; private set; }
+
+    public static string OutputPath { get; private set; } = Path.GetFullPath("native-result.json");
+
+#if PRO && PRODATAGRID_PR335
+    public static string ProMode { get; } =
+        (Environment.GetEnvironmentVariable("GRID_BENCH_PRO_MODE") ?? "standard")
+        .Trim()
+        .ToLowerInvariant();
+#endif
+
+    public static string ImplementationName =>
+#if PRO
+#if PRODATAGRID_PR335
+        ProMode switch
+        {
+            "standard" => "ProDataGrid (legacy default retained)",
+            "optimized" => "ProDataGrid (optimized retained)",
+            "direct" => "ProDataGrid (direct-content retained)",
+            "direct-cell" => "ProDataGrid (direct-cell retained)",
+            "drawn" => "ProDataGrid (drawn ordinary cells)",
+            _ => $"ProDataGrid ({ProMode})",
+        };
+#else
+        "ProDataGrid";
+#endif
+#elif ACCELERATE
+        DrawnCells ? "Accelerate TreeDataGrid (drawn cells)" : "Accelerate TreeDataGrid (retained cells)";
+#else
+        "Wieslaw's TreeDataGrid";
+#endif
+
+#if PRO && PRODATAGRID_PR335
+    public static string PerformanceMode => ProMode;
+#endif
+
+    public static void Initialize(string[] args)
+    {
+        for (var i = 0; i < args.Length; ++i)
+        {
+            switch (args[i])
+            {
+                case "--inspect":
+                    Inspect = true;
+                    break;
+                case "--drawn":
+                    DrawnCells = bool.Parse(RequireValue(args, ref i));
+                    break;
+                case "--output":
+                    OutputPath = Path.GetFullPath(RequireValue(args, ref i));
+                    break;
+                case "--warmup":
+                    WarmupIterations = ParsePositive(RequireValue(args, ref i), "warmup iterations", allowZero: true);
+                    break;
+                case "--iterations":
+                    Iterations = ParsePositive(RequireValue(args, ref i), "iterations", allowZero: false);
+                    break;
+                case "--scroll-jumps":
+                    ScrollJumps = ParsePositive(RequireValue(args, ref i), "scroll jumps", allowZero: false);
+                    break;
+                case "--first-render-only":
+                    FirstRenderOnly = true;
+                    break;
+            }
+        }
+
+#if !ACCELERATE
+        if (DrawnCells)
+            throw new ArgumentException("--drawn true is supported only by Accelerate TreeDataGrid.");
+#endif
+#if PRO && PRODATAGRID_PR335
+        if (ProMode is not ("standard" or "optimized" or "direct" or "direct-cell" or "drawn"))
+            throw new ArgumentException($"Unsupported GRID_BENCH_PRO_MODE: {ProMode}.");
+#endif
+    }
+
+    private static string RequireValue(string[] args, ref int index)
+    {
+        if (++index >= args.Length)
+            throw new ArgumentException($"Missing value for {args[index - 1]}.");
+        return args[index];
+    }
+
+    private static int ParsePositive(string value, string name, bool allowZero)
+    {
+        if (!int.TryParse(value, out var result) || result < (allowZero ? 0 : 1))
+            throw new ArgumentException($"Invalid {name}: {value}.");
+        return result;
+    }
+}
+
+internal sealed class NativeBenchmarkRunner
+{
+    private readonly Window _host;
+
+    public NativeBenchmarkRunner(Window host)
+    {
+        _host = host;
+    }
+
+    public async Task<NativeBenchmarkResult> RunAsync()
+    {
+        var firstRender = await MeasureFirstRenderAsync();
+        var expandAndRender = NativeBenchmarkOptions.FirstRenderOnly
+            ? null
+            : await MeasureExpandAndRenderAsync();
+        var scrollAndRender = NativeBenchmarkOptions.FirstRenderOnly
+            ? null
+            : await MeasureScrollAndRenderAsync();
+
+        return new NativeBenchmarkResult
+        {
+            TimestampUtc = DateTimeOffset.UtcNow,
+            Implementation = NativeBenchmarkOptions.ImplementationName,
+#if PRO && PRODATAGRID_PR335
+            Mode = NativeBenchmarkOptions.PerformanceMode,
+#else
+            Mode = NativeBenchmarkOptions.DrawnCells ? "drawn" : "retained",
+#endif
+            AvaloniaVersion = typeof(Application).Assembly.GetName().Version?.ToString() ?? "unknown",
+            Runtime = RuntimeInformation.FrameworkDescription,
+            OS = RuntimeInformation.OSDescription,
+            Architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            Processor = Environment.GetEnvironmentVariable("PROCESSOR_IDENTIFIER") ?? "unknown",
+            LogicalProcessorCount = Environment.ProcessorCount,
+            ClientWidth = _host.ClientSize.Width,
+            ClientHeight = _host.ClientSize.Height,
+            RenderScaling = _host.RenderScaling,
+            WarmupIterations = NativeBenchmarkOptions.WarmupIterations,
+            MeasuredIterations = NativeBenchmarkOptions.Iterations,
+            ScrollJumpsPerIteration = NativeBenchmarkOptions.ScrollJumps,
+            FirstExpandedRender = firstRender,
+            ExpandAllAndRender = expandAndRender,
+            ScrollAndRender = scrollAndRender,
+        };
+    }
+
+    private async Task<NativeWorkloadResult> MeasureFirstRenderAsync()
+    {
+        for (var i = 0; i < NativeBenchmarkOptions.WarmupIterations; ++i)
+            await FirstRenderIterationAsync(measure: false);
+
+        var times = new List<double>();
+        var allocations = new List<double>();
+        NativeValidation? validation = null;
+
+        for (var i = 0; i < NativeBenchmarkOptions.Iterations; ++i)
+        {
+            var measurement = await FirstRenderIterationAsync(measure: true);
+            times.Add(measurement.ElapsedMilliseconds);
+            allocations.Add(measurement.AllocatedBytes);
+            validation = measurement.Validation;
+        }
+
+        return NativeWorkloadResult.Create("FirstExpandedRender", times, allocations, validation!);
+    }
+
+    private async Task<NativeMeasurement> FirstRenderIterationAsync(bool measure)
+    {
+        using var handle = NativeGridAdapter.Create(expanded: true);
+        if (measure)
+            CollectForMeasurement();
+
+        var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var stopwatch = Stopwatch.StartNew();
+        _host.Content = handle.Grid;
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+        stopwatch.Stop();
+        var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
+        var validation = NativeGridAdapter.Validate(handle);
+        await DetachAsync();
+
+        return new NativeMeasurement(stopwatch.Elapsed.TotalMilliseconds, allocated, validation);
+    }
+
+    private async Task<NativeWorkloadResult> MeasureExpandAndRenderAsync()
+    {
+        for (var i = 0; i < NativeBenchmarkOptions.WarmupIterations; ++i)
+            await ExpandAndRenderIterationAsync(measure: false);
+
+        var times = new List<double>();
+        var allocations = new List<double>();
+        NativeValidation? validation = null;
+
+        for (var i = 0; i < NativeBenchmarkOptions.Iterations; ++i)
+        {
+            var measurement = await ExpandAndRenderIterationAsync(measure: true);
+            times.Add(measurement.ElapsedMilliseconds);
+            allocations.Add(measurement.AllocatedBytes);
+            validation = measurement.Validation;
+        }
+
+        return NativeWorkloadResult.Create("ExpandAllAndRender", times, allocations, validation!);
+    }
+
+    private async Task<NativeMeasurement> ExpandAndRenderIterationAsync(bool measure)
+    {
+        using var handle = NativeGridAdapter.Create(expanded: false);
+        _host.Content = handle.Grid;
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+
+        if (measure)
+            CollectForMeasurement();
+
+        var allocatedBefore = measure ? GC.GetTotalAllocatedBytes(precise: false) : 0;
+        var stopwatch = Stopwatch.StartNew();
+        handle.ExpandAll();
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+        stopwatch.Stop();
+        var allocated = measure ? GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore : 0;
+        var validation = NativeGridAdapter.Validate(handle);
+        await DetachAsync();
+
+        return new NativeMeasurement(stopwatch.Elapsed.TotalMilliseconds, allocated, validation);
+    }
+
+    private async Task<NativeWorkloadResult> MeasureScrollAndRenderAsync()
+    {
+        using var handle = NativeGridAdapter.Create(expanded: true);
+        _host.Content = handle.Grid;
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+        NativeGridAdapter.Validate(handle);
+        var viewer = NativeGridAdapter.GetScrollViewer(handle);
+
+        for (var batch = 0; batch < NativeBenchmarkOptions.WarmupIterations; ++batch)
+            await RunScrollBatchAsync(handle, viewer, batch, measure: false);
+
+        var times = new List<double>();
+        var allocationPerJump = new List<double>();
+
+        for (var batch = 0; batch < NativeBenchmarkOptions.Iterations; ++batch)
+        {
+            CollectForMeasurement();
+            var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+            var batchTimes = await RunScrollBatchAsync(handle, viewer, batch, measure: true);
+            var allocated = GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore;
+            times.AddRange(batchTimes);
+            allocationPerJump.Add(allocated / (double)NativeBenchmarkOptions.ScrollJumps);
+        }
+
+        var validation = NativeGridAdapter.Validate(handle);
+        await DetachAsync();
+        return NativeWorkloadResult.Create("ScrollAndRender", times, allocationPerJump, validation);
+    }
+
+    private async Task<IReadOnlyList<double>> RunScrollBatchAsync(
+        NativeGridHandle handle,
+        ScrollViewer viewer,
+        int batch,
+        bool measure)
+    {
+        var times = measure ? new List<double>(NativeBenchmarkOptions.ScrollJumps) : null;
+        for (var i = 0; i < NativeBenchmarkOptions.ScrollJumps; ++i)
+        {
+            var operation = (batch * NativeBenchmarkOptions.ScrollJumps) + i;
+            var row = ((operation * 509) % 2_000) + 1;
+            var stopwatch = Stopwatch.StartNew();
+            NativeGridAdapter.SetScrollRow(viewer, row);
+            handle.Grid.UpdateLayout();
+            await WaitForRenderedFrameAsync(_host);
+            stopwatch.Stop();
+            times?.Add(stopwatch.Elapsed.TotalMilliseconds);
+        }
+
+        return times is null ? Array.Empty<double>() : times;
+    }
+
+    private async Task DetachAsync()
+    {
+        _host.Content = null;
+        _host.UpdateLayout();
+        await WaitForRenderedFrameAsync(_host);
+    }
+
+    private static void CollectForMeasurement()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    public static async Task WaitForRenderedFrameAsync(TopLevel topLevel)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        topLevel.RequestAnimationFrame(_ =>
+            topLevel.RequestAnimationFrame(__ => completion.TrySetResult()));
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}
+
+internal static class NativeGridAdapter
+{
+    public static Window CreateHostWindow()
+    {
+        var window = new Window
+        {
+            Name = "BenchmarkWindow",
+            Title = $"Native hierarchy benchmark - {NativeBenchmarkOptions.ImplementationName}",
+            Width = 800,
+            Height = 500,
+            CanResize = false,
+            Background = Brushes.White,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
+        };
+#if !PRO
+        window.Styles.Add(new Style(x => x.OfType<TreeDataGridRow>())
+        {
+            Setters =
+            {
+                new Setter(TreeDataGridRow.HeightProperty, 24.0),
+            },
+        });
+#endif
+        return window;
+    }
+
+    public static NativeGridHandle Create(bool expanded)
+    {
+        var roots = TreeDataFactory.Create(TreeShape.Deep4094Depth11);
+#if PRO
+#if PRODATAGRID_PR335
+        var optimized = NativeBenchmarkOptions.ProMode != "standard";
+        var directHierarchy = NativeBenchmarkOptions.ProMode is "direct" or "direct-cell" or "drawn";
+        var directContent = NativeBenchmarkOptions.ProMode == "direct";
+        var directCell = NativeBenchmarkOptions.ProMode == "direct-cell";
+        var drawn = NativeBenchmarkOptions.ProMode == "drawn";
+        var options = new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            VirtualizeChildren = true,
+        };
+        var model = new HierarchicalModel<Node>(options);
+        model.SetRoots(roots);
+        if (expanded)
+            model.ExpandAll();
+
+        var grid = new DataGrid
+        {
+            Name = "BenchmarkGrid",
+            AutoGenerateColumns = false,
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            GridLinesVisibility = DataGridGridLinesVisibility.None,
+            IsReadOnly = true,
+            RowHeight = 24,
+            UseLogicalScrollable = true,
+            CanUserSortColumns = false,
+            CanUserResizeColumns = false,
+            CanUserReorderColumns = false,
+            UseLightweightFiller = optimized,
+        };
+        var hierarchyColumn = new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Width = new DataGridLength(300),
+            Binding = new Binding("Item.Name"),
+            UseDirectCell = directHierarchy,
+            UseDirectTextContent = directHierarchy,
+            TrackDirectTextValueChanges = false,
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            hierarchyColumn,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(node => ((Node)node.Item).Name));
+        grid.Columns.Add(hierarchyColumn);
+        AddProTextColumn(grid, "Id", 90, "Item.Id", node => ((Node)node.Item).Id, directContent, directCell, drawn);
+        AddProTextColumn(grid, "Depth", 90, "Item.Depth", node => ((Node)node.Item).Depth, directContent, directCell, drawn);
+        AddProTextColumn(grid, "Children", 100, "Item.ChildCount", node => ((Node)node.Item).ChildCount, directContent, directCell, drawn);
+        AddProTextColumn(grid, "Payload", 180, "Item.Payload", node => ((Node)node.Item).Payload, directContent, directCell, drawn);
+        if (optimized)
+            ApplyProOptimizedThemes(grid, featurePreserving: NativeBenchmarkOptions.ProMode == "optimized");
+        return new NativeGridHandle(model, grid);
+#else
+        var options = new HierarchicalOptions<Node>
+        {
+            ChildrenSelector = node => node.Children,
+            IsLeafSelector = node => node.Children.Count == 0,
+            VirtualizeChildren = true,
+        };
+        var model = new HierarchicalModel<Node>(options);
+        model.SetRoots(roots);
+        if (expanded)
+            model.ExpandAll();
+
+        var grid = new DataGrid
+        {
+            Name = "BenchmarkGrid",
+            AutoGenerateColumns = false,
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            GridLinesVisibility = DataGridGridLinesVisibility.None,
+            IsReadOnly = true,
+            RowHeight = 24,
+            UseLogicalScrollable = true,
+            CanUserSortColumns = false,
+            CanUserResizeColumns = false,
+            CanUserReorderColumns = false,
+        };
+        grid.Columns.Add(new DataGridHierarchicalColumn
+        {
+            Header = "Name",
+            Width = new DataGridLength(300),
+            Binding = new Binding("Item.Name"),
+        });
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Id",
+            Width = new DataGridLength(90),
+            Binding = new Binding("Item.Id"),
+        });
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Depth",
+            Width = new DataGridLength(90),
+            Binding = new Binding("Item.Depth"),
+        });
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Children",
+            Width = new DataGridLength(100),
+            Binding = new Binding("Item.ChildCount"),
+        });
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Payload",
+            Width = new DataGridLength(180),
+            Binding = new Binding("Item.Payload"),
+        });
+        return new NativeGridHandle(model, grid);
+#endif
+#else
+        var source = new HierarchicalTreeDataGridSource<Node>(roots);
+#if ACCELERATE
+        source.WithHierarchicalExpanderTextColumn(
+            "Name",
+            x => x.Name,
+            x => x.Children,
+            hasChildren: x => x.HasChildren,
+            options: options =>
+            {
+                options.Width = new GridLength(300);
+                options.UseDrawnCells = NativeBenchmarkOptions.DrawnCells;
+            });
+#else
+        source.WithHierarchicalExpanderTextColumn(
+            "Name",
+            x => x.Name,
+            x => x.Children,
+            options => options.Width = new GridLength(300));
+#endif
+        source.WithTextColumn("Id", x => x.Id, options =>
+        {
+            options.Width = new GridLength(90);
+#if ACCELERATE
+            options.UseDrawnCells = NativeBenchmarkOptions.DrawnCells;
+#endif
+        });
+        source.WithTextColumn("Depth", x => x.Depth, options =>
+        {
+            options.Width = new GridLength(90);
+#if ACCELERATE
+            options.UseDrawnCells = NativeBenchmarkOptions.DrawnCells;
+#endif
+        });
+        source.WithTextColumn("Children", x => x.ChildCount, options =>
+        {
+            options.Width = new GridLength(100);
+#if ACCELERATE
+            options.UseDrawnCells = NativeBenchmarkOptions.DrawnCells;
+#endif
+        });
+        source.WithTextColumn("Payload", x => x.Payload, options =>
+        {
+            options.Width = new GridLength(180);
+#if ACCELERATE
+            options.UseDrawnCells = NativeBenchmarkOptions.DrawnCells;
+#endif
+        });
+        if (expanded)
+            source.ExpandAll();
+
+        var grid = new TreeDataGridControl
+        {
+            Name = "BenchmarkGrid",
+            Source = source,
+        };
+        return new NativeGridHandle(source, grid);
+#endif
+    }
+
+#if PRO && PRODATAGRID_PR335
+    private static void AddProTextColumn<TValue>(
+        DataGrid grid,
+        string header,
+        double width,
+        string bindingPath,
+        Func<HierarchicalNode, TValue> getter,
+        bool directContent,
+        bool directCell,
+        bool drawn)
+    {
+        var column = new DataGridTextColumn
+        {
+            Header = header,
+            Width = new DataGridLength(width),
+            Binding = new Binding(bindingPath),
+            UseDirectTextContent = directContent,
+            UseDirectTextCell = directCell,
+            TrackDirectTextValueChanges = false,
+            DisplayMode = drawn ? DataGridColumnDisplayMode.Drawn : DataGridColumnDisplayMode.Retained,
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, TValue>(getter));
+        grid.Columns.Add(column);
+    }
+
+    private static void ApplyProOptimizedThemes(DataGrid grid, bool featurePreserving)
+    {
+        grid.RowTheme = FindProTheme(
+            grid,
+            featurePreserving ? "DataGridOptimizedFeatureUnfrozenRowTheme" : "DataGridOptimizedUnfrozenRowTheme");
+        grid.CellTheme = FindProTheme(grid, "DataGridOptimizedCellTheme");
+        grid.ColumnHeaderTheme = FindProTheme(
+            grid,
+            featurePreserving ? "DataGridOptimizedFeatureColumnHeaderTheme" : "DataGridOptimizedColumnHeaderTheme");
+    }
+
+    private static ControlTheme FindProTheme(DataGrid grid, string key)
+    {
+        if ((grid.TryFindResource(key, out object? value) ||
+             Application.Current?.TryFindResource(key, out value) == true) &&
+            value is ControlTheme theme)
+        {
+            return theme;
+        }
+
+        throw new InvalidOperationException($"Unable to resolve optimized theme resource '{key}'.");
+    }
+#endif
+
+    public static NativeValidation Validate(NativeGridHandle handle)
+    {
+        if (handle.Count != 4_094)
+            throw new InvalidOperationException($"Expected 4,094 expanded rows, got {handle.Count:N0}.");
+
+#if PRO
+        var realizedRows = handle.Grid.GetVisualDescendants().OfType<DataGridRow>().Count();
+        var realizedCells = handle.Grid.GetVisualDescendants().OfType<DataGridCell>().Count();
+#else
+        var realizedRows = handle.Grid.GetVisualDescendants().OfType<TreeDataGridRow>().Count();
+        var realizedCells = handle.Grid.GetVisualDescendants().OfType<TreeDataGridCell>().Count();
+#endif
+        if (realizedRows <= 0 || realizedRows >= 200)
+            throw new InvalidOperationException($"Virtualization validation failed: {realizedRows} realized rows.");
+
+        var viewer = GetScrollViewer(handle);
+        return new NativeValidation(
+            realizedRows,
+            realizedCells,
+            viewer.Extent.Width,
+            viewer.Extent.Height,
+            viewer.Viewport.Width,
+            viewer.Viewport.Height);
+    }
+
+    public static ScrollViewer GetScrollViewer(NativeGridHandle handle) =>
+        handle.Grid.GetVisualDescendants()
+            .OfType<ScrollViewer>()
+            .First(x => x.Name == "PART_ScrollViewer");
+
+    public static void SetScrollRow(ScrollViewer viewer, int row)
+    {
+#if PRO
+        viewer.Offset = new Vector(0, row);
+#else
+        viewer.Offset = new Vector(0, row * 24.0);
+#endif
+    }
+}
+
+#if PRO
+internal sealed class NativeGridHandle : IDisposable
+{
+    public NativeGridHandle(HierarchicalModel<Node> model, DataGrid grid)
+    {
+        Model = model;
+        Grid = grid;
+    }
+
+    public HierarchicalModel<Node> Model { get; }
+
+    public DataGrid Grid { get; }
+
+    public int Count => Model.Count;
+
+    public void ExpandAll() => Model.ExpandAll();
+
+    public void Dispose()
+    {
+    }
+}
+#else
+internal sealed class NativeGridHandle : IDisposable
+{
+    public NativeGridHandle(HierarchicalTreeDataGridSource<Node> source, TreeDataGridControl grid)
+    {
+        Source = source;
+        Grid = grid;
+    }
+
+    public HierarchicalTreeDataGridSource<Node> Source { get; }
+
+    public TreeDataGridControl Grid { get; }
+
+    public int Count => Source.Rows.Count;
+
+    public void ExpandAll() => Source.ExpandAll();
+
+    public void Dispose() => Source.Dispose();
+}
+#endif
+
+internal sealed record NativeMeasurement(
+    double ElapsedMilliseconds,
+    long AllocatedBytes,
+    NativeValidation Validation);
+
+internal sealed record NativeValidation(
+    int RealizedRows,
+    int RealizedCells,
+    double ExtentWidth,
+    double ExtentHeight,
+    double ViewportWidth,
+    double ViewportHeight);
+
+internal sealed class NativeWorkloadResult
+{
+    public required string Name { get; init; }
+
+    public int Samples { get; init; }
+
+    public double MeanMilliseconds { get; init; }
+
+    public double MedianMilliseconds { get; init; }
+
+    public double P95Milliseconds { get; init; }
+
+    public double StandardDeviationMilliseconds { get; init; }
+
+    public double MeanAllocatedBytes { get; init; }
+
+    public required NativeValidation Validation { get; init; }
+
+    public static NativeWorkloadResult Create(
+        string name,
+        IReadOnlyList<double> times,
+        IReadOnlyList<double> allocations,
+        NativeValidation validation)
+    {
+        var ordered = times.OrderBy(x => x).ToArray();
+        var mean = times.Average();
+        var variance = times.Sum(x => Math.Pow(x - mean, 2)) / times.Count;
+        return new NativeWorkloadResult
+        {
+            Name = name,
+            Samples = times.Count,
+            MeanMilliseconds = mean,
+            MedianMilliseconds = Percentile(ordered, 0.50),
+            P95Milliseconds = Percentile(ordered, 0.95),
+            StandardDeviationMilliseconds = Math.Sqrt(variance),
+            MeanAllocatedBytes = allocations.Average(),
+            Validation = validation,
+        };
+    }
+
+    private static double Percentile(IReadOnlyList<double> ordered, double percentile)
+    {
+        var index = Math.Clamp((int)Math.Ceiling(percentile * ordered.Count) - 1, 0, ordered.Count - 1);
+        return ordered[index];
+    }
+}
+
+internal sealed class NativeBenchmarkResult
+{
+    public DateTimeOffset TimestampUtc { get; init; }
+
+    public required string Implementation { get; init; }
+
+    public required string Mode { get; init; }
+
+    public required string AvaloniaVersion { get; init; }
+
+    public required string Runtime { get; init; }
+
+    public required string OS { get; init; }
+
+    public required string Architecture { get; init; }
+
+    public required string Processor { get; init; }
+
+    public int LogicalProcessorCount { get; init; }
+
+    public double ClientWidth { get; init; }
+
+    public double ClientHeight { get; init; }
+
+    public double RenderScaling { get; init; }
+
+    public int WarmupIterations { get; init; }
+
+    public int MeasuredIterations { get; init; }
+
+    public int ScrollJumpsPerIteration { get; init; }
+
+    public required NativeWorkloadResult FirstExpandedRender { get; init; }
+
+    public NativeWorkloadResult? ExpandAllAndRender { get; init; }
+
+    public NativeWorkloadResult? ScrollAndRender { get; init; }
+}
+
+internal static class NativeBenchmarkResultWriter
+{
+    public static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        WriteIndented = true,
+    };
+
+    public static async Task WriteAsync(NativeBenchmarkResult result, string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(result, JsonOptions));
+    }
+}


### PR DESCRIPTION
## Summary

- add a public settable `DataGridRealizationFactory` for row, cell, and column-header containers, with typed realization contexts and safe recycling-key partitioning
- add a guarded hierarchy bulk-splice path that preserves valid realized rows and avoids the broad refresh used by large flattened changes
- replace repeated-node `CollapseAll` mutation with one traversal and one coherent flattened replacement while preserving lifecycle notifications
- avoid summary dispatch when unused, pool collapse traversal storage, and suppress the redundant post-bulk-splice `LayoutUpdated` indentation refresh
- add headless/unit/regression coverage for factory replacement, recycling, hierarchy correctness, lifecycle events, selection, and exact indentation-refresh count
- add a source-only native benchmark against a pinned open-source TreeDataGrid revision, including independent processes, phase/callback diagnostics, sampled traces, and CI gates

## Public realization factory

`DataGridRealizationFactory` controls the virtualized outer row, cell, and column-header containers. Contexts expose normalized application items, hierarchy nodes, row/slot coordinates, columns, and frozen regions. Symmetric request/element keys prevent incompatible containers from sharing pools. Replacing the factory clears old realized/recycled containers while preserving selection. Column-owned display content, editors, value access, filtering, export, and validation remain separate.

## Native expand all + render

The corrected source-only Windows lane uses four independent process means per mode, two warmups and ten measurements per process, alternating order, a 4,094-node hierarchy, five columns, an 800 x 500 native window, explicit `UpdateLayout()`, and a timed two-callback completion convention.

| Source implementation | Mean | 95% CI | Managed allocation |
|---|---:|---:|---:|
| ProDataGrid drawn ordinary cells | **40.53 ms** | 29.47–51.60 ms | **4,671,045 B** |
| Pinned open-source TreeDataGrid | 46.78 ms | 43.17–50.39 ms | 6,466,079 B |

ProDataGrid's mean is **13.4% faster** and allocation is **27.8% lower**. The latency intervals overlap, so this is a relative mean result rather than a claim of statistical separation.

## Bulk collapse and frame-wait diagnosis

The 149,792-node sample begins fully expanded with retained children and collapses to 32 roots.

| Source implementation | Mutation + layout | Frame wait | Two-callback total | 95% CI for total | Allocation |
|---|---:|---:|---:|---:|---:|
| ProDataGrid direct-content (best path/allocation) | **9.53 ms** | 9.80 ms | 19.33 ms | 16.99–21.66 ms | **543,013 B** |
| ProDataGrid direct-cell (best total) | 10.28 ms | 8.55 ms | **18.83 ms** | 15.99–21.67 ms | 548,964 B |
| Pinned open-source TreeDataGrid | 13.02 ms | **7.85 ms** | 20.87 ms | 18.68–23.06 ms | 1,076,210 B |

The prior apparent 3x frame-wait gap was a pre-sample alignment defect. Two unmeasured alignment callbacks could return while ProDataGrid's preceding composition batch was still pending, so timed callback 1 waited for unrelated work. Changing only the unmeasured alignment barrier from two to three pulses reduced ProDataGrid's layout-to-callback-1 delay from 5.93 ms to 0.048 ms and its diagnostic frame wait from 24.03 ms to 13.84 ms; TreeDataGrid stayed in the same band. The measured operation still uses two callbacks.

In the complete corrected matrix, best-total ProDataGrid's frame wait is only 8.9% above TreeDataGrid, a practical tie under the established 10% rule. ProDataGrid's full total is 9.8% faster. Every mode raises exactly one `LayoutUpdated` per sample. Avalonia compositor update/render meters and sampled Windows compositor-loop CPU do not support a speculative production render change.

`RequestAnimationFrame` is an animation-clock callback, not a GPU/presentation fence. Callback 1 runs before UI render recording; callback 2 runs on a later pulse after the preceding composition batch is marked `Processed`, which is earlier than `Rendered`. The benchmark README and comparison article document the exact sequence.

[Passing corrected source-only workflow](https://github.com/wieslawsoltes/ProDataGrid/actions/runs/31494599053)

## Validation

- focused hierarchy headless tests: 42 passed
- hierarchy model tests: 126 passed
- complete hierarchy test set: 323 passed
- complete `Avalonia.Controls.DataGrid.UnitTests` suite: 2,749 passed before final benchmark/documentation-only commits
- complete `DataGridSample.UnitTests` suite: 354 passed
- leak-test suite: 38 passed
- current source builds, platform test workflow, leak workflow, native source comparison, `actionlint`, and `git diff --check`: passing/clean

No paid assembly or package was inspected, referenced, restored, or benchmarked. The unrelated local edit in `src/DataGridSample/MainWindow.axaml.cs` remains excluded from this branch and PR.
