### PR TITLE
fix: address outstanding PR #335 review findings

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDirectBindingSemanticsTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDirectBindingSemanticsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Data;
@@ -159,6 +160,44 @@ public sealed class DataGridDirectBindingSemanticsTests
         Assert.Equal("Value: ", cell.Value);
     }
 
+    [AvaloniaFact]
+    public void Nested_Path_Falls_Back_To_Binding_And_Observes_Leaf_Notifications()
+    {
+        var address = new Address("Warsaw");
+        var item = new PersonWithAddress(address);
+        var column = new TestTextColumn
+        {
+            Binding = new Binding("Address.City"),
+            UseDirectTextCell = true,
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<PersonWithAddress, string>(
+                static person => person.Address.City));
+        var cell = Assert.IsType<DataGridDirectTextCell>(column.CreateCell());
+        cell.DataContext = item;
+
+        Assert.Null(column.GenerateDisplay(cell, item));
+        var window = new Window { Width = 180, Height = 60, Content = cell };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(cell.UsesValueAccessor);
+            Assert.Equal("Warsaw", cell.Value);
+
+            address.City = "Krakow";
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("Krakow", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static TestTextColumn CreateColumn(BindingMode mode)
     {
         var column = new TestTextColumn
@@ -181,6 +220,35 @@ public sealed class DataGridDirectBindingSemanticsTests
     private sealed record Item(string Name);
 
     private sealed record NullableItem(string? Name);
+
+    private sealed record PersonWithAddress(Address Address);
+
+    private sealed class Address : INotifyPropertyChanged
+    {
+        private string _city;
+
+        public Address(string city)
+        {
+            _city = city;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string City
+        {
+            get => _city;
+            set
+            {
+                if (_city == value)
+                {
+                    return;
+                }
+
+                _city = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(City)));
+            }
+        }
+    }
 
     private sealed class RecordingConverter : IValueConverter
     {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridImageColumnHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridImageColumnHeadlessTests.cs
@@ -106,6 +106,101 @@ public class DataGridImageColumnHeadlessTests
         Assert.Equal(Stretch.Uniform, column.Stretch);
     }
 
+    [AvaloniaTheory]
+    [InlineData(Stretch.UniformToFill, 28d, 8d, 24d, 24d)]
+    [InlineData(Stretch.None, 30d, 10d, 20d, 20d)]
+    public void Drawn_Image_Uses_Expected_Source_Destination_And_Retained_Viewport(
+        Stretch stretch,
+        double destinationX,
+        double destinationY,
+        double destinationWidth,
+        double destinationHeight)
+    {
+        var source = new RecordingImage(new Size(20, 20));
+        var item = new RenderImageItem(source);
+        TestImageColumn retainedColumn = CreateRenderColumn(
+            "Retained",
+            DataGridColumnDisplayMode.Retained,
+            stretch);
+        TestImageColumn drawnColumn = CreateRenderColumn(
+            "Drawn",
+            DataGridColumnDisplayMode.Drawn,
+            stretch);
+        var retainedCell = new DataGridCell { DataContext = item };
+        Image retainedImage = Assert.IsType<Image>(retainedColumn.CreateDisplay(retainedCell, item));
+        retainedImage.Measure(new Size(80, 40));
+        Assert.Equal(new Size(24, 12), retainedImage.DesiredSize);
+
+        var drawnCell = Assert.IsType<DataGridCustomDrawingCell>(drawnColumn.CreateCell());
+        drawnCell.OwningColumn = drawnColumn;
+        drawnCell.DataContext = item;
+        Assert.Null(drawnColumn.CreateDisplay(drawnCell, item));
+        drawnCell.Measure(new Size(80, 40));
+        drawnCell.Arrange(new Rect(0, 0, 80, 40));
+
+        var recorded = new DrawingGroup();
+        using (DrawingContext context = recorded.Open())
+        {
+            DataGridImageCellRenderer.Instance.Render(drawnCell, context);
+        }
+
+        DrawingGroup clippedImage = Assert.IsType<DrawingGroup>(Assert.Single(recorded.Children));
+        RectangleGeometry clip = Assert.IsType<RectangleGeometry>(clippedImage.ClipGeometry);
+        Assert.Equal(new Rect(28, 14, retainedImage.DesiredSize.Width, retainedImage.DesiredSize.Height), clip.Rect);
+        Assert.Equal(1, source.DrawCount);
+        Assert.Equal(new Rect(0, 0, 20, 20), source.SourceRect);
+        Assert.Equal(
+            new Rect(destinationX, destinationY, destinationWidth, destinationHeight),
+            source.DestinationRect);
+        Assert.NotEmpty(clippedImage.Children);
+    }
+
+    private static TestImageColumn CreateRenderColumn(
+        object header,
+        DataGridColumnDisplayMode displayMode,
+        Stretch stretch)
+    {
+        var column = new TestImageColumn
+        {
+            Header = header,
+            Binding = new Binding(nameof(RenderImageItem.Source)),
+            DisplayMode = displayMode,
+            ImageWidth = 24,
+            ImageHeight = 12,
+            Stretch = stretch,
+            Width = new DataGridLength(80),
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<RenderImageItem, IImage>(
+                static item => item.Source));
+        return column;
+    }
+
+    private sealed class RecordingImage : IImage
+    {
+        public RecordingImage(Size size)
+        {
+            Size = size;
+        }
+
+        public Size Size { get; }
+
+        public int DrawCount { get; private set; }
+
+        public Rect SourceRect { get; private set; }
+
+        public Rect DestinationRect { get; private set; }
+
+        public void Draw(DrawingContext context, Rect sourceRect, Rect destRect)
+        {
+            DrawCount++;
+            SourceRect = sourceRect;
+            DestinationRect = destRect;
+            context.DrawRectangle(Brushes.Red, null, destRect);
+        }
+    }
+
     private static (Window window, DataGrid grid) CreateWindow(ImageTestViewModel vm)
     {
         var window = new Window
@@ -171,8 +266,13 @@ public class DataGridImageColumnHeadlessTests
         public string? ImagePath { get; set; }
     }
 
+    private sealed record RenderImageItem(IImage Source);
+
     private sealed class TestImageColumn : DataGridImageColumn
     {
+        public Control? CreateDisplay(DataGridCell cell, object dataItem) =>
+            GenerateElement(cell, dataItem);
+
         public Control CreateEditingElement(DataGridCell cell, object dataItem) =>
             GenerateEditingElementDirect(cell, dataItem);
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridOptimizedCellTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridOptimizedCellTests.cs
@@ -668,6 +668,280 @@ public sealed class DataGridOptimizedCellTests
     }
 
     [AvaloniaFact]
+    public void DrawnText_HierarchicalNodeAccessor_WithoutTracking_RefreshesOnlyOnRecycle()
+    {
+        var oldItem = new NotifyItem("Old");
+        var oldNode = new HierarchicalNode(oldItem, isLeaf: true);
+        var currentItem = new NotifyItem("Current");
+        var currentNode = new HierarchicalNode(currentItem, isLeaf: true);
+        var column = new TestTextColumn
+        {
+            Binding = new Binding("Item.Name"),
+            DisplayMode = DataGridColumnDisplayMode.Drawn,
+            TrackDirectTextValueChanges = false
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(
+                node => $"accessor:{((NotifyItem)node.Item).Name}"));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = oldNode;
+        Assert.Null(column.GenerateDisplay(cell, oldNode));
+        Assert.True(cell.UsesValueProvider);
+        Assert.Equal("accessor:Old", cell.Value);
+
+        var window = AttachCell(cell);
+        try
+        {
+            oldItem.Name = "Ignored";
+            Assert.Equal("accessor:Old", cell.Value);
+
+            cell.DataContext = currentNode;
+            Assert.Equal("accessor:Current", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DrawnText_HierarchicalNodeAccessor_TracksWrappedItem_AndIgnoresStaleOrDetachedItem()
+    {
+        var oldItem = new NotifyItem("Old");
+        var oldNode = new HierarchicalNode(oldItem, isLeaf: true);
+        var currentItem = new NotifyItem("Current");
+        var currentNode = new HierarchicalNode(currentItem, isLeaf: true);
+        var column = new TestTextColumn
+        {
+            Binding = new Binding("Item.Name"),
+            DisplayMode = DataGridColumnDisplayMode.Drawn
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(
+                node => $"accessor:{((NotifyItem)node.Item).Name}"));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = oldNode;
+        Assert.Null(column.GenerateDisplay(cell, oldNode));
+        Assert.True(cell.UsesValueProvider);
+
+        var window = AttachCell(cell);
+        try
+        {
+            oldItem.Name = "Old updated";
+            Assert.Equal("accessor:Old updated", cell.Value);
+
+            cell.DataContext = currentNode;
+            Assert.Equal("accessor:Current", cell.Value);
+
+            oldItem.Name = "Stale";
+            Assert.Equal("accessor:Current", cell.Value);
+
+            currentItem.Name = "Current updated";
+            Assert.Equal("accessor:Current updated", cell.Value);
+
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+
+            currentItem.Name = "Detached";
+            Assert.Equal("accessor:Current updated", cell.Value);
+
+            window.Content = cell;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.Equal("accessor:Detached", cell.Value);
+
+            currentItem.Name = "Reattached";
+            Assert.Equal("accessor:Reattached", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DrawnText_SelfWrappedHierarchyNotifier_RefreshesAccessorOncePerChange()
+    {
+        var item = new SelfWrappedNotifyItem("First");
+        var column = new TestTextColumn
+        {
+            Binding = new Binding("Item.Name"),
+            DisplayMode = DataGridColumnDisplayMode.Drawn
+        };
+        int accessorReads = 0;
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<SelfWrappedNotifyItem, string>(value =>
+            {
+                accessorReads++;
+                return value.Name;
+            }));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = item;
+        Assert.Null(column.GenerateDisplay(cell, item));
+        Assert.True(cell.UsesValueProvider);
+
+        var window = AttachCell(cell);
+        try
+        {
+            int readsBeforeChange = accessorReads;
+
+            item.Name = "Second";
+
+            Assert.Equal(readsBeforeChange + 1, accessorReads);
+            Assert.Equal("Second", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DrawnText_RuntimeTrackingEnable_SubscribesToWrappedHierarchyItem()
+    {
+        var item = new NotifyItem("First");
+        var node = new HierarchicalNode(item, isLeaf: true);
+        var column = new DataGridTextColumn
+        {
+            Binding = new Binding("Item.Name"),
+            DisplayMode = DataGridColumnDisplayMode.Drawn,
+            TrackDirectTextValueChanges = false,
+            Width = new DataGridLength(160)
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(
+                value => $"accessor:{((NotifyItem)value.Item).Name}"));
+        var grid = new DataGrid
+        {
+            Width = 240,
+            Height = 120,
+            RowHeight = 24,
+            ItemsSource = new[] { node },
+            AutoGenerateColumns = false
+        };
+        grid.ColumnsInternal.Add(column);
+
+        var window = new Window { Width = 280, Height = 160 };
+        window.SetThemeStyles(DataGridTheme.FluentV2);
+        window.Content = grid;
+        try
+        {
+            window.Show();
+            grid.ApplyTemplate();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            grid.UpdateLayout();
+
+            var row = Assert.Single(GetRealizedRows(grid));
+            var cell = Assert.IsType<DataGridCustomDrawingCell>(row.Cells[0]);
+            Assert.True(cell.UsesValueProvider);
+            Assert.Equal("accessor:First", cell.Value);
+
+            item.Name = "Ignored";
+            Assert.Equal("accessor:First", cell.Value);
+
+            column.TrackDirectTextValueChanges = true;
+            Assert.Equal("accessor:Ignored", cell.Value);
+
+            item.Name = "Tracked";
+            Assert.Equal("accessor:Tracked", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DrawnText_DirectHierarchyMember_TracksNodeButNotWrappedItem()
+    {
+        var item = new NotifyItem("First");
+        var node = new HierarchicalNode(item, isLeaf: true);
+        var column = new TestTextColumn
+        {
+            Binding = new Binding(nameof(HierarchicalNode.Level)),
+            DisplayMode = DataGridColumnDisplayMode.Drawn
+        };
+        int accessorReads = 0;
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(value =>
+            {
+                accessorReads++;
+                return $"accessor:{value.Level}";
+            }));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = node;
+        Assert.Null(column.GenerateDisplay(cell, node));
+        Assert.True(cell.UsesValueProvider);
+        Assert.Equal("accessor:0", cell.Value);
+
+        var window = AttachCell(cell);
+        try
+        {
+            int readsAfterAttach = accessorReads;
+
+            item.Name = "Wrapped change";
+
+            Assert.Equal(readsAfterAttach, accessorReads);
+            Assert.Equal("accessor:0", cell.Value);
+
+            node.Level = 1;
+
+            Assert.Equal(readsAfterAttach + 1, accessorReads);
+            Assert.Equal("accessor:1", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DrawnText_NestedHierarchyPath_UsesBindingAndTracksLeaf_WhenDirectTrackingDisabled()
+    {
+        var address = new NotifyAddress("First");
+        var node = new HierarchicalNode(new AddressItem(address), isLeaf: true);
+        var column = new TestTextColumn
+        {
+            Binding = new Binding("Item.Address.City"),
+            DisplayMode = DataGridColumnDisplayMode.Drawn,
+            TrackDirectTextValueChanges = false
+        };
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(
+                value => $"accessor:{((AddressItem)value.Item).Address.City}"));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = node;
+        Assert.Null(column.GenerateDisplay(cell, node));
+
+        var window = AttachCell(cell);
+        try
+        {
+            Assert.False(cell.UsesValueProvider);
+            Assert.Equal("First", cell.Value);
+
+            address.City = "Second";
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("Second", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void CustomDrawingCell_Can_Use_Typed_Accessor_Without_Change_Subscription()
     {
         var item = new NotifyItem("First");
@@ -691,6 +965,53 @@ public sealed class DataGridOptimizedCellTests
 
         cell.DataContext = new NotifyItem("Third");
         Assert.Equal("Third", cell.Value);
+    }
+
+    [AvaloniaFact]
+    public void CustomDrawingCell_TracksHierarchyNodeButNotWrappedItem()
+    {
+        var item = new NotifyItem("First");
+        var node = new HierarchicalNode(item, isLeaf: true);
+        var column = new TestCustomDrawingColumn
+        {
+            Binding = new Binding(nameof(HierarchicalNode.Level)),
+            UseDirectValueAccessor = true,
+            TrackDirectValueChanges = true
+        };
+        int accessorReads = 0;
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<HierarchicalNode, string>(value =>
+            {
+                accessorReads++;
+                return $"provider:{value.Level}";
+            }));
+
+        var cell = Assert.IsType<DataGridCustomDrawingCell>(column.CreateCell());
+        cell.DataContext = node;
+        Assert.Null(column.GenerateDisplay(cell, node));
+        Assert.True(cell.UsesValueProvider);
+        Assert.Equal("provider:0", cell.Value);
+
+        var window = AttachCell(cell);
+        try
+        {
+            int readsAfterAttach = accessorReads;
+
+            item.Name = "Wrapped change";
+
+            Assert.Equal(readsAfterAttach, accessorReads);
+            Assert.Equal("provider:0", cell.Value);
+
+            node.Level = 1;
+
+            Assert.Equal(readsAfterAttach + 1, accessorReads);
+            Assert.Equal("provider:1", cell.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -1742,6 +2063,65 @@ public sealed class DataGridOptimizedCellTests
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
             }
         }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    private sealed record AddressItem(NotifyAddress Address);
+
+    private sealed class NotifyAddress : INotifyPropertyChanged
+    {
+        private string _city;
+
+        public NotifyAddress(string city) => _city = city;
+
+        public string City
+        {
+            get => _city;
+            set
+            {
+                if (_city == value)
+                {
+                    return;
+                }
+
+                _city = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(City)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    private sealed class SelfWrappedNotifyItem : INotifyPropertyChanged, IHierarchicalNodeItem
+    {
+        private readonly HierarchicalNode _node;
+        private string _name;
+
+        public SelfWrappedNotifyItem(string name)
+        {
+            _name = name;
+            _node = new HierarchicalNode(this, isLeaf: true);
+        }
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name == value)
+                {
+                    return;
+                }
+
+                _name = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            }
+        }
+
+        object IHierarchicalNodeItem.Item => this;
+
+        HierarchicalNode IHierarchicalNodeItem.Node => _node;
 
         public event PropertyChangedEventHandler? PropertyChanged;
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowStylingTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowStylingTests.cs
@@ -9,7 +9,9 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
 using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -31,6 +33,44 @@ public class DataGridRowStylingTests
         {
             var row = grid.GetVisualDescendants().OfType<DataGridRow>().First();
             Assert.Same(rowTheme, row.GetValue(StyledElement.ThemeProperty));
+        }
+        finally
+        {
+            root.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void OptimizedRowTheme_Propagates_RowBackground_Initially_And_After_Change()
+    {
+        var initialBackground = new SolidColorBrush(Colors.Crimson);
+        var updatedBackground = new SolidColorBrush(Colors.CornflowerBlue);
+        var (grid, root, items) = CreateGrid();
+
+        try
+        {
+            Assert.True(grid.TryFindResource("DataGridOptimizedRowTheme", out var rowTheme));
+            grid.RowBackground = initialBackground;
+            grid.RowTheme = Assert.IsType<ControlTheme>(rowTheme);
+            grid.ItemsSource = null;
+            grid.ItemsSource = items;
+            Dispatcher.UIThread.RunJobs();
+            root.UpdateLayout();
+            grid.UpdateLayout();
+
+            var row = Assert.IsType<DataGridRow>(grid.GetRowFromItem(items[0]));
+            var rowRoot = Assert.Single(row.GetVisualDescendants().OfType<DataGridFrozenGrid>());
+            Assert.Same(initialBackground, row.Background);
+            Assert.Same(initialBackground, rowRoot.Background);
+
+            grid.RowBackground = updatedBackground;
+            Dispatcher.UIThread.RunJobs();
+            root.UpdateLayout();
+            grid.UpdateLayout();
+
+            Assert.Same(row, grid.GetRowFromItem(items[0]));
+            Assert.Same(updatedBackground, row.Background);
+            Assert.Same(updatedBackground, rowRoot.Background);
         }
         finally
         {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridAccessorFilteringAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridAccessorFilteringAdapterTests.cs
@@ -327,6 +327,56 @@ public class DataGridAccessorFilteringAdapterTests
         Assert.Empty(view.Cast<LongPerson>());
     }
 
+    [AvaloniaFact]
+    public void AccessorAdapter_Invokes_Refresh_Lifecycle_Once_Per_Effective_Filter_Change()
+    {
+        var items = new[]
+        {
+            new Person("A", 1),
+            new Person("B", 2)
+        };
+        var view = new DataGridCollectionView(items);
+        var model = new FilteringModel();
+        var column = new DataGridTextColumn();
+        DataGridColumnMetadata.SetValueAccessor(
+            column,
+            new DataGridColumnValueAccessor<Person, int>(static person => person.Score));
+        int beforeRefreshCount = 0;
+        int afterRefreshCount = 0;
+
+        using var adapter = new DataGridAccessorFilteringAdapter(
+            model,
+            () => new[] { column },
+            beforeViewRefresh: () => beforeRefreshCount++,
+            afterViewRefresh: () => afterRefreshCount++);
+        adapter.AttachView(view);
+        beforeRefreshCount = 0;
+        afterRefreshCount = 0;
+
+        model.SetOrUpdate(new FilteringDescriptor(
+            columnId: column,
+            @operator: FilteringOperator.Equals,
+            value: 2));
+
+        Assert.Equal(1, beforeRefreshCount);
+        Assert.Equal(1, afterRefreshCount);
+        Assert.Equal(new[] { 2 }, view.Cast<Person>().Select(static person => person.Score));
+
+        model.SetOrUpdate(new FilteringDescriptor(
+            columnId: column,
+            @operator: FilteringOperator.Equals,
+            value: 2));
+
+        Assert.Equal(1, beforeRefreshCount);
+        Assert.Equal(1, afterRefreshCount);
+
+        model.Clear();
+
+        Assert.Equal(2, beforeRefreshCount);
+        Assert.Equal(2, afterRefreshCount);
+        Assert.Equal(new[] { 1, 2 }, view.Cast<Person>().Select(static person => person.Score));
+    }
+
     private sealed class Person
     {
         public Person(string name, int score)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridHierarchicalFilteringAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridHierarchicalFilteringAdapterTests.cs
@@ -95,6 +95,27 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.False(branch.IsExpanded);
     }
 
+    [AvaloniaFact]
+    public void Removing_Only_Matching_Descendant_From_Collapsed_Branch_Removes_Retained_Ancestors()
+    {
+        TreeItem root = CreateTree();
+        TreeItem branchItem = root.Children[0];
+        HierarchicalModel hierarchy = CreateModel(root, virtualizeChildren: false);
+        HierarchicalNode branch = hierarchy.Root!.Children[0];
+        hierarchy.Collapse(branch);
+        using AdapterFixture fixture = CreateFixture(
+            hierarchy,
+            DataGridHierarchyFilterPolicy.KeepAncestorsOfMatches);
+        fixture.Filter("needle");
+        Assert.Equal(new[] { "root", "branch" }, fixture.VisibleNames());
+
+        branchItem.Children.RemoveAt(0);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Empty(fixture.VisibleNames());
+        Assert.False(branch.IsExpanded);
+    }
+
     [Fact]
     public void Filtering_Does_Not_Implicitly_Load_Unmaterialized_Children()
     {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridHierarchicalFilteringAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Filtering/DataGridHierarchicalFilteringAdapterTests.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.DataGridTests.Filtering;
 
 public class DataGridHierarchicalFilteringAdapterTests
 {
-    [Theory]
+    [AvaloniaTheory]
     [InlineData(DataGridHierarchyFilterPolicy.SelfOnly, "needle")]
     [InlineData(DataGridHierarchyFilterPolicy.KeepAncestorsOfMatches, "root,branch,needle")]
     [InlineData(DataGridHierarchyFilterPolicy.KeepDescendantsOfMatches, "needle")]
@@ -47,7 +47,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.True(hierarchy.Root!.IsExpanded);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Descendant_Policy_Keeps_The_Materialized_Subtree_Of_A_Match()
     {
         TreeItem root = CreateTree();
@@ -61,7 +61,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.Equal(new[] { "branch", "needle" }, fixture.VisibleNames());
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Clearing_Filter_Restores_View_Without_Changing_Expansion()
     {
         TreeItem root = CreateTree();
@@ -78,7 +78,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.True(hierarchy.Root.Children[0].IsExpanded);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Collapsed_Tree_Uses_Materialized_Descendants_Without_Expanding()
     {
         TreeItem root = CreateTree();
@@ -116,7 +116,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.False(branch.IsExpanded);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Filtering_Does_Not_Implicitly_Load_Unmaterialized_Children()
     {
         int loadCount = 0;
@@ -178,12 +178,21 @@ public class DataGridHierarchicalFilteringAdapterTests
             DataGridHierarchyFilterPolicy.KeepAncestorsOfMatches);
         fixture.Filter("needle");
         fixture.ResetRefreshCounts();
+        var queued = new Queue<Action>();
+        fixture.SetViewThreadPost(queued.Enqueue);
 
         Task expand = hierarchy.ExpandAsync(hierarchy.Root!);
         completion.SetResult(new[] { new TreeItem("needle") });
         await expand;
-        Dispatcher.UIThread.RunJobs();
 
+        Assert.Single(queued);
+        queued.Dequeue()();
+        Assert.Single(queued);
+        Assert.Equal(0, fixture.BeforeRefreshCount);
+        Assert.Equal(0, fixture.AfterRefreshCount);
+        queued.Dequeue()();
+
+        Assert.Empty(queued);
         Assert.Equal(new[] { "root", "needle" }, fixture.VisibleNames());
         Assert.Equal(1, fixture.BeforeRefreshCount);
         Assert.Equal(1, fixture.AfterRefreshCount);
@@ -316,7 +325,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.Equal(1, fixture.AfterRefreshCount);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Supports_Node_Typed_Column_Accessors_For_Compatibility()
     {
         TreeItem root = CreateTree();
@@ -336,7 +345,7 @@ public class DataGridHierarchicalFilteringAdapterTests
         Assert.Equal(new[] { "root", "branch", "needle" }, fixture.VisibleNames());
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Custom_Predicate_Receives_The_Underlying_Item()
     {
         TreeItem root = CreateTree();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -2035,6 +2035,84 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
     }
 
     [Fact]
+    public async Task ExpandAllAsync_Failed_Reload_Clears_Pending_Collapsed_Descendant()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        var grandchild = new Item("grandchild");
+        child.Children.Add(grandchild);
+        root.Children.Add(child);
+        var failChildLoad = false;
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            VirtualizeChildren = true,
+            ChildrenSelectorAsync = (item, _) =>
+            {
+                if (failChildLoad && ReferenceEquals(item, child))
+                {
+                    return Task.FromException<IEnumerable?>(new InvalidOperationException("child load failed"));
+                }
+
+                return Task.FromResult<IEnumerable?>(((Item)item).Children);
+            }
+        });
+        model.SetRoot(root);
+        await model.ExpandAllAsync(
+            maxDepth: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var childNode = Assert.Single(model.Root!.Children);
+        Assert.True(childNode.IsExpanded);
+        Assert.True(childNode.HasMaterializedChildren);
+
+        failChildLoad = true;
+        await model.RefreshAsync(childNode, TestContext.Current.CancellationToken);
+        Assert.True(childNode.IsExpanded);
+        Assert.False(childNode.HasMaterializedChildren);
+        Assert.NotNull(childNode.LoadError);
+
+        failChildLoad = false;
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterChildMaterializes;
+        try
+        {
+            Task canceledExpansion = model.ExpandAllAsync(maxDepth: 1, cancellationToken: cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        }
+        finally
+        {
+            model.NodeLoaded -= CancelAfterChildMaterializes;
+        }
+
+        Assert.True(childNode.IsExpanded);
+        Assert.True(childNode.HasMaterializedChildren);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+
+        model.Collapse(childNode);
+        Assert.False(childNode.IsExpanded);
+        Assert.False(childNode.HasMaterializedChildren);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+
+        failChildLoad = true;
+        await model.ExpandAllAsync(
+            maxDepth: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(childNode.LoadError);
+        Assert.False(childNode.IsExpanded);
+        Assert.False(childNode.HasMaterializedChildren);
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+
+        void CancelAfterChildMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node, childNode))
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    [Fact]
     public async Task ExpandAsync_Reinserting_Expanded_Descendant_Clears_Its_Pending_Materialization()
     {
         var root = new Item("root");

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -1984,6 +1984,57 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
     }
 
     [Fact]
+    public async Task ShallowExpandAllAsync_Does_Not_Clear_Deeper_Pending_Materialization()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        root.Children.Add(child);
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = static (item, _) =>
+                Task.FromResult<IEnumerable?>(((Item)item).Children)
+        });
+        model.SetRoot(root);
+
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterChildMaterializes;
+        try
+        {
+            Task canceledExpansion = model.ExpandAllAsync(cancellationToken: cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        }
+        finally
+        {
+            model.NodeLoaded -= CancelAfterChildMaterializes;
+        }
+
+        var rootNode = model.Root!;
+        var childNode = Assert.Single(rootNode.Children);
+        Assert.True(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+
+        await model.ExpandAllAsync(
+            maxDepth: 0,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+
+        await model.ExpandAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+        Assert.Equal(2, model.Count);
+
+        void CancelAfterChildMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node.Item, child))
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    [Fact]
     public async Task ExpandAsync_Reinserting_Expanded_Descendant_Clears_Its_Pending_Materialization()
     {
         var root = new Item("root");

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -55,6 +55,11 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         }
     }
 
+    private sealed class Counter
+    {
+        public int Value { get; set; }
+    }
+
     private sealed class ExpandableItem : INotifyPropertyChanged
     {
         public ExpandableItem(string name)
@@ -1807,6 +1812,362 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         Assert.Equal(2, childAttempts);
         Assert.Equal(3, model.Count);
         Assert.All(model.Flattened, node => Assert.True(node.IsExpanded));
+    }
+
+    [Fact]
+    public async Task ExpandAllAsync_Canceled_After_Materializing_Expanded_Node_Commits_Children_On_Retry()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        root.Children.Add(child);
+        bool failRefresh = false;
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = (item, _) =>
+            {
+                if (failRefresh)
+                {
+                    return Task.FromException<IEnumerable?>(new InvalidOperationException("refresh failed"));
+                }
+
+                return Task.FromResult<IEnumerable?>(((Item)item).Children);
+            }
+        });
+        model.SetRoot(root);
+        await model.ExpandAllAsync(
+            maxDepth: 0,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(model.Root!.IsExpanded);
+        Assert.Equal(2, model.Count);
+
+        failRefresh = true;
+        await model.RefreshAsync(model.Root, TestContext.Current.CancellationToken);
+        Assert.True(model.Root.IsExpanded);
+        Assert.False(model.Root.HasMaterializedChildren);
+        Assert.Equal(1, model.Count);
+
+        failRefresh = false;
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterRootMaterializes;
+        Task canceledExpansion = model.ExpandAllAsync(maxDepth: 0, cancellationToken: cts.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        model.NodeLoaded -= CancelAfterRootMaterializes;
+        Assert.True(model.Root.HasMaterializedChildren);
+        Assert.Equal(1, model.Count);
+
+        await model.ExpandAllAsync(
+            maxDepth: 0,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, model.Count);
+        Assert.Same(child, model.GetItem(1));
+
+        void CancelAfterRootMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node, model.Root))
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    [Fact]
+    public Task ExpandAsync_Recovers_Pending_Bulk_Materialization_And_Clears_Marker()
+    {
+        return AssertPendingBulkMaterializationRecoveryAsync(
+            static (model, cancellationToken) => model.ExpandAsync(model.Root!, cancellationToken),
+            expectedSelectorCallsDuringRecovery: 0);
+    }
+
+    [Fact]
+    public Task RefreshAsync_Recovers_Pending_Bulk_Materialization_And_Clears_Marker()
+    {
+        return AssertPendingBulkMaterializationRecoveryAsync(
+            static (model, cancellationToken) => model.RefreshAsync(model.Root, cancellationToken),
+            expectedSelectorCallsDuringRecovery: 1);
+    }
+
+    [Fact]
+    public Task SynchronousExpandAll_Recovers_Pending_Bulk_Materialization_And_Clears_Marker()
+    {
+        return AssertPendingBulkMaterializationRecoveryAsync(
+            static (model, _) =>
+            {
+                model.ExpandAll(maxDepth: 0);
+                return Task.CompletedTask;
+            },
+            expectedSelectorCallsDuringRecovery: 0);
+    }
+
+    [Fact]
+    public async Task SynchronousExpandAll_Clears_Pending_Leaf_Materialized_By_Canceled_Bulk_Expansion()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        root.Children.Add(child);
+        var selectorCalls = new Counter();
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = (item, _) =>
+            {
+                selectorCalls.Value++;
+                return Task.FromResult<IEnumerable?>(((Item)item).Children);
+            }
+        });
+        model.SetRoot(root);
+        var observedInitiallyNonLeafChild = false;
+        model.NodeLoading += (_, args) =>
+        {
+            if (ReferenceEquals(args.Node.Item, child))
+            {
+                Assert.False(args.Node.IsLeaf);
+                Assert.False(args.Node.HasMaterializedChildren);
+                observedInitiallyNonLeafChild = true;
+            }
+        };
+
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterChildMaterializes;
+        try
+        {
+            Task canceledExpansion = model.ExpandAllAsync(cancellationToken: cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        }
+        finally
+        {
+            model.NodeLoaded -= CancelAfterChildMaterializes;
+        }
+
+        var rootNode = model.Root!;
+        var childNode = Assert.Single(rootNode.Children);
+        Assert.True(observedInitiallyNonLeafChild);
+        Assert.True(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+        Assert.True(childNode.HasMaterializedChildren);
+        Assert.True(childNode.IsLeaf);
+        Assert.Single(model.Flattened);
+
+        var flattenedChanges = 0;
+        model.FlattenedChanged += (_, _) =>
+        {
+            Assert.True(rootNode.HasPendingBulkMaterializationCommit);
+            Assert.True(childNode.HasPendingBulkMaterializationCommit);
+            flattenedChanges++;
+        };
+
+        model.ExpandAll();
+
+        Assert.Equal(2, model.Count);
+        Assert.Same(child, model.GetItem(1));
+        Assert.False(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+        Assert.Equal(1, flattenedChanges);
+
+        var recoveredFlattenedVersion = model.FlattenedVersion;
+        var recoveredSelectorCalls = selectorCalls.Value;
+        await model.ExpandAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(recoveredFlattenedVersion, model.FlattenedVersion);
+        Assert.Equal(recoveredSelectorCalls, selectorCalls.Value);
+        Assert.Equal(1, flattenedChanges);
+        Assert.False(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+
+        void CancelAfterChildMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node.Item, child))
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExpandAsync_Reinserting_Expanded_Descendant_Clears_Its_Pending_Materialization()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        var grandchild = new Item("grandchild");
+        child.Children.Add(grandchild);
+        root.Children.Add(child);
+        var selectorCalls = new Counter();
+        var failChildRefresh = false;
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            VirtualizeChildren = false,
+            ChildrenSelectorAsync = (item, _) =>
+            {
+                selectorCalls.Value++;
+                if (failChildRefresh && ReferenceEquals(item, child))
+                {
+                    return Task.FromException<IEnumerable?>(new InvalidOperationException("refresh failed"));
+                }
+
+                return Task.FromResult<IEnumerable?>(((Item)item).Children);
+            }
+        });
+        model.SetRoot(root);
+        await model.ExpandAllAsync(
+            maxDepth: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var rootNode = model.Root!;
+        var childNode = Assert.Single(rootNode.Children);
+        Assert.True(childNode.IsExpanded);
+        Assert.Equal(3, model.Count);
+
+        failChildRefresh = true;
+        await model.RefreshAsync(childNode, TestContext.Current.CancellationToken);
+        Assert.False(childNode.HasMaterializedChildren);
+        Assert.Equal(2, model.Count);
+
+        failChildRefresh = false;
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterChildMaterializes;
+        try
+        {
+            Task canceledExpansion = model.ExpandAllAsync(maxDepth: 1, cancellationToken: cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        }
+        finally
+        {
+            model.NodeLoaded -= CancelAfterChildMaterializes;
+        }
+
+        var reloadedGrandchildNode = Assert.Single(childNode.Children);
+        Assert.True(childNode.IsExpanded);
+        Assert.True(childNode.HasPendingBulkMaterializationCommit);
+        Assert.False(reloadedGrandchildNode.HasPendingBulkMaterializationCommit);
+        Assert.Equal(2, model.Count);
+
+        model.Collapse(rootNode);
+        Assert.Single(model.Flattened);
+        var flattenedChanges = 0;
+        model.FlattenedChanged += (_, _) =>
+        {
+            Assert.True(childNode.HasPendingBulkMaterializationCommit);
+            flattenedChanges++;
+        };
+
+        await model.ExpandAsync(rootNode, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, model.Count);
+        Assert.Same(child, model.GetItem(1));
+        Assert.Same(grandchild, model.GetItem(2));
+        Assert.False(rootNode.HasPendingBulkMaterializationCommit);
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+        Assert.False(reloadedGrandchildNode.HasPendingBulkMaterializationCommit);
+        Assert.Equal(1, flattenedChanges);
+
+        var recoveredFlattenedVersion = model.FlattenedVersion;
+        var recoveredSelectorCalls = selectorCalls.Value;
+        await model.ExpandAllAsync(
+            maxDepth: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(recoveredFlattenedVersion, model.FlattenedVersion);
+        Assert.Equal(recoveredSelectorCalls, selectorCalls.Value);
+        Assert.Equal(1, flattenedChanges);
+        Assert.False(childNode.HasPendingBulkMaterializationCommit);
+
+        void CancelAfterChildMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node, childNode))
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    private static async Task AssertPendingBulkMaterializationRecoveryAsync(
+        Func<HierarchicalModel, CancellationToken, Task> recover,
+        int expectedSelectorCallsDuringRecovery)
+    {
+        var (model, child, selectorCalls) =
+            await CreatePendingBulkMaterializationFixtureAsync();
+        var flattenedChanges = 0;
+        model.FlattenedChanged += (_, _) => flattenedChanges++;
+        var initialFlattenedVersion = model.FlattenedVersion;
+        var initialSelectorCalls = selectorCalls.Value;
+
+        await recover(model, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, model.Count);
+        Assert.Same(child, model.GetItem(1));
+        Assert.Equal(1, model.Root!.ExpandedCount);
+        Assert.False(model.Root.HasPendingBulkMaterializationCommit);
+        Assert.Equal(initialFlattenedVersion + 1, model.FlattenedVersion);
+        Assert.Equal(1, flattenedChanges);
+        Assert.Equal(initialSelectorCalls + expectedSelectorCallsDuringRecovery, selectorCalls.Value);
+
+        var recoveredFlattenedVersion = model.FlattenedVersion;
+        var recoveredFlattenedChanges = flattenedChanges;
+        var recoveredSelectorCalls = selectorCalls.Value;
+
+        await model.ExpandAllAsync(
+            maxDepth: 0,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(recoveredFlattenedVersion, model.FlattenedVersion);
+        Assert.Equal(recoveredFlattenedChanges, flattenedChanges);
+        Assert.Equal(recoveredSelectorCalls, selectorCalls.Value);
+        Assert.False(model.Root.HasPendingBulkMaterializationCommit);
+    }
+
+    private static async Task<(HierarchicalModel Model, Item Child, Counter SelectorCalls)>
+        CreatePendingBulkMaterializationFixtureAsync()
+    {
+        var root = new Item("root");
+        var child = new Item("child");
+        root.Children.Add(child);
+        var failRefresh = false;
+        var selectorCalls = new Counter();
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = (item, _) =>
+            {
+                selectorCalls.Value++;
+                return failRefresh
+                    ? Task.FromException<IEnumerable?>(new InvalidOperationException("refresh failed"))
+                    : Task.FromResult<IEnumerable?>(((Item)item).Children);
+            }
+        });
+        model.SetRoot(root);
+        await model.ExpandAllAsync(
+            maxDepth: 0,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        failRefresh = true;
+        await model.RefreshAsync(model.Root, TestContext.Current.CancellationToken);
+
+        failRefresh = false;
+        using var cts = new CancellationTokenSource();
+        model.NodeLoaded += CancelAfterRootMaterializes;
+        try
+        {
+            Task canceledExpansion = model.ExpandAllAsync(maxDepth: 0, cancellationToken: cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledExpansion);
+        }
+        finally
+        {
+            model.NodeLoaded -= CancelAfterRootMaterializes;
+        }
+
+        Assert.True(model.Root!.IsExpanded);
+        Assert.True(model.Root.HasMaterializedChildren);
+        Assert.True(model.Root.HasPendingBulkMaterializationCommit);
+        Assert.Equal(1, model.Count);
+
+        return (model, child, selectorCalls);
+
+        void CancelAfterRootMaterializes(object? sender, HierarchicalNodeEventArgs args)
+        {
+            if (ReferenceEquals(args.Node, model.Root))
+            {
+                cts.Cancel();
+            }
+        }
     }
 
     [Fact]

--- a/src/Avalonia.Controls.DataGrid/DataGridBuiltInCellRenderers.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridBuiltInCellRenderers.cs
@@ -155,6 +155,11 @@ namespace Avalonia.Controls
             var target = new Size(
                 Math.Min(Math.Max(0d, column.ImageWidth), contentBounds.Width),
                 Math.Min(Math.Max(0d, column.ImageHeight), contentBounds.Height));
+            var targetViewport = new Rect(
+                contentBounds.X + (contentBounds.Width - target.Width) * 0.5d,
+                contentBounds.Y + (contentBounds.Height - target.Height) * 0.5d,
+                target.Width,
+                target.Height);
             var scaleX = target.Width / sourceSize.Width;
             var scaleY = target.Height / sourceSize.Height;
             var scale = column.Stretch switch
@@ -179,11 +184,14 @@ namespace Avalonia.Controls
             }
 
             var destination = new Rect(
-                contentBounds.X + Math.Max(0d, (contentBounds.Width - width) * 0.5d),
-                contentBounds.Y + Math.Max(0d, (contentBounds.Height - height) * 0.5d),
+                targetViewport.X + (targetViewport.Width - width) * 0.5d,
+                targetViewport.Y + (targetViewport.Height - height) * 0.5d,
                 Math.Max(0d, width),
                 Math.Max(0d, height));
-            context.DrawImage(image, new Rect(sourceSize), destination);
+            using (context.PushClip(targetViewport))
+            {
+                context.DrawImage(image, new Rect(sourceSize), destination);
+            }
         }
 
         private static double ApplyStretchDirection(double scale, StretchDirection direction)

--- a/src/Avalonia.Controls.DataGrid/DataGridCustomDrawingCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCustomDrawingCell.cs
@@ -990,8 +990,7 @@ namespace Avalonia.Controls
 
         private void OnValueProviderPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (ReferenceEquals(sender, _valueNotifier) ||
-                ReferenceEquals(sender, _wrappedItemNotifier))
+            if (ReferenceEquals(sender, _valueNotifier) || ReferenceEquals(sender, _wrappedItemNotifier))
             {
                 UpdateValueFromProvider();
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridCustomDrawingCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCustomDrawingCell.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Utils;
 using Avalonia.Media;
@@ -43,7 +44,9 @@ namespace Avalonia.Controls
         private float _compositionVisualHeight;
         private IDataGridDrawnCellValueProvider _valueProvider;
         private IDataGridBuiltInCellRenderer _builtInRenderer;
+        private bool _observeWrappedItemValueChanges;
         private INotifyPropertyChanged _valueNotifier;
+        private INotifyPropertyChanged _wrappedItemNotifier;
         private int _configurationDepth;
         private bool _configurationDirty;
         private readonly WeakPropertyChangedListener<DataGridCustomDrawingCell> _valuePropertyChangedListener;
@@ -346,10 +349,12 @@ namespace Avalonia.Controls
 
         internal void ConfigureBuiltInRenderer(
             IDataGridDrawnCellValueProvider valueProvider,
-            IDataGridBuiltInCellRenderer renderer)
+            IDataGridBuiltInCellRenderer renderer,
+            bool observeWrappedItemValueChanges = false)
         {
             _valueProvider = valueProvider;
             _builtInRenderer = renderer;
+            _observeWrappedItemValueChanges = valueProvider != null && observeWrappedItemValueChanges;
             UseDrawingTemplate();
             UpdateValueProviderSubscription();
             if (_configurationDepth > 0)
@@ -367,6 +372,7 @@ namespace Avalonia.Controls
         {
             _valueProvider = null;
             _builtInRenderer = null;
+            _observeWrappedItemValueChanges = false;
             UpdateValueProviderSubscription();
         }
 
@@ -956,22 +962,36 @@ namespace Avalonia.Controls
                 _valueNotifier = notifier;
                 _valueNotifier.PropertyChanged += _valuePropertyChangedListener.Handler;
             }
+
+            if (_observeWrappedItemValueChanges &&
+                DataContext is IHierarchicalNodeItem node &&
+                node.Item is INotifyPropertyChanged itemNotifier &&
+                !ReferenceEquals(itemNotifier, _valueNotifier))
+            {
+                _wrappedItemNotifier = itemNotifier;
+                _wrappedItemNotifier.PropertyChanged += _valuePropertyChangedListener.Handler;
+            }
         }
 
         private void DetachValueProviderSubscription()
         {
-            if (_valueNotifier == null)
+            if (_valueNotifier != null)
             {
-                return;
+                _valueNotifier.PropertyChanged -= _valuePropertyChangedListener.Handler;
+                _valueNotifier = null;
             }
 
-            _valueNotifier.PropertyChanged -= _valuePropertyChangedListener.Handler;
-            _valueNotifier = null;
+            if (_wrappedItemNotifier != null)
+            {
+                _wrappedItemNotifier.PropertyChanged -= _valuePropertyChangedListener.Handler;
+                _wrappedItemNotifier = null;
+            }
         }
 
         private void OnValueProviderPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (ReferenceEquals(sender, _valueNotifier))
+            if (ReferenceEquals(sender, _valueNotifier) ||
+                ReferenceEquals(sender, _wrappedItemNotifier))
             {
                 UpdateValueFromProvider();
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
@@ -121,9 +121,7 @@ internal
         internal bool CanUseDirectValueAccessorFor(object item)
         {
             var accessor = DataGridColumnMetadata.GetValueAccessor(this);
-            return BindingCloneHelper.SupportsDirectTextDataContextRead(
-                       Binding,
-                       item is IHierarchicalNodeItem) &&
+            return BindingCloneHelper.SupportsDirectTextDataContextRead(Binding, item is IHierarchicalNodeItem) &&
                    item != null &&
                    accessor != null &&
                    accessor is IDataGridColumnTextAccessor &&
@@ -324,15 +322,9 @@ internal
                     drawingCell.ClearValue(DataGridCustomDrawingCell.ValueProperty);
 
                     var accessor = DataGridColumnMetadata.GetValueAccessor(this);
-                    if (CanUseDrawnValueAccessor(
-                            accessor,
-                            dataItem,
-                            out bool observeWrappedItemValueChanges))
+                    if (CanUseDrawnValueAccessor(accessor, dataItem, out bool observeWrappedItemValueChanges))
                     {
-                        drawingCell.ConfigureBuiltInRenderer(
-                            this,
-                            renderer: null,
-                            observeWrappedItemValueChanges: observeWrappedItemValueChanges);
+                        drawingCell.ConfigureBuiltInRenderer(this, renderer: null, observeWrappedItemValueChanges: observeWrappedItemValueChanges);
                     }
                     else
                     {
@@ -548,19 +540,13 @@ internal
                 : null;
         }
 
-        private bool CanUseDrawnValueAccessor(
-            IDataGridColumnValueAccessor accessor,
-            object dataItem,
-            out bool observeWrappedItemValueChanges)
+        private bool CanUseDrawnValueAccessor(IDataGridColumnValueAccessor accessor, object dataItem, out bool observeWrappedItemValueChanges)
         {
             observeWrappedItemValueChanges = false;
             return accessor is IDataGridColumnTextAccessor &&
                    dataItem != null &&
                    accessor.ItemType.IsInstanceOfType(dataItem) &&
-                   BindingCloneHelper.SupportsDirectTextDataContextRead(
-                       Binding,
-                       dataItem is IHierarchicalNodeItem,
-                       out observeWrappedItemValueChanges);
+                   BindingCloneHelper.SupportsDirectTextDataContextRead(Binding, dataItem is IHierarchicalNodeItem, out observeWrappedItemValueChanges);
         }
 
         private void SyncProperties(AvaloniaObject content)

--- a/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
@@ -15,6 +15,7 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Controls.Documents;
+using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.Utils;
 using Avalonia.Styling;
 using System.Globalization;
@@ -120,9 +121,12 @@ internal
         internal bool CanUseDirectValueAccessorFor(object item)
         {
             var accessor = DataGridColumnMetadata.GetValueAccessor(this);
-            return CanUseDirectValueAccessor &&
+            return BindingCloneHelper.SupportsDirectTextDataContextRead(
+                       Binding,
+                       item is IHierarchicalNodeItem) &&
                    item != null &&
                    accessor != null &&
+                   accessor is IDataGridColumnTextAccessor &&
                    accessor.ItemType.IsInstanceOfType(item);
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
@@ -324,9 +324,15 @@ internal
                     drawingCell.ClearValue(DataGridCustomDrawingCell.ValueProperty);
 
                     var accessor = DataGridColumnMetadata.GetValueAccessor(this);
-                    if (CanUseDrawnValueAccessor(accessor, dataItem))
+                    if (CanUseDrawnValueAccessor(
+                            accessor,
+                            dataItem,
+                            out bool observeWrappedItemValueChanges))
                     {
-                        drawingCell.ConfigureBuiltInRenderer(this, renderer: null);
+                        drawingCell.ConfigureBuiltInRenderer(
+                            this,
+                            renderer: null,
+                            observeWrappedItemValueChanges: observeWrappedItemValueChanges);
                     }
                     else
                     {
@@ -542,12 +548,19 @@ internal
                 : null;
         }
 
-        private bool CanUseDrawnValueAccessor(IDataGridColumnValueAccessor accessor, object dataItem)
+        private bool CanUseDrawnValueAccessor(
+            IDataGridColumnValueAccessor accessor,
+            object dataItem,
+            out bool observeWrappedItemValueChanges)
         {
+            observeWrappedItemValueChanges = false;
             return accessor is IDataGridColumnTextAccessor &&
                    dataItem != null &&
                    accessor.ItemType.IsInstanceOfType(dataItem) &&
-                   BindingCloneHelper.SupportsDirectTextDataContextRead(Binding);
+                   BindingCloneHelper.SupportsDirectTextDataContextRead(
+                       Binding,
+                       dataItem is IHierarchicalNodeItem,
+                       out observeWrappedItemValueChanges);
         }
 
         private void SyncProperties(AvaloniaObject content)

--- a/src/Avalonia.Controls.DataGrid/Filtering/DataGridAccessorFilteringAdapter.cs
+++ b/src/Avalonia.Controls.DataGrid/Filtering/DataGridAccessorFilteringAdapter.cs
@@ -59,17 +59,9 @@ namespace Avalonia.Controls.DataGridFiltering
                 return true;
             }
 
-            InvokeBeforeViewRefresh();
-            try
+            using (view.DeferRefresh())
             {
-                using (view.DeferRefresh())
-                {
-                    view.Filter = predicate;
-                }
-            }
-            finally
-            {
-                InvokeAfterViewRefresh();
+                view.Filter = predicate;
             }
 
             changed = true;

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
@@ -120,7 +120,9 @@ internal
         internal bool CanUseDirectTextContent =>
             UseDirectTextContent &&
             CellTemplate == null &&
-            BindingCloneHelper.SupportsDirectTextDataContextRead(Binding) &&
+            BindingCloneHelper.SupportsDirectTextDataContextRead(
+                Binding,
+                observesWrappedHierarchyItem: true) &&
             DataGridColumnMetadata.GetValueAccessor(this) is IDataGridColumnTextAccessor;
 
         internal bool CanUseDirectTextContentFor(object? item)

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
@@ -120,9 +120,7 @@ internal
         internal bool CanUseDirectTextContent =>
             UseDirectTextContent &&
             CellTemplate == null &&
-            BindingCloneHelper.SupportsDirectTextDataContextRead(
-                Binding,
-                observesWrappedHierarchyItem: true) &&
+            BindingCloneHelper.SupportsDirectTextDataContextRead(Binding, observesWrappedHierarchyItem: true) &&
             DataGridColumnMetadata.GetValueAccessor(this) is IDataGridColumnTextAccessor;
 
         internal bool CanUseDirectTextContentFor(object? item)

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1084,10 +1084,7 @@ namespace Avalonia.Controls.DataGridHierarchical
                     var hasVisible = GetVisibleDescendantCount(node, parentIndex) > 0;
                     if (!hasVisible)
                     {
-                        inserted = InsertVisibleChildren(
-                            node,
-                            parentIndex + 1,
-                            ref visibleMaterializationCommits);
+                        inserted = InsertVisibleChildren(node, parentIndex + 1, ref visibleMaterializationCommits);
                         if (inserted > 0)
                         {
                             OnFlattenedChanged(new[] { new FlattenedChange(parentIndex + 1, 0, inserted) });
@@ -1801,8 +1798,7 @@ namespace Avalonia.Controls.DataGridHierarchical
                         .ConfigureAwait(continueOnCapturedContext);
                 }
 
-                var materializedDuringOperation =
-                    !hadMaterializedChildren && current.HasMaterializedChildren;
+                var materializedDuringOperation = !hadMaterializedChildren && current.HasMaterializedChildren;
 
                 if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
                 {
@@ -1974,8 +1970,7 @@ namespace Avalonia.Controls.DataGridHierarchical
                     }
                 }
 
-                var materializedDuringOperation =
-                    !hadMaterializedChildren && current.HasMaterializedChildren;
+                var materializedDuringOperation = !hadMaterializedChildren && current.HasMaterializedChildren;
                 if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
                 {
                     materializationChanged = true;
@@ -2460,11 +2455,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             ref List<HierarchicalNode>? materializationCommits)
         {
             var buffer = new List<HierarchicalNode>();
-            CollectVisibleChildren(
-                parent,
-                buffer,
-                collectMaterializationCommits,
-                ref materializationCommits);
+            CollectVisibleChildren(parent, buffer, collectMaterializationCommits, ref materializationCommits);
 
             if (buffer.Count > 0)
             {
@@ -2474,9 +2465,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             return buffer.Count;
         }
 
-        private void CollectVisibleChildren(
-            HierarchicalNode parent,
-            List<HierarchicalNode> buffer)
+        private void CollectVisibleChildren(HierarchicalNode parent, List<HierarchicalNode> buffer)
         {
             List<HierarchicalNode>? ignoredMaterializationCommits = null;
             CollectVisibleChildren(

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -2849,6 +2849,7 @@ namespace Avalonia.Controls.DataGridHierarchical
                     DetachHierarchy(removed);
                 }
                 ApplyExpandedCountDelta(parent, 0);
+                OnHierarchyChanged(parent, NotifyCollectionChangedAction.Remove);
                 return;
             }
 

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -521,6 +521,7 @@ namespace Avalonia.Controls.DataGridHierarchical
         private readonly Dictionary<HierarchicalNode, NodeLoadState> _loadStates = new();
         private SemaphoreSlim? _bulkExpandGate;
         private int _synchronousBulkExpandActive;
+        private int _bulkMaterializationCommitGeneration;
         // Cached lookups for flattened items to avoid repeated linear scans.
         private int _flattenedLookupVersion = -1;
         private Dictionary<object, int>? _flattenedReferenceIndexLookup;
@@ -1762,98 +1763,100 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
             var stack = new Stack<(HierarchicalNode Node, int Depth, bool Exit)>();
             var materializationChanged = false;
-            List<HierarchicalNode>? materializationCommits = null;
+            var materializationCommitGeneration = GetNextBulkMaterializationCommitGeneration();
+            var requiresVisibleMaterializationCommitClear = false;
+            var expandedNodesHavePropertyObservers = false;
             var traversedNodeCount = 0;
             stack.Push((start, 0, false));
 
-            try
+            while (stack.Count > 0)
             {
-                while (stack.Count > 0)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var (current, depth, exit) = stack.Pop();
-                    if (exit)
-                    {
-                        ancestors.Remove(current.Item);
-                        continue;
-                    }
-
-                    if (depth > limit)
-                    {
-                        continue;
-                    }
-
-                    traversedNodeCount++;
-                    ancestors.Add(current.Item);
-                    var isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
-                    var hadMaterializedChildren = current.HasMaterializedChildren;
-
-                    if (!isVirtualRoot &&
-                        (!current.HasMaterializedChildren || current.LoadError != null))
-                    {
-                        await EnsureChildrenMaterializedAsync(
-                                current,
-                                forceReload: false,
-                                cancellationToken,
-                                ancestors,
-                                continueOnCapturedContext)
-                            .ConfigureAwait(continueOnCapturedContext);
-                    }
-
-                    var materializedDuringOperation =
-                        !hadMaterializedChildren && current.HasMaterializedChildren;
-
-                    if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
-                    {
-                        materializationChanged = true;
-                        (materializationCommits ??= new List<HierarchicalNode>()).Add(current);
-                    }
-
-                    if (current.LoadError != null || !current.HasMaterializedChildren)
-                    {
-                        ancestors.Remove(current.Item);
-                        continue;
-                    }
-
-                    if (!current.IsExpanded && !isVirtualRoot)
-                    {
-                        nodesToExpand.Add(current);
-                    }
-
-                    if (current.IsLeaf || depth >= limit)
-                    {
-                        ancestors.Remove(current.Item);
-                        continue;
-                    }
-
-                    var children = current.Children;
-                    stack.Push((current, depth, true));
-                    for (int i = children.Count - 1; i >= 0; i--)
-                    {
-                        stack.Push((children[i], depth + 1, false));
-                    }
-                }
-
                 cancellationToken.ThrowIfCancellationRequested();
-                if (nodesToExpand.Count == 0 && !materializationChanged)
+                var (current, depth, exit) = stack.Pop();
+                if (exit)
                 {
-                    return;
+                    ancestors.Remove(current.Item);
+                    continue;
                 }
 
-                CommitBulkExpansion(
-                    start,
-                    nodesToExpand,
-                    expansionStatesAlreadyApplied: false,
-                    materializationChanged,
-                    traversedNodeCount);
-            }
-            catch
-            {
-                SetPendingBulkMaterializationCommit(materializationCommits, value: true);
-                throw;
+                if (depth > limit)
+                {
+                    continue;
+                }
+
+                traversedNodeCount++;
+                ancestors.Add(current.Item);
+                var isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
+                var hadMaterializedChildren = current.HasMaterializedChildren;
+
+                if (!isVirtualRoot &&
+                    (!current.HasMaterializedChildren || current.LoadError != null))
+                {
+                    await EnsureChildrenMaterializedAsync(
+                            current,
+                            forceReload: false,
+                            cancellationToken,
+                            ancestors,
+                            continueOnCapturedContext)
+                        .ConfigureAwait(continueOnCapturedContext);
+                }
+
+                var materializedDuringOperation =
+                    !hadMaterializedChildren && current.HasMaterializedChildren;
+
+                if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
+                {
+                    materializationChanged = true;
+                    current.PendingBulkMaterializationCommitGeneration =
+                        materializationCommitGeneration;
+                    if ((current.IsExpanded || isVirtualRoot) &&
+                        !ReferenceEquals(current, start))
+                    {
+                        requiresVisibleMaterializationCommitClear = true;
+                    }
+                }
+
+                if (current.LoadError != null || !current.HasMaterializedChildren)
+                {
+                    ancestors.Remove(current.Item);
+                    continue;
+                }
+
+                if (!current.IsExpanded && !isVirtualRoot)
+                {
+                    nodesToExpand.Add(current);
+                    expandedNodesHavePropertyObservers |= current.HasPropertyChangedObservers;
+                }
+
+                if (current.IsLeaf || depth >= limit)
+                {
+                    ancestors.Remove(current.Item);
+                    continue;
+                }
+
+                var children = current.Children;
+                stack.Push((current, depth, true));
+                for (int i = children.Count - 1; i >= 0; i--)
+                {
+                    stack.Push((children[i], depth + 1, false));
+                }
             }
 
-            SetPendingBulkMaterializationCommit(materializationCommits, value: false);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (nodesToExpand.Count == 0 && !materializationChanged)
+            {
+                return;
+            }
+
+            CommitBulkExpansion(
+                start,
+                nodesToExpand,
+                expansionStatesAlreadyApplied: false,
+                materializationChanged,
+                traversedNodeCount,
+                materializationCommitGeneration,
+                requiresVisibleMaterializationCommitClear,
+                expandedNodesHavePropertyObservers);
         }
 
         private SemaphoreSlim GetBulkExpandGate()
@@ -1875,13 +1878,24 @@ namespace Avalonia.Controls.DataGridHierarchical
             return created;
         }
 
+        private int GetNextBulkMaterializationCommitGeneration()
+        {
+            var generation = Interlocked.Increment(ref _bulkMaterializationCommitGeneration);
+            if (generation == 0)
+            {
+                generation = Interlocked.Increment(ref _bulkMaterializationCommitGeneration);
+            }
+
+            return generation;
+        }
+
         private void ExpandAllSynchronously(
             HierarchicalNode start,
             int limit,
             bool resolveAsyncChildrenOffContext = false)
         {
             List<HierarchicalNode>? expandedNodes = null;
-            List<HierarchicalNode>? materializationCommits = null;
+            var materializationCommitGeneration = GetNextBulkMaterializationCommitGeneration();
             const int hashedCycleDepth = 32;
             HashSet<object>? ancestors = null;
             if (start.Level >= hashedCycleDepth)
@@ -1897,81 +1911,57 @@ namespace Avalonia.Controls.DataGridHierarchical
             var stack = new Stack<(HierarchicalNode Node, int Depth, bool Exit)>();
             var anyExpanded = false;
             var materializationChanged = false;
+            var requiresVisibleMaterializationCommitClear = false;
+            var expandedNodesHavePropertyObservers = false;
             var traversedNodeCount = 0;
             stack.Push((start, 0, false));
 
-            try
+            while (stack.Count > 0)
             {
-                while (stack.Count > 0)
+                var (current, depth, exit) = stack.Pop();
+                if (exit)
                 {
-                    var (current, depth, exit) = stack.Pop();
-                    if (exit)
-                    {
-                        if (current.Level >= hashedCycleDepth)
-                        {
-                            ancestors!.Remove(current.Item);
-                        }
-                        continue;
-                    }
-
-                    if (depth > limit)
-                    {
-                        continue;
-                    }
-                    traversedNodeCount++;
                     if (current.Level >= hashedCycleDepth)
                     {
-                        if (ancestors == null)
-                        {
-                            ancestors = new HashSet<object>(ReferenceEqualityComparer.Instance);
-                            var ancestor = current.Parent;
-                            while (ancestor != null)
-                            {
-                                ancestors.Add(ancestor.Item);
-                                ancestor = ancestor.Parent;
-                            }
-                        }
-
-                        ancestors.Add(current.Item);
+                        ancestors!.Remove(current.Item);
                     }
+                    continue;
+                }
 
-                    bool isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
-                    bool wasExpanded = current.IsExpanded;
-                    bool hadMaterializedChildren = current.HasMaterializedChildren;
-
-                    if (!isVirtualRoot &&
-                        (!current.HasMaterializedChildren || current.LoadError != null))
+                if (depth > limit)
+                {
+                    continue;
+                }
+                traversedNodeCount++;
+                if (current.Level >= hashedCycleDepth)
+                {
+                    if (ancestors == null)
                     {
-                        EnsureChildrenMaterializedSynchronously(
-                            current,
-                            forceReload: false,
-                            current.Level >= hashedCycleDepth ? ancestors : null,
-                            resolveAsyncChildrenOffContext);
-                        if (current.LoadError != null || !current.HasMaterializedChildren)
+                        ancestors = new HashSet<object>(ReferenceEqualityComparer.Instance);
+                        var ancestor = current.Parent;
+                        while (ancestor != null)
                         {
-                            if (current.Level >= hashedCycleDepth)
-                            {
-                                ancestors!.Remove(current.Item);
-                            }
-                            continue;
+                            ancestors.Add(ancestor.Item);
+                            ancestor = ancestor.Parent;
                         }
                     }
 
-                    var materializedDuringOperation =
-                        !hadMaterializedChildren && current.HasMaterializedChildren;
-                    if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
-                    {
-                        materializationChanged = true;
-                        (materializationCommits ??= new List<HierarchicalNode>()).Add(current);
-                    }
+                    ancestors.Add(current.Item);
+                }
 
-                    if (!wasExpanded && !isVirtualRoot)
-                    {
-                        anyExpanded = true;
-                        (expandedNodes ??= new List<HierarchicalNode>()).Add(current);
-                    }
+                bool isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
+                bool wasExpanded = current.IsExpanded;
+                bool hadMaterializedChildren = current.HasMaterializedChildren;
 
-                    if (current.IsLeaf || depth >= limit)
+                if (!isVirtualRoot &&
+                    (!current.HasMaterializedChildren || current.LoadError != null))
+                {
+                    EnsureChildrenMaterializedSynchronously(
+                        current,
+                        forceReload: false,
+                        current.Level >= hashedCycleDepth ? ancestors : null,
+                        resolveAsyncChildrenOffContext);
+                    if (current.LoadError != null || !current.HasMaterializedChildren)
                     {
                         if (current.Level >= hashedCycleDepth)
                         {
@@ -1979,72 +1969,104 @@ namespace Avalonia.Controls.DataGridHierarchical
                         }
                         continue;
                     }
+                }
 
-                    var children = current.MutableChildren;
-                    var allChildrenAreLeaves = children.Count > 0;
+                var materializedDuringOperation =
+                    !hadMaterializedChildren && current.HasMaterializedChildren;
+                if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
+                {
+                    materializationChanged = true;
+                    current.PendingBulkMaterializationCommitGeneration =
+                        materializationCommitGeneration;
+                    if ((wasExpanded || isVirtualRoot) &&
+                        !ReferenceEquals(current, start))
+                    {
+                        requiresVisibleMaterializationCommitClear = true;
+                    }
+                }
+
+                if (!wasExpanded && !isVirtualRoot)
+                {
+                    anyExpanded = true;
+                    (expandedNodes ??= new List<HierarchicalNode>()).Add(current);
+                    expandedNodesHavePropertyObservers |= current.HasPropertyChangedObservers;
+                }
+
+                if (current.IsLeaf || depth >= limit)
+                {
+                    if (current.Level >= hashedCycleDepth)
+                    {
+                        ancestors!.Remove(current.Item);
+                    }
+                    continue;
+                }
+
+                var children = current.MutableChildren;
+                var allChildrenAreLeaves = children.Count > 0;
+                for (int i = 0; i < children.Count; i++)
+                {
+                    if (!children[i].IsLeaf)
+                    {
+                        allChildrenAreLeaves = false;
+                        break;
+                    }
+                }
+
+                if (allChildrenAreLeaves)
+                {
+                    // Preserve leaf expansion state and preorder events without pushing a stack
+                    // frame for every terminal node in wide hierarchies.
+                    traversedNodeCount += children.Count;
                     for (int i = 0; i < children.Count; i++)
                     {
-                        if (!children[i].IsLeaf)
+                        var child = children[i];
+                        if (child.HasPendingBulkMaterializationCommit)
                         {
-                            allChildrenAreLeaves = false;
-                            break;
-                        }
-                    }
-
-                    if (allChildrenAreLeaves)
-                    {
-                        // Preserve leaf expansion state and preorder events without pushing a stack
-                        // frame for every terminal node in wide hierarchies.
-                        traversedNodeCount += children.Count;
-                        for (int i = 0; i < children.Count; i++)
-                        {
-                            var child = children[i];
-                            if (child.HasPendingBulkMaterializationCommit)
+                            materializationChanged = true;
+                            child.PendingBulkMaterializationCommitGeneration =
+                                materializationCommitGeneration;
+                            if (child.IsExpanded)
                             {
-                                materializationChanged = true;
-                                (materializationCommits ??= new List<HierarchicalNode>()).Add(child);
-                            }
-
-                            if (!child.IsExpanded)
-                            {
-                                anyExpanded = true;
-                                (expandedNodes ??= new List<HierarchicalNode>()).Add(child);
+                                requiresVisibleMaterializationCommitClear = true;
                             }
                         }
 
-                        if (current.Level >= hashedCycleDepth)
+                        if (!child.IsExpanded)
                         {
-                            ancestors!.Remove(current.Item);
+                            anyExpanded = true;
+                            (expandedNodes ??= new List<HierarchicalNode>()).Add(child);
+                            expandedNodesHavePropertyObservers |= child.HasPropertyChangedObservers;
                         }
-                        continue;
                     }
 
-                    stack.Push((current, depth, true));
-                    for (int i = children.Count - 1; i >= 0; i--)
+                    if (current.Level >= hashedCycleDepth)
                     {
-                        stack.Push((children[i], depth + 1, false));
+                        ancestors!.Remove(current.Item);
                     }
+                    continue;
                 }
 
-                if (!anyExpanded && !materializationChanged)
+                stack.Push((current, depth, true));
+                for (int i = children.Count - 1; i >= 0; i--)
                 {
-                    return;
+                    stack.Push((children[i], depth + 1, false));
                 }
-
-                CommitBulkExpansion(
-                    start,
-                    expandedNodes,
-                    expansionStatesAlreadyApplied: false,
-                    materializationChanged,
-                    traversedNodeCount);
             }
-            catch
+
+            if (!anyExpanded && !materializationChanged)
             {
-                SetPendingBulkMaterializationCommit(materializationCommits, value: true);
-                throw;
+                return;
             }
 
-            SetPendingBulkMaterializationCommit(materializationCommits, value: false);
+            CommitBulkExpansion(
+                start,
+                expandedNodes,
+                expansionStatesAlreadyApplied: false,
+                materializationChanged,
+                traversedNodeCount,
+                materializationCommitGeneration,
+                requiresVisibleMaterializationCommitClear,
+                expandedNodesHavePropertyObservers);
         }
 
         private static void SetPendingBulkMaterializationCommit(
@@ -2067,7 +2089,10 @@ namespace Avalonia.Controls.DataGridHierarchical
             IList<HierarchicalNode>? expandedNodes,
             bool expansionStatesAlreadyApplied,
             bool materializationChanged,
-            int traversedNodeCount)
+            int traversedNodeCount,
+            int materializationCommitGeneration,
+            bool requiresVisibleMaterializationCommitClear,
+            bool expandedNodesHavePropertyObservers)
         {
             var isVirtualRoot = IsVirtualRootNode(start);
             var startIndex = isVirtualRoot ? -1 : GetFlattenedIndex(start);
@@ -2121,24 +2146,63 @@ namespace Avalonia.Controls.DataGridHierarchical
                 InvalidateFlattenedLookup();
             }
 
-            if (expandedNodes == null)
+            if (expandedNodes != null)
             {
-                return;
+                var raiseNodeExpanded = HasNodeExpandedObservers;
+                var deferExpandedNodeMaterializationCommitClear =
+                    raiseNodeExpanded || expandedNodesHavePropertyObservers;
+                for (int i = 0; i < expandedNodes.Count; i++)
+                {
+                    var expandedNode = expandedNodes[i];
+                    if (expandedNode.HasPropertyChangedObservers)
+                    {
+                        expandedNode.RaiseExpandedChanged();
+                    }
+
+                    if (raiseNodeExpanded)
+                    {
+                        OnNodeExpanded(expandedNode);
+                    }
+
+                    if (!deferExpandedNodeMaterializationCommitClear)
+                    {
+                        ClearPendingBulkMaterializationCommit(
+                            expandedNode,
+                            materializationCommitGeneration);
+                    }
+                }
+
+                if (deferExpandedNodeMaterializationCommitClear)
+                {
+                    for (int i = 0; i < expandedNodes.Count; i++)
+                    {
+                        ClearPendingBulkMaterializationCommit(
+                            expandedNodes[i],
+                            materializationCommitGeneration);
+                    }
+                }
             }
 
-            var raiseNodeExpanded = HasNodeExpandedObservers;
-            for (int i = 0; i < expandedNodes.Count; i++)
+            ClearPendingBulkMaterializationCommit(start, materializationCommitGeneration);
+            if (requiresVisibleMaterializationCommitClear)
             {
-                var expandedNode = expandedNodes[i];
-                if (expandedNode.HasPropertyChangedObservers)
+                for (int i = 0; i < visibleNodes.Count; i++)
                 {
-                    expandedNode.RaiseExpandedChanged();
+                    ClearPendingBulkMaterializationCommit(
+                        visibleNodes[i],
+                        materializationCommitGeneration);
                 }
+            }
+        }
 
-                if (raiseNodeExpanded)
-                {
-                    OnNodeExpanded(expandedNode);
-                }
+        private static void ClearPendingBulkMaterializationCommit(
+            HierarchicalNode node,
+            int materializationCommitGeneration)
+        {
+            if (node.PendingBulkMaterializationCommitGeneration ==
+                materializationCommitGeneration)
+            {
+                node.PendingBulkMaterializationCommitGeneration = 0;
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1809,7 +1809,10 @@ namespace Avalonia.Controls.DataGridHierarchical
                     materializationChanged = true;
                     current.PendingBulkMaterializationCommitGeneration =
                         materializationCommitGeneration;
-                    if ((current.IsExpanded || isVirtualRoot) &&
+                    if ((current.IsExpanded ||
+                         isVirtualRoot ||
+                         current.LoadError != null ||
+                         !current.HasMaterializedChildren) &&
                         !ReferenceEquals(current, start))
                     {
                         requiresVisibleMaterializationCommitClear = true;

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1037,11 +1037,17 @@ namespace Avalonia.Controls.DataGridHierarchical
                 {
                     if (node.IsLeaf || parentIndex < 0)
                     {
+                        if (node.IsLeaf && parentIndex >= 0)
+                        {
+                            node.HasPendingBulkMaterializationCommit = false;
+                        }
+
                         return;
                     }
 
                     if (node.HasMaterializedChildren && hasVisibleDescendants)
                     {
+                        node.HasPendingBulkMaterializationCommit = false;
                         return;
                     }
                 }
@@ -1070,13 +1076,17 @@ namespace Avalonia.Controls.DataGridHierarchical
 
                 parentIndex = GetFlattenedIndex(node);
                 var inserted = 0;
+                List<HierarchicalNode>? visibleMaterializationCommits = null;
 
                 if (parentIndex >= 0 && !node.IsLeaf)
                 {
                     var hasVisible = GetVisibleDescendantCount(node, parentIndex) > 0;
                     if (!hasVisible)
                     {
-                        inserted = InsertVisibleChildren(node, parentIndex + 1);
+                        inserted = InsertVisibleChildren(
+                            node,
+                            parentIndex + 1,
+                            ref visibleMaterializationCommits);
                         if (inserted > 0)
                         {
                             OnFlattenedChanged(new[] { new FlattenedChange(parentIndex + 1, 0, inserted) });
@@ -1087,6 +1097,11 @@ namespace Avalonia.Controls.DataGridHierarchical
                 SetNodeExpandedState(node, true);
                 RecalculateExpandedCountsFrom(node);
                 OnNodeExpanded(node);
+                if (parentIndex >= 0)
+                {
+                    node.HasPendingBulkMaterializationCommit = false;
+                    SetPendingBulkMaterializationCommit(visibleMaterializationCommits, value: false);
+                }
             }
             finally
             {
@@ -1299,6 +1314,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
 
             RecalculateExpandedCountsFrom(target);
+            target.HasPendingBulkMaterializationCommit = false;
         }
 
         public HierarchicalNode? FindNode(object item)
@@ -1746,83 +1762,98 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
             var stack = new Stack<(HierarchicalNode Node, int Depth, bool Exit)>();
             var materializationChanged = false;
+            List<HierarchicalNode>? materializationCommits = null;
             var traversedNodeCount = 0;
             stack.Push((start, 0, false));
 
-            while (stack.Count > 0)
+            try
             {
+                while (stack.Count > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var (current, depth, exit) = stack.Pop();
+                    if (exit)
+                    {
+                        ancestors.Remove(current.Item);
+                        continue;
+                    }
+
+                    if (depth > limit)
+                    {
+                        continue;
+                    }
+
+                    traversedNodeCount++;
+                    ancestors.Add(current.Item);
+                    var isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
+                    var hadMaterializedChildren = current.HasMaterializedChildren;
+
+                    if (!isVirtualRoot &&
+                        (!current.HasMaterializedChildren || current.LoadError != null))
+                    {
+                        await EnsureChildrenMaterializedAsync(
+                                current,
+                                forceReload: false,
+                                cancellationToken,
+                                ancestors,
+                                continueOnCapturedContext)
+                            .ConfigureAwait(continueOnCapturedContext);
+                    }
+
+                    var materializedDuringOperation =
+                        !hadMaterializedChildren && current.HasMaterializedChildren;
+
+                    if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
+                    {
+                        materializationChanged = true;
+                        (materializationCommits ??= new List<HierarchicalNode>()).Add(current);
+                    }
+
+                    if (current.LoadError != null || !current.HasMaterializedChildren)
+                    {
+                        ancestors.Remove(current.Item);
+                        continue;
+                    }
+
+                    if (!current.IsExpanded && !isVirtualRoot)
+                    {
+                        nodesToExpand.Add(current);
+                    }
+
+                    if (current.IsLeaf || depth >= limit)
+                    {
+                        ancestors.Remove(current.Item);
+                        continue;
+                    }
+
+                    var children = current.Children;
+                    stack.Push((current, depth, true));
+                    for (int i = children.Count - 1; i >= 0; i--)
+                    {
+                        stack.Push((children[i], depth + 1, false));
+                    }
+                }
+
                 cancellationToken.ThrowIfCancellationRequested();
-                var (current, depth, exit) = stack.Pop();
-                if (exit)
+                if (nodesToExpand.Count == 0 && !materializationChanged)
                 {
-                    ancestors.Remove(current.Item);
-                    continue;
+                    return;
                 }
 
-                if (depth > limit)
-                {
-                    continue;
-                }
-
-                traversedNodeCount++;
-                ancestors.Add(current.Item);
-                var isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
-                var hadMaterializedChildren = current.HasMaterializedChildren;
-
-                if (!isVirtualRoot &&
-                    (!current.HasMaterializedChildren || current.LoadError != null))
-                {
-                    await EnsureChildrenMaterializedAsync(
-                            current,
-                            forceReload: false,
-                            cancellationToken,
-                            ancestors,
-                            continueOnCapturedContext)
-                        .ConfigureAwait(continueOnCapturedContext);
-                }
-
-                if (!hadMaterializedChildren && current.HasMaterializedChildren)
-                {
-                    materializationChanged = true;
-                }
-
-                if (current.LoadError != null || !current.HasMaterializedChildren)
-                {
-                    ancestors.Remove(current.Item);
-                    continue;
-                }
-
-                if (!current.IsExpanded && !isVirtualRoot)
-                {
-                    nodesToExpand.Add(current);
-                }
-
-                if (current.IsLeaf || depth >= limit)
-                {
-                    ancestors.Remove(current.Item);
-                    continue;
-                }
-
-                var children = current.Children;
-                stack.Push((current, depth, true));
-                for (int i = children.Count - 1; i >= 0; i--)
-                {
-                    stack.Push((children[i], depth + 1, false));
-                }
+                CommitBulkExpansion(
+                    start,
+                    nodesToExpand,
+                    expansionStatesAlreadyApplied: false,
+                    materializationChanged,
+                    traversedNodeCount);
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            if (nodesToExpand.Count == 0 && !materializationChanged)
+            catch
             {
-                return;
+                SetPendingBulkMaterializationCommit(materializationCommits, value: true);
+                throw;
             }
 
-            CommitBulkExpansion(
-                start,
-                nodesToExpand,
-                expansionStatesAlreadyApplied: false,
-                materializationChanged,
-                traversedNodeCount);
+            SetPendingBulkMaterializationCommit(materializationCommits, value: false);
         }
 
         private SemaphoreSlim GetBulkExpandGate()
@@ -1850,6 +1881,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             bool resolveAsyncChildrenOffContext = false)
         {
             List<HierarchicalNode>? expandedNodes = null;
+            List<HierarchicalNode>? materializationCommits = null;
             const int hashedCycleDepth = 32;
             HashSet<object>? ancestors = null;
             if (start.Level >= hashedCycleDepth)
@@ -1868,52 +1900,12 @@ namespace Avalonia.Controls.DataGridHierarchical
             var traversedNodeCount = 0;
             stack.Push((start, 0, false));
 
-            while (stack.Count > 0)
+            try
             {
-                var (current, depth, exit) = stack.Pop();
-                if (exit)
+                while (stack.Count > 0)
                 {
-                    if (current.Level >= hashedCycleDepth)
-                    {
-                        ancestors!.Remove(current.Item);
-                    }
-                    continue;
-                }
-
-                if (depth > limit)
-                {
-                    continue;
-                }
-                traversedNodeCount++;
-                if (current.Level >= hashedCycleDepth)
-                {
-                    if (ancestors == null)
-                    {
-                        ancestors = new HashSet<object>(ReferenceEqualityComparer.Instance);
-                        var ancestor = current.Parent;
-                        while (ancestor != null)
-                        {
-                            ancestors.Add(ancestor.Item);
-                            ancestor = ancestor.Parent;
-                        }
-                    }
-
-                    ancestors.Add(current.Item);
-                }
-
-                bool isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
-                bool wasExpanded = current.IsExpanded;
-                bool hadMaterializedChildren = current.HasMaterializedChildren;
-
-                if (!isVirtualRoot &&
-                    (!current.HasMaterializedChildren || current.LoadError != null))
-                {
-                    EnsureChildrenMaterializedSynchronously(
-                        current,
-                        forceReload: false,
-                        current.Level >= hashedCycleDepth ? ancestors : null,
-                        resolveAsyncChildrenOffContext);
-                    if (current.LoadError != null || !current.HasMaterializedChildren)
+                    var (current, depth, exit) = stack.Pop();
+                    if (exit)
                     {
                         if (current.Level >= hashedCycleDepth)
                         {
@@ -1921,79 +1913,153 @@ namespace Avalonia.Controls.DataGridHierarchical
                         }
                         continue;
                     }
-                }
 
-                if (!hadMaterializedChildren && current.HasMaterializedChildren)
-                {
-                    materializationChanged = true;
-                }
-
-                if (!wasExpanded && !isVirtualRoot)
-                {
-                    anyExpanded = true;
-                    (expandedNodes ??= new List<HierarchicalNode>()).Add(current);
-                }
-
-                if (current.IsLeaf || depth >= limit)
-                {
+                    if (depth > limit)
+                    {
+                        continue;
+                    }
+                    traversedNodeCount++;
                     if (current.Level >= hashedCycleDepth)
                     {
-                        ancestors!.Remove(current.Item);
-                    }
-                    continue;
-                }
-
-                var children = current.MutableChildren;
-                var allChildrenAreLeaves = children.Count > 0;
-                for (int i = 0; i < children.Count; i++)
-                {
-                    if (!children[i].IsLeaf)
-                    {
-                        allChildrenAreLeaves = false;
-                        break;
-                    }
-                }
-
-                if (allChildrenAreLeaves)
-                {
-                    // Preserve leaf expansion state and preorder events without pushing a stack
-                    // frame for every terminal node in wide hierarchies.
-                    traversedNodeCount += children.Count;
-                    for (int i = 0; i < children.Count; i++)
-                    {
-                        var child = children[i];
-                        if (!child.IsExpanded)
+                        if (ancestors == null)
                         {
-                            anyExpanded = true;
-                            (expandedNodes ??= new List<HierarchicalNode>()).Add(child);
+                            ancestors = new HashSet<object>(ReferenceEqualityComparer.Instance);
+                            var ancestor = current.Parent;
+                            while (ancestor != null)
+                            {
+                                ancestors.Add(ancestor.Item);
+                                ancestor = ancestor.Parent;
+                            }
+                        }
+
+                        ancestors.Add(current.Item);
+                    }
+
+                    bool isVirtualRoot = _isVirtualRoot && ReferenceEquals(current, Root);
+                    bool wasExpanded = current.IsExpanded;
+                    bool hadMaterializedChildren = current.HasMaterializedChildren;
+
+                    if (!isVirtualRoot &&
+                        (!current.HasMaterializedChildren || current.LoadError != null))
+                    {
+                        EnsureChildrenMaterializedSynchronously(
+                            current,
+                            forceReload: false,
+                            current.Level >= hashedCycleDepth ? ancestors : null,
+                            resolveAsyncChildrenOffContext);
+                        if (current.LoadError != null || !current.HasMaterializedChildren)
+                        {
+                            if (current.Level >= hashedCycleDepth)
+                            {
+                                ancestors!.Remove(current.Item);
+                            }
+                            continue;
                         }
                     }
 
-                    if (current.Level >= hashedCycleDepth)
+                    var materializedDuringOperation =
+                        !hadMaterializedChildren && current.HasMaterializedChildren;
+                    if (materializedDuringOperation || current.HasPendingBulkMaterializationCommit)
                     {
-                        ancestors!.Remove(current.Item);
+                        materializationChanged = true;
+                        (materializationCommits ??= new List<HierarchicalNode>()).Add(current);
                     }
-                    continue;
+
+                    if (!wasExpanded && !isVirtualRoot)
+                    {
+                        anyExpanded = true;
+                        (expandedNodes ??= new List<HierarchicalNode>()).Add(current);
+                    }
+
+                    if (current.IsLeaf || depth >= limit)
+                    {
+                        if (current.Level >= hashedCycleDepth)
+                        {
+                            ancestors!.Remove(current.Item);
+                        }
+                        continue;
+                    }
+
+                    var children = current.MutableChildren;
+                    var allChildrenAreLeaves = children.Count > 0;
+                    for (int i = 0; i < children.Count; i++)
+                    {
+                        if (!children[i].IsLeaf)
+                        {
+                            allChildrenAreLeaves = false;
+                            break;
+                        }
+                    }
+
+                    if (allChildrenAreLeaves)
+                    {
+                        // Preserve leaf expansion state and preorder events without pushing a stack
+                        // frame for every terminal node in wide hierarchies.
+                        traversedNodeCount += children.Count;
+                        for (int i = 0; i < children.Count; i++)
+                        {
+                            var child = children[i];
+                            if (child.HasPendingBulkMaterializationCommit)
+                            {
+                                materializationChanged = true;
+                                (materializationCommits ??= new List<HierarchicalNode>()).Add(child);
+                            }
+
+                            if (!child.IsExpanded)
+                            {
+                                anyExpanded = true;
+                                (expandedNodes ??= new List<HierarchicalNode>()).Add(child);
+                            }
+                        }
+
+                        if (current.Level >= hashedCycleDepth)
+                        {
+                            ancestors!.Remove(current.Item);
+                        }
+                        continue;
+                    }
+
+                    stack.Push((current, depth, true));
+                    for (int i = children.Count - 1; i >= 0; i--)
+                    {
+                        stack.Push((children[i], depth + 1, false));
+                    }
                 }
 
-                stack.Push((current, depth, true));
-                for (int i = children.Count - 1; i >= 0; i--)
+                if (!anyExpanded && !materializationChanged)
                 {
-                    stack.Push((children[i], depth + 1, false));
+                    return;
                 }
+
+                CommitBulkExpansion(
+                    start,
+                    expandedNodes,
+                    expansionStatesAlreadyApplied: false,
+                    materializationChanged,
+                    traversedNodeCount);
+            }
+            catch
+            {
+                SetPendingBulkMaterializationCommit(materializationCommits, value: true);
+                throw;
             }
 
-            if (!anyExpanded && !materializationChanged)
+            SetPendingBulkMaterializationCommit(materializationCommits, value: false);
+        }
+
+        private static void SetPendingBulkMaterializationCommit(
+            IList<HierarchicalNode>? nodes,
+            bool value)
+        {
+            if (nodes == null)
             {
                 return;
             }
 
-            CommitBulkExpansion(
-                start,
-                expandedNodes,
-                expansionStatesAlreadyApplied: false,
-                materializationChanged,
-                traversedNodeCount);
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                nodes[i].HasPendingBulkMaterializationCommit = value;
+            }
         }
 
         private void CommitBulkExpansion(
@@ -2300,8 +2366,38 @@ namespace Avalonia.Controls.DataGridHierarchical
 
         private int InsertVisibleChildren(HierarchicalNode parent, int insertIndex)
         {
+            List<HierarchicalNode>? ignoredMaterializationCommits = null;
+            return InsertVisibleChildren(
+                parent,
+                insertIndex,
+                collectMaterializationCommits: false,
+                ref ignoredMaterializationCommits);
+        }
+
+        private int InsertVisibleChildren(
+            HierarchicalNode parent,
+            int insertIndex,
+            ref List<HierarchicalNode>? materializationCommits)
+        {
+            return InsertVisibleChildren(
+                parent,
+                insertIndex,
+                collectMaterializationCommits: true,
+                ref materializationCommits);
+        }
+
+        private int InsertVisibleChildren(
+            HierarchicalNode parent,
+            int insertIndex,
+            bool collectMaterializationCommits,
+            ref List<HierarchicalNode>? materializationCommits)
+        {
             var buffer = new List<HierarchicalNode>();
-            CollectVisibleChildren(parent, buffer);
+            CollectVisibleChildren(
+                parent,
+                buffer,
+                collectMaterializationCommits,
+                ref materializationCommits);
 
             if (buffer.Count > 0)
             {
@@ -2311,7 +2407,23 @@ namespace Avalonia.Controls.DataGridHierarchical
             return buffer.Count;
         }
 
-        private void CollectVisibleChildren(HierarchicalNode parent, List<HierarchicalNode> buffer)
+        private void CollectVisibleChildren(
+            HierarchicalNode parent,
+            List<HierarchicalNode> buffer)
+        {
+            List<HierarchicalNode>? ignoredMaterializationCommits = null;
+            CollectVisibleChildren(
+                parent,
+                buffer,
+                collectMaterializationCommits: false,
+                ref ignoredMaterializationCommits);
+        }
+
+        private void CollectVisibleChildren(
+            HierarchicalNode parent,
+            List<HierarchicalNode> buffer,
+            bool collectMaterializationCommits,
+            ref List<HierarchicalNode>? materializationCommits)
         {
             if (!parent.IsExpanded || parent.IsLeaf)
             {
@@ -2334,6 +2446,10 @@ namespace Avalonia.Controls.DataGridHierarchical
             {
                 var current = stack.Pop();
                 buffer.Add(current);
+                if (collectMaterializationCommits && current.HasPendingBulkMaterializationCommit)
+                {
+                    (materializationCommits ??= new List<HierarchicalNode>()).Add(current);
+                }
 
                 if (!current.IsExpanded || current.IsLeaf)
                 {

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
@@ -380,11 +380,7 @@ namespace Avalonia.Controls.DataGridHierarchical
 
         private void TrimLoadInfo()
         {
-            if (_loadInfo is
-                {
-                    Error: null,
-                    Cancellation: null
-                })
+            if (_loadInfo is { Error: null, Cancellation: null })
             {
                 _loadInfo = null;
             }

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
@@ -295,6 +295,27 @@ namespace Avalonia.Controls.DataGridHierarchical
         /// </summary>
         internal bool HasMaterializedChildren { get; set; }
 
+        /// <summary>
+        /// Tracks materialization completed by a transactional bulk expansion that has not yet
+        /// committed its flattened snapshot.
+        /// </summary>
+        internal bool HasPendingBulkMaterializationCommit
+        {
+            get => _loadInfo?.PendingBulkMaterializationCommit ?? false;
+            set
+            {
+                if (value)
+                {
+                    (_loadInfo ??= new NodeLoadInfo()).PendingBulkMaterializationCommit = true;
+                }
+                else if (_loadInfo != null)
+                {
+                    _loadInfo.PendingBulkMaterializationCommit = false;
+                    TrimLoadInfo();
+                }
+            }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         /// <summary>
@@ -353,7 +374,12 @@ namespace Avalonia.Controls.DataGridHierarchical
 
         private void TrimLoadInfo()
         {
-            if (_loadInfo is { Error: null, Cancellation: null })
+            if (_loadInfo is
+                {
+                    Error: null,
+                    Cancellation: null,
+                    PendingBulkMaterializationCommit: false
+                })
             {
                 _loadInfo = null;
             }
@@ -377,6 +403,7 @@ namespace Avalonia.Controls.DataGridHierarchical
         {
             public Exception? Error;
             public CancellationTokenSource? Cancellation;
+            public bool PendingBulkMaterializationCommit;
         }
 
         private sealed class NodeConnectionInfo

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalNode.cs
@@ -28,6 +28,7 @@ namespace Avalonia.Controls.DataGridHierarchical
         private bool _isLeaf;
         private int _level;
         private bool _isLoading;
+        private int _pendingBulkMaterializationCommitGeneration;
         private NodeLoadInfo? _loadInfo;
         // Collection and item notification state is absent for most nodes. Keeping it in a
         // sidecar avoids four unused references on every immutable hierarchy node.
@@ -301,19 +302,24 @@ namespace Avalonia.Controls.DataGridHierarchical
         /// </summary>
         internal bool HasPendingBulkMaterializationCommit
         {
-            get => _loadInfo?.PendingBulkMaterializationCommit ?? false;
+            get => _pendingBulkMaterializationCommitGeneration != 0;
             set
             {
-                if (value)
+                if (!value)
                 {
-                    (_loadInfo ??= new NodeLoadInfo()).PendingBulkMaterializationCommit = true;
+                    _pendingBulkMaterializationCommitGeneration = 0;
                 }
-                else if (_loadInfo != null)
+                else if (_pendingBulkMaterializationCommitGeneration == 0)
                 {
-                    _loadInfo.PendingBulkMaterializationCommit = false;
-                    TrimLoadInfo();
+                    _pendingBulkMaterializationCommitGeneration = -1;
                 }
             }
+        }
+
+        internal int PendingBulkMaterializationCommitGeneration
+        {
+            get => _pendingBulkMaterializationCommitGeneration;
+            set => _pendingBulkMaterializationCommitGeneration = value;
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -377,8 +383,7 @@ namespace Avalonia.Controls.DataGridHierarchical
             if (_loadInfo is
                 {
                     Error: null,
-                    Cancellation: null,
-                    PendingBulkMaterializationCommit: false
+                    Cancellation: null
                 })
             {
                 _loadInfo = null;
@@ -403,7 +408,6 @@ namespace Avalonia.Controls.DataGridHierarchical
         {
             public Exception? Error;
             public CancellationTokenSource? Cancellation;
-            public bool PendingBulkMaterializationCommit;
         }
 
         private sealed class NodeConnectionInfo

--- a/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
@@ -240,7 +240,9 @@
       </ControlTheme>
 
       <ControlTheme x:Key="DataGridOptimizedRowTheme" TargetType="DataGridRow">
-        <Setter Property="Background" Value="{Binding $parent[DataGrid].RowBackground}" />
+        <Setter Property="Background"
+                x:DataType="DataGridRow"
+                Value="{CompiledBinding $parent[DataGrid].RowBackground}" />
         <Setter Property="Template">
           <ControlTemplate>
             <DataGridFrozenGrid Name="PART_Root"

--- a/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
@@ -240,8 +240,7 @@
       </ControlTheme>
 
       <ControlTheme x:Key="DataGridOptimizedRowTheme" TargetType="DataGridRow">
-        <Setter Property="Background"
-                Value="{CompiledBinding $parent[DataGrid].RowBackground}" />
+        <Setter Property="Background" Value="{CompiledBinding $parent[DataGrid].RowBackground}" />
         <Setter Property="Template">
           <ControlTemplate>
             <DataGridFrozenGrid Name="PART_Root"

--- a/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Optimized.xaml
@@ -241,7 +241,6 @@
 
       <ControlTheme x:Key="DataGridOptimizedRowTheme" TargetType="DataGridRow">
         <Setter Property="Background"
-                x:DataType="DataGridRow"
                 Value="{CompiledBinding $parent[DataGrid].RowBackground}" />
         <Setter Property="Template">
           <ControlTemplate>

--- a/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
@@ -205,12 +205,27 @@ namespace Avalonia.Controls.Utils
             BindingBase? binding,
             bool observesWrappedHierarchyItem = false)
         {
+            return SupportsDirectTextDataContextRead(
+                binding,
+                observesWrappedHierarchyItem,
+                out _);
+        }
+
+        public static bool SupportsDirectTextDataContextRead(
+            BindingBase? binding,
+            bool observesWrappedHierarchyItem,
+            out bool requiresWrappedHierarchyItemObservation)
+        {
+            requiresWrappedHierarchyItemObservation = false;
             if (!SupportsDirectDataContextRead(binding) ||
                 !HasSupportedDirectReadMode(binding) ||
                 !HasDefaultDirectReadAnchorAndPriority(binding) ||
                 !HasDefaultFallbackValues(binding) ||
                 HasReadDelay(binding) ||
-                !HasObservableDirectReadPath(binding, observesWrappedHierarchyItem))
+                !HasObservableDirectReadPath(
+                    binding,
+                    observesWrappedHierarchyItem,
+                    out requiresWrappedHierarchyItemObservation))
             {
                 return false;
             }
@@ -220,13 +235,21 @@ namespace Avalonia.Controls.Utils
             // Avalonia's retained binding path. The grid's default converter is known to perform
             // only the standard value-to-string conversion reproduced by the typed accessor.
             var converter = GetConverter(binding);
-            return converter == null || ReferenceEquals(converter, DataGridValueConverter.Instance);
+            if (converter == null || ReferenceEquals(converter, DataGridValueConverter.Instance))
+            {
+                return true;
+            }
+
+            requiresWrappedHierarchyItemObservation = false;
+            return false;
         }
 
         private static bool HasObservableDirectReadPath(
             BindingBase? binding,
-            bool observesWrappedHierarchyItem)
+            bool observesWrappedHierarchyItem,
+            out bool requiresWrappedHierarchyItemObservation)
         {
+            requiresWrappedHierarchyItemObservation = false;
             var path = GetPath(binding);
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -240,10 +263,13 @@ namespace Avalonia.Controls.Utils
             }
 
             const string wrappedItemPrefix = "Item.";
-            return observesWrappedHierarchyItem &&
-                   path.StartsWith(wrappedItemPrefix, System.StringComparison.Ordinal) &&
-                   path.IndexOf('.', wrappedItemPrefix.Length) < 0 &&
-                   path.IndexOf('[', wrappedItemPrefix.Length) < 0;
+            requiresWrappedHierarchyItemObservation = observesWrappedHierarchyItem &&
+                                                       path.StartsWith(
+                                                           wrappedItemPrefix,
+                                                           System.StringComparison.Ordinal) &&
+                                                       path.IndexOf('.', wrappedItemPrefix.Length) < 0 &&
+                                                       path.IndexOf('[', wrappedItemPrefix.Length) < 0;
+            return requiresWrappedHierarchyItemObservation;
         }
 
         public static bool SupportsDirectRawDataContextRead(BindingBase? binding)

--- a/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
@@ -201,9 +201,7 @@ namespace Avalonia.Controls.Utils
             };
         }
 
-        public static bool SupportsDirectTextDataContextRead(
-            BindingBase? binding,
-            bool observesWrappedHierarchyItem = false)
+        public static bool SupportsDirectTextDataContextRead(BindingBase? binding, bool observesWrappedHierarchyItem = false)
         {
             return SupportsDirectTextDataContextRead(
                 binding,

--- a/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/BindingCloneHelper.cs
@@ -201,13 +201,16 @@ namespace Avalonia.Controls.Utils
             };
         }
 
-        public static bool SupportsDirectTextDataContextRead(BindingBase? binding)
+        public static bool SupportsDirectTextDataContextRead(
+            BindingBase? binding,
+            bool observesWrappedHierarchyItem = false)
         {
             if (!SupportsDirectDataContextRead(binding) ||
                 !HasSupportedDirectReadMode(binding) ||
                 !HasDefaultDirectReadAnchorAndPriority(binding) ||
                 !HasDefaultFallbackValues(binding) ||
-                HasReadDelay(binding))
+                HasReadDelay(binding) ||
+                !HasObservableDirectReadPath(binding, observesWrappedHierarchyItem))
             {
                 return false;
             }
@@ -218,6 +221,29 @@ namespace Avalonia.Controls.Utils
             // only the standard value-to-string conversion reproduced by the typed accessor.
             var converter = GetConverter(binding);
             return converter == null || ReferenceEquals(converter, DataGridValueConverter.Instance);
+        }
+
+        private static bool HasObservableDirectReadPath(
+            BindingBase? binding,
+            bool observesWrappedHierarchyItem)
+        {
+            var path = GetPath(binding);
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return true;
+            }
+
+            path = path.Trim();
+            if (path.IndexOf('.') < 0 && path.IndexOf('[') < 0)
+            {
+                return true;
+            }
+
+            const string wrappedItemPrefix = "Item.";
+            return observesWrappedHierarchyItem &&
+                   path.StartsWith(wrappedItemPrefix, System.StringComparison.Ordinal) &&
+                   path.IndexOf('.', wrappedItemPrefix.Length) < 0 &&
+                   path.IndexOf('[', wrappedItemPrefix.Length) < 0;
         }
 
         public static bool SupportsDirectRawDataContextRead(BindingBase? binding)


### PR DESCRIPTION
## Summary

- prevent duplicate filtering lifecycle callbacks and refresh collapsed hierarchy filtering when retained descendants change
- align drawn-image clipping and crop geometry with retained image behavior
- preserve nested direct-binding notifications by falling back when direct accessors cannot observe the full path
- keep the optimized row background binding compiled
- preserve canceled asynchronous hierarchy materialization for safe recovery through later expansion paths
- stabilize dispatcher-sensitive filtering regression tests so they coexist with PR #336's Avalonia headless tests
- remove success-path hierarchy materialization journal allocations while preserving cancellation and exception recovery
- clear stale pending-materialization bookkeeping when a collapsed, dematerialized descendant fails its later asynchronous reload

## Why

This is a follow-up to #335 that addresses the six outstanding review findings. The highest-impact fixes cover duplicate filter refresh lifecycle work and stale collapsed-hierarchy filtering. It also repairs rendering, binding notification, and asynchronous cancellation recovery issues while keeping the optimized theme free of reflection binding.

The final recovery follow-up closes a case where a descendant materialized during a canceled bulk expansion, was later collapsed and dematerialized, and then failed its retry. The operation now clears the obsolete generation-tagged pending marker through the existing visible-node commit path without adding a journal, collection, or per-operation allocation.

## Validation

- focused regression coverage was added for every behavioral fix
- `DataGridHierarchicalFilteringAdapterTests`: 20 passed, 0 failed after the PR #336 compatibility hardening
- `HierarchicalModelTests`: 129 passed, 0 failed
- full `Avalonia.Controls.DataGrid.UnitTests` at final head: 2,758 passed, 0 failed
- exact current-master integration (`1c67b7ca` + the preceding PR head): 2,770 passed, 0 failed with the xUnit v3 runner
- the optimized-row runtime test covers both initial `RowBackground` propagation and updates after changing `DataGrid.RowBackground`
- independent review of final commit `09c5a74a`: passed with no actionable findings; the reviewer independently reran all 129 hierarchy-model tests and verified the eight full BenchmarkDotNet JSON reports

No review threads were replied to or resolved as part of this work.

## Drawn hierarchy accessor follow-up

- restore the typed value-provider path for drawn `DataGridTextColumn` bindings that use a simple `Item.Member` path on `IHierarchicalNodeItem` rows
- scope wrapped-item notification tracking to those eligible text providers; existing custom, numeric, image, and progress providers remain unchanged
- retain Avalonia-binding fallback for true nested paths such as `Item.Address.City`, as well as converters, fallback/target-null values, delays, and non-local binding priorities
- preserve runtime tracking toggles, recycling, detach, and deduplication semantics
- `DataGridOptimizedCellTests` + `DataGridDirectBindingSemanticsTests`: 60 passed, 0 failed

The earlier focused drawn-scroll result against `2f16eb9f` (latency -7.64%, managed allocation -3.82%) demonstrates recovery from that intermediate regression; it is not a net PR-versus-master result. In the maintainer's net comparison, the equivalent headless and native drawn lanes were inconclusive (+4.03% and -0.15% latency respectively).

## Mitigation of the reported expansion-allocation regression

The maintainer performance review identified repeatable allocation growth from the per-operation materialization-commit `List<HierarchicalNode>`. Commit `6799d292` removes that journal and replaces it with generation-tagged node state; tags are cleared only after the corresponding flattened commit and callbacks complete.

- a one-million-object allocation probe measured `HierarchicalNode` at 96.003 bytes both before and after the direct generation field
- BenchmarkDotNet `Short` + `MemoryDiagnoser`, `AsyncHierarchyExpansionBenchmarks.ExpandAllAsync`, `Strategy=Batched`, three representative shapes, exact current master versus integrated PR head
- all eight final balanced ABBA/BAAB processes reported byte-for-byte allocation parity:
  - `Wide2555Depth3`: 402.25 KiB master / 402.25 KiB PR
  - `Binary4094Depth11`: 1816.01 KiB master / 1816.01 KiB PR
  - `VeryDeep512Depth128`: 396.65 KiB master / 396.65 KiB PR
- latency remained inconclusive because the one-operation iterations are short and showed pronounced process/outlier noise; no net latency improvement is claimed

This directly mitigates the allocation regression raised in the maintainer review while retaining cancellation and exception recovery semantics.

## Final pending-marker correction performance isolation

The final correction was isolated by comparing exact baseline `6799d292` with final head `09c5a74a` using eight independent Short processes in `A-B-B-A / B-A-A-B` order. Every process executed the same three Batched shapes with `MemoryDiagnoser` after successful Dry validation.

Managed allocation was byte-identical in every run:

- `Wide2555Depth3`: 412,000 / 412,000 bytes per operation
- `Binary4094Depth11`: 1,855,680 / 1,855,680 bytes per operation
- `VeryDeep512Depth128`: 402,272 / 402,272 bytes per operation

Latency did not show a repeatable practical regression. The two balanced blocks disagreed in direction for Wide (+43.6%, then -9.2%) and VeryDeep (+0.8%, then -18.5%); Binary measured +0.5%, then +9.0%. Because the cross-process and one-operation iteration noise is material, neither a speedup nor a regression is claimed.

Benchmark artifacts remained outside the repository.
