### PR TITLE
Add model-driven DataGrid navigation, input, and routing

### DIFF
--- a/docfx/articles/navigation-input-model.md
+++ b/docfx/articles/navigation-input-model.md
@@ -1,0 +1,314 @@
+# Navigation input model
+
+The navigation input model lets a ViewModel translate key, pointer, and wheel input
+into semantic cell or application-route navigation. It removes the need for
+code-behind handlers, behaviors, custom templates, or UI-framework event objects in
+the ViewModel.
+
+The responsibilities stay deliberately separate:
+
+```text
+Avalonia routed input
+        |
+        v
+DataGrid normalization
+        |
+        v
+IDataGridNavigationInputModel       ViewModel input policy
+        |
+        +---- cell command --------> IDataGridNavigationModel
+        |
+        +---- route operation -----> IDataGridRouteNavigationModel
+        |
+        v
+DataGrid edit / focus / selection / layout / scroll mechanics
+```
+
+The input model chooses **intent**. The cell navigation model chooses cell policy.
+The route model chooses application navigation. The grid remains the only layer
+that handles routed events, hit testing, editing, focus, selection, virtualization,
+and spatial layout geometry.
+
+## Create and bind a model
+
+Configure the model in the ViewModel and bind it like every other DataGrid model:
+
+```csharp
+public sealed class OrdersViewModel : ReactiveObject
+{
+    public OrdersViewModel()
+    {
+        NavigationInputModel.SetBindings(
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.J,
+                DataGridNavigationInputResult.Navigate(
+                    DataGridNavigationCommand.Down)),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.K,
+                DataGridNavigationInputResult.Navigate(
+                    DataGridNavigationCommand.Up)));
+    }
+
+    public DataGridNavigationInputModel NavigationInputModel { get; } = new();
+}
+```
+
+```xml
+<DataGrid ItemsSource="{CompiledBinding Orders}"
+          NavigationInputModel="{CompiledBinding NavigationInputModel}" />
+```
+
+Bindings are evaluated in declaration order and the first match wins. Replacing the
+table with `SetBindings` is explicit and does not scan commands, methods, attributes,
+or assemblies at runtime.
+
+## Normalized input contract
+
+`DataGridNavigationInputRequest` is immutable and contains no Avalonia event args,
+control, visual, or routed-event reference. It describes:
+
+- event kind: key down/up, pointer pressed/released, or pointer wheel;
+- logical key and layout-independent physical key;
+- keyboard, gamepad, remote, or unknown key device;
+- Shift, Control, Alt, and Meta modifiers;
+- mouse, pen, touch, button, click count, and wheel direction/deltas;
+- pointer coordinates relative to the grid;
+- semantic hit target: grid, cell, row, row header, column header, group header, or
+  empty area;
+- target and current cell positions; and
+- whether a cell editor is active.
+
+This contract is suitable for a plain ViewModel unit test. Avalonia-specific
+normalization is confined to `DataGrid`.
+
+## Logical and physical keys
+
+Use a logical binding when the shortcut follows the user's active keyboard layout:
+
+```csharp
+DataGridNavigationInputBinding.KeyDown(
+    DataGridNavigationInputKey.G,
+    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.GridStart))
+```
+
+Use a physical binding when the shortcut represents a stable key position, such as
+a game control or Vim-style cluster that must not move when the keyboard layout
+changes:
+
+```csharp
+DataGridNavigationInputBinding.PhysicalKeyDown(
+    DataGridNavigationInputKey.H,
+    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Left))
+```
+
+Bindings can require modifiers. By default, extra modifiers are allowed; set
+`exactModifiers: true` when the shortcut must match exactly:
+
+```csharp
+DataGridNavigationInputBinding.KeyDown(
+    DataGridNavigationInputKey.Enter,
+    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.GridEnd),
+    DataGridNavigationInputModifiers.Control |
+        DataGridNavigationInputModifiers.Shift,
+    exactModifiers: true)
+```
+
+## Pointer and wheel navigation
+
+A pointer binding matches normalized button, click count, modifiers, and semantic
+target. `NavigateToTarget` activates the row or cell already resolved by the grid;
+the ViewModel never searches the visual tree:
+
+```csharp
+DataGridNavigationInputBinding.Pointer(
+    DataGridNavigationInputKind.PointerPressed,
+    DataGridNavigationPointerButton.Primary,
+    DataGridNavigationInputResult.NavigateToTarget(),
+    clickCount: 1,
+    targetKind: DataGridNavigationInputTargetKind.Cell)
+```
+
+Wheel input can issue cell commands or application history operations:
+
+```csharp
+NavigationInputModel.SetBindings(
+    DataGridNavigationInputBinding.Wheel(
+        DataGridNavigationWheelDirection.Up,
+        DataGridNavigationInputResult.NavigateRoute(
+            DataGridRouteNavigationKind.Back),
+        DataGridNavigationInputModifiers.Control),
+    DataGridNavigationInputBinding.Wheel(
+        DataGridNavigationWheelDirection.Down,
+        DataGridNavigationInputResult.NavigateRoute(
+            DataGridRouteNavigationKind.Forward),
+        DataGridNavigationInputModifiers.Control));
+```
+
+Ordinary unmodified wheel input is ignored by this table and continues through the
+normal scrolling path.
+
+## Dynamic ViewModel policy
+
+Use `InputResolving` when a decision depends on normalized request state. The table
+is resolved first; the ViewModel may then replace the result:
+
+```csharp
+NavigationInputModel.InputResolving += (_, e) =>
+{
+    if (e.Request.Kind == DataGridNavigationInputKind.KeyDown &&
+        e.Request.Key == DataGridNavigationInputKey.G)
+    {
+        bool extend =
+            (e.Request.Modifiers & DataGridNavigationInputModifiers.Shift) != 0;
+        e.Result = DataGridNavigationInputResult.Navigate(
+            extend
+                ? DataGridNavigationCommand.GridEnd
+                : DataGridNavigationCommand.GridStart);
+    }
+};
+```
+
+Keep resolution synchronous and allocation-light. Long-running application
+navigation belongs behind `IDataGridRouteNavigator`, whose route operation is
+asynchronous and cancellation-aware.
+
+## Result decisions and fallback
+
+The model can return:
+
+| Decision | Effect |
+| --- | --- |
+| `Ignore` | Preserve descendant and legacy DataGrid processing. |
+| `Handle` | Consume the input without navigation. |
+| `Navigate` | Execute one semantic `DataGridNavigationCommand`. |
+| `NavigateToTarget` | Activate the cell or row under pointer input. |
+| `NavigateToPosition` | Activate an explicit row/display-column position. |
+| `NavigateRoute` | Execute Navigate, Replace, Reset, Back, or Forward in the route model. |
+
+Navigation results default to `consumeWhenNavigationFails: false`. If a target is
+unavailable or a boundary policy exits, the input remains available to normal
+control/focus processing. Set the flag to `true` only when the shortcut must always
+be owned by the grid.
+
+The input model is resolved once for an event. A semantic command then enters the
+same edit, navigation-policy, focus, selection, spatial-layout, and scrolling
+pipeline used by built-in keyboard input and ViewModel commands. Boundary policy is
+not evaluated twice.
+
+## Editors and routed input
+
+The grid observes normalized input on the routed tunnel so application policy can
+see an event before a cell template consumes it. Returning `Ignore` preserves
+editor-first behavior and all legacy handling. This is important for text entry,
+multiline editors, combo boxes, and embedded controls.
+
+Recommended rules:
+
+- ignore ordinary text-entry keys while `IsEditing` is true;
+- map explicit edit commands such as Escape or F2 to semantic commands;
+- leave unowned Tab and arrow operations available when focus must exit;
+- avoid taking Space or Enter from an embedded button unless that is intentional;
+- prefer semantic target kinds over assumptions about template visuals.
+
+## Spatial layouts
+
+Input and layout are independent extensions. Input first resolves to a semantic
+command; an active layout may then own its geometry through
+`IDataGridLayoutNavigation`. Stack layouts keep their stacking axis, while spatial
+UniformGrid and Wrap layouts can resolve two-dimensional neighbors, page movement,
+line edges, and first/last positions, including unrealized targets.
+
+This ordering means custom keys, physical-key mappings, pointer target activation,
+and route operations require no layout-specific input binding. Runtime layout
+switches preserve the same ViewModel input policy.
+
+## MVVM framework use
+
+The core type has no dependency on an MVVM framework:
+
+| Framework | Recommended ownership |
+| --- | --- |
+| ReactiveUI | Create/configure the model in a `ReactiveObject`; expose separate `ReactiveCommand`s for toolbar or automation actions. Route operations delegate to the `RoutingState` adapter. |
+| CommunityToolkit.Mvvm | Expose the model from an `ObservableObject`; commands can call the same semantic navigation controller or injected route service. |
+| Prism | Own the model in the ViewModel; let `NavigateRoute` reach a Prism page/region adapter through `IDataGridRouteNavigator`. |
+| Caliburn.Micro | Expose the model as a normal bindable property; action methods and the model can share the same navigation service. |
+| Plain MVVM / Microsoft DI | Register factories or scoped route adapters in the composition root and create one mutable input model per grid ViewModel. |
+
+Do not register a mutable input model as a singleton unless every grid intentionally
+shares one binding table and resolving event.
+
+## Source generation
+
+The generator can create the model property and direct generated-view binding:
+
+```csharp
+[GenerateDataGridViewModel(
+    typeof(Order),
+    ProviderName = "OrderSchema",
+    GenerateNavigationModel = true,
+    GenerateNavigationInputModel = true,
+    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
+[GenerateDataGridView(
+    typeof(Order),
+    NavigationModelPropertyName = nameof(NavigationModel),
+    RouteNavigationModelPropertyName = nameof(RouteNavigationModel),
+    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
+public sealed partial class OrdersViewModel : ReactiveObject
+{
+    public IDataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public OrdersViewModel()
+    {
+        NavigationInputModel.SetBindings(/* application policy */);
+    }
+}
+```
+
+The schema provider emits `CreateNavigationInputModel()`. Namespace-wide attributes
+support the same options. Generated views validate manual properties against
+`IDataGridNavigationInputModel` and report `PDGSG141` for invalid integration.
+
+## Testing
+
+Test static and dynamic policy without a UI:
+
+```csharp
+DataGridNavigationInputResult result = model.Resolve(
+    new DataGridNavigationInputRequest(
+        DataGridNavigationInputKind.KeyDown,
+        DataGridNavigationInputKey.J,
+        DataGridNavigationInputKey.J,
+        DataGridNavigationKeyDeviceKind.Keyboard,
+        DataGridNavigationInputModifiers.None,
+        DataGridNavigationPointerDeviceKind.Unknown,
+        DataGridNavigationPointerButton.None,
+        DataGridNavigationWheelDirection.None,
+        clickCount: 0,
+        x: double.NaN,
+        y: double.NaN,
+        wheelDeltaX: 0,
+        wheelDeltaY: 0,
+        DataGridNavigationInputTargetKind.Cell,
+        DataGridNavigationPosition.Unset,
+        DataGridNavigationPosition.Unset,
+        isEditing: false));
+
+Assert.Equal(DataGridNavigationCommand.Down, result.Command);
+```
+
+Use Avalonia Headless tests for normalization, routed-event ordering, hit targets,
+editor ownership, focus exit, and the final edit/selection/layout pipeline.
+
+## Sample
+
+The gallery's **Navigation Source Generator** page uses a generated input model and
+generated view binding. It demonstrates J/K movement, a physical-key shortcut,
+dynamic G/Shift+G resolution, pointer target navigation, Ctrl+wheel route history,
+and cell/route completion telemetry without view event handlers.
+
+See also:
+
+- [Navigation model](navigation-model.md)
+- [Route navigation and MVVM frameworks](route-navigation.md)
+- [Navigation model design](navigation-model-design.md)
+- [Source-generated navigation](source-generators/selection-navigation-state.md#navigation-model-generation)

--- a/docfx/articles/navigation-input-model.md
+++ b/docfx/articles/navigation-input-model.md
@@ -147,6 +147,13 @@ NavigationInputModel.SetBindings(
 Ordinary unmodified wheel input is ignored by this table and continues through the
 normal scrolling path.
 
+For route activation, pointer input is target-aware. A matching pointer press or
+release routes the hit-tested `TargetPosition`, not a possibly stale current cell.
+Keyboard input routes the current cell. This keeps item, stable item key, column key,
+position, and input origin together across the asynchronous route boundary. Use
+pointer release for ordinary single-click activation when selection should run on
+press first.
+
 ## Dynamic ViewModel policy
 
 Use `InputResolving` when a decision depends on normalized request state. The table
@@ -183,7 +190,7 @@ The model can return:
 | `Navigate` | Execute one semantic `DataGridNavigationCommand`. |
 | `NavigateToTarget` | Activate the cell or row under pointer input. |
 | `NavigateToPosition` | Activate an explicit row/display-column position. |
-| `NavigateRoute` | Execute Navigate, Replace, Reset, Back, or Forward in the route model. |
+| `NavigateRoute` | Execute Navigate, Replace, Reset, Back, or Forward with target/current grid context. |
 
 Navigation results default to `consumeWhenNavigationFails: false`. If a target is
 unavailable or a boundary policy exits, the input remains available to normal
@@ -236,6 +243,11 @@ The core type has no dependency on an MVVM framework:
 
 Do not register a mutable input model as a singleton unless every grid intentionally
 shares one binding table and resolving event.
+
+Toolbar and framework commands should call
+`IDataGridRouteNavigationController.RequestNavigate`. The bound DataGrid then creates
+the same context used by key and pointer activation; commands do not need to copy
+`SelectedItem` or guess the current column.
 
 ## Source generation
 

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -5,10 +5,16 @@ Status: implementation design for the model-driven DataGrid navigation subsystem
 ## Purpose
 
 ProDataGrid already has mature keyboard movement, current-cell, selection, editing,
-grouping, hierarchy, and virtualization behavior. The navigation model adds a stable
-policy boundary around that engine. Applications can observe, cancel, redirect, or
-programmatically issue navigation without duplicating DataGrid internals or handling
-view events in code-behind.
+grouping, hierarchy, and virtualization behavior. The navigation model adds two
+composable boundaries around that engine:
+
+1. cell navigation resolves fast, synchronous movement inside the grid; and
+2. route navigation resolves a stable row/column context into an asynchronous
+   application route.
+
+Applications can observe, cancel, redirect, or programmatically issue either kind of
+navigation without duplicating DataGrid internals or handling view events in
+code-behind.
 
 The design preserves the current default behavior. Assigning no custom model must
 produce the same movement, selection, editing, scrolling, and focus results as today.
@@ -26,6 +32,13 @@ The public contract combines the strongest conventions from established grids:
   navigation while leaving row-model and virtualization details in the grid.
 - Spreadsheet-oriented grids add Ctrl/Cmd edge jumps, row-major Tab traversal,
   explicit wrapping policies, and predictable behavior for hidden/frozen columns.
+- ReactiveUI models view-model-first navigation as route segments in a stack owned by
+  `IScreen`/`RoutingState` and hosted by `RoutedViewHost`.
+- Prism models navigation as URI requests with parameters, target regions or page
+  hosts, history operations, and explicit success/cancellation/failure results.
+- CommunityToolkit.Mvvm is intentionally UI-framework and router agnostic. Its
+  applications inject an application-defined navigation service and expose async
+  commands, so no Toolkit-specific router type can be assumed.
 
 The resulting ProDataGrid contract is input-independent, model-driven, observable,
 and compatible with Avalonia routed input and focus management.
@@ -54,9 +67,40 @@ keyboard / command / application API
        DataGridNavigationCompleted
 ```
 
-The model decides policy; the grid owns mechanics. In particular, the model does not
+The cell model decides policy; the grid owns mechanics. In particular, the model does not
 realize rows, mutate selection collections, commit editors, or calculate scroll
 offsets. This keeps virtualization and layout out of application ViewModels.
+
+Application routing is a separate, opt-in pipeline:
+
+```text
+row/cell activation or ViewModel command
+                 |
+                 v
+        DataGridRouteContext
+      (item/key/column/origin)
+                 |
+                 v
+       IDataGridRouteResolver
+                 |
+                 v
+   DataGridRouteNavigationRequest
+    (navigate/replace/reset/back/forward)
+                 |
+                 v
+       IDataGridRouteNavigator
+          |       |        |
+     ReactiveUI  Prism  app-defined service
+                 |
+                 v
+   DataGridRouteNavigationResult
+```
+
+The core route contract contains no ReactiveUI, Prism, CommunityToolkit, service
+locator, or view type. An adapter is responsible for translating the request into its
+native router and translating native completion into the common result. Route
+activation is asynchronous and cancellation-aware; arrow-key navigation stays
+synchronous and allocation-free.
 
 ## Public API shape
 
@@ -80,9 +124,29 @@ The new `Avalonia.Controls.DataGridNavigation` namespace contains:
 - `DataGridNavigationChangedEventArgs`: completion telemetry with old/new positions,
   handled/moved status, and failure reason when a requested target is invalid.
 - `IDataGridNavigationModel`: resolves requests and publishes preview/completion.
+- `IDataGridNavigationQueryModel`: optional side-effect-free policy queries for
+  command CanExecute evaluation.
 - `IDataGridNavigationModelFactory`: creates the per-grid default model.
 - `DataGridNavigationModel`: extensible default implementation and the home for
   reusable boundary, wrapping, RTL, editing, and traversal policies.
+
+The same namespace contains a distinct route family:
+
+- `DataGridRouteContext`: item, stable item key, stable column key, grid position,
+  and activation origin without a `DataGrid` or control reference.
+- `DataGridRoute`: stable path, optional immutable parameter/state, and optional
+  target region/outlet/screen identifier.
+- `DataGridRouteNavigationKind`: Navigate, Replace, Reset, Back, and Forward.
+- `DataGridRouteNavigationRequest` and `DataGridRouteNavigationResult`: immutable
+  framework-neutral input and typed completion status.
+- `IDataGridRouteResolver`: maps row/cell context to a route without reflection.
+- `IDataGridRouteNavigator`: advertises host capabilities and executes requests with
+  `ValueTask` and `CancellationToken`.
+- `IDataGridRouteNavigationModel`: exposes command enablement, busy/current state,
+  cancelable preview, execution, and completion telemetry.
+- `DataGridRouteNavigationModel`: the default orchestration implementation.
+- `DelegateDataGridRouteResolver` and `DelegateDataGridRouteNavigator`: AOT-safe
+  composition seams for adapters and application-defined navigation services.
 
 `DataGrid` adds:
 
@@ -96,6 +160,28 @@ The existing `KeyboardGestureOverrides`, `EnterKeyNavigationMode`, and
 `ContinueEditingOnEnter` APIs remain supported. Gesture mapping determines the
 semantic command; the navigation model determines policy; the existing movement
 engine applies the result.
+
+## Framework adapter contract
+
+Adapters are deliberately thin and live outside the grid engine:
+
+| Host | Native mapping |
+| --- | --- |
+| ReactiveUI | Navigate maps a route to an `IRoutableViewModel` and executes `RoutingState.Navigate`; Reset uses `NavigateAndReset`; Back uses `NavigateBack`; the adapter owns route-to-ViewModel creation and `IScreen`. |
+| Prism | Path and Target map to URI/region navigation; Parameter maps to navigation parameters; Back maps to page history or a region journal; native success, cancellation, and exception values map to the typed result. |
+| CommunityToolkit.Mvvm | The Toolkit ViewModel injects an application-defined `IDataGridRouteNavigator` (or wraps its existing navigation service) and invokes the model from `AsyncRelayCommand`; the Toolkit itself adds no router dependency. |
+| ReactiveUI + Avalonia | The application continues hosting views in `RoutedViewHost`; the adapter is registered in the composition root and contains no view code-behind. |
+| Plain MVVM / Microsoft DI | Register the application router as `IDataGridRouteNavigator`, register an AOT-safe resolver, and inject one `DataGridRouteNavigationModel` per navigation scope. |
+
+The route `Path` is an opaque stable identifier. It may be a URI, ReactiveUI segment,
+Prism registration key, or application route name. `Target` is optional because some
+hosts have one stack while region/outlet routers require a destination. Parameters
+remain application-owned so adapters can preserve typed ViewModel state.
+
+Inbound deep links and browser/history changes update application ViewModel state;
+ordinary bindings then restore `SelectedItem` and current cell by stable item and
+column keys. This prevents the router from reaching into realized row containers and
+keeps route restoration valid across sorting, filtering, paging, and virtualization.
 
 ## Required behavior matrix
 
@@ -117,6 +203,9 @@ The implementation and samples cover:
 | Accessibility | Current-cell focus, automation updates, no keyboard trap |
 | Programmatic | MVVM command navigation, cancellation, redirection, completion telemetry |
 | State | Optional current-cell/model policy capture with stable item/column keys |
+| Routes | Row/cell activation, stable paths, parameters, target regions, guards, cancellation |
+| History | Navigate, replace, reset, back, forward, deep-link restoration |
+| MVVM hosts | ReactiveUI, Prism page/region navigation, CommunityToolkit-style service, plain DI |
 
 ## Compatibility and rollout
 
@@ -128,6 +217,8 @@ The implementation and samples cover:
    model without changing existing defaults.
 5. Add state persistence only for opt-in navigation policy/current-cell sections;
    existing state payloads remain readable.
+6. Add route adapters and recipes without adding framework dependencies to the core
+   package or coupling cell navigation to an application router.
 
 ## Performance requirements
 
@@ -138,6 +229,8 @@ The implementation and samples cover:
   item source or realize off-screen containers.
 - Events are raised only when subscribed, and diagnostics remain opt-in.
 - Programmatic navigation is synchronous and UI-thread-affine, matching DataGrid.
+- Application route execution is asynchronous, cancellation-aware, and outside the
+  cell-movement hot path.
 
 ## Test strategy
 
@@ -146,6 +239,8 @@ The implementation and samples cover:
   grouping, hierarchy, RTL, hidden/frozen columns, and virtualization.
 - Regression tests preserve the existing navigation matrix.
 - Sample ViewModel tests verify ReactiveCommand wiring and event-free views.
+- Contract tests run the same route suite against delegate, ReactiveUI, Prism-shaped,
+  and Toolkit-style adapters.
 - State tests verify round-trip, missing keys, reordered columns, filtered rows, and
   backward-compatible payloads.
 
@@ -162,6 +257,12 @@ The gallery receives focused pages rather than one overloaded demo:
 7. Custom Navigation Model: cancel/redirection rules implemented in a ViewModel-owned
    model with no code-behind handlers.
 8. Navigation State: capture/restore with stable row and column keys.
+9. Route Navigation: row/cell activation, parameters, cancellation, failures, and
+   deep-link restoration using the framework-neutral contract.
+10. ReactiveUI Routing: `IScreen`, `RoutingState`, `IRoutableViewModel`, and
+    `RoutedViewHost` wiring.
+11. Prism and Toolkit Recipes: URI/region and injected-service adapters with the same
+    route resolver and ViewModel tests.
 
 All pages use compiled bindings with explicit `x:DataType`; code-behind contains only
 `InitializeComponent()`.

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -1,6 +1,6 @@
 # Navigation Model Design
 
-Status: implementation design for the model-driven DataGrid navigation subsystem.
+Status: implemented architecture for the model-driven DataGrid navigation subsystem.
 
 ## Purpose
 
@@ -218,8 +218,9 @@ The implementation and samples cover:
 3. Centralize explicit-target application and programmatic navigation.
 4. Move reusable wrapping, boundary, RTL, and traversal policies into the default
    model without changing existing defaults.
-5. Add state persistence only for opt-in navigation policy/current-cell sections;
-   existing state payloads remain readable.
+5. Capture opt-in navigation policy with `IDataGridNavigationStateModel`; retain
+   current-cell identity in the existing stable-key selection state so existing
+   state payloads remain readable.
 6. Add route adapters and recipes without adding framework dependencies to the core
    package or coupling cell navigation to an application router.
 
@@ -269,3 +270,8 @@ The gallery receives focused pages rather than one overloaded demo:
 
 All pages use compiled bindings with explicit `x:DataType`; code-behind contains only
 `InitializeComponent()`.
+
+The source generator additionally emits cell and route model factories, an opt-in
+cell-controller property, compiled bindings for both models, and `PDGSG141` contract
+validation. Its pre-existing `NavigationInteractionPropertyName` remains a separate
+activated-view current-cell/scroll bridge and may coexist with both model bindings.

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -165,6 +165,8 @@ The same namespace contains a distinct route family:
 
 - `DataGridRouteContext`: item, stable item key, stable column key, grid position,
   and activation origin without a `DataGrid` or control reference.
+- `IDataGridRouteContextFactory` and `DataGridRouteContextFactory`: optional AOT-safe
+  stable-key enrichment for contexts created by the grid.
 - `DataGridRoute`: stable path, optional immutable parameter/state, and optional
   target region/outlet/screen identifier.
 - `DataGridRouteNavigationKind`: Navigate, Replace, Reset, Back, and Forward.
@@ -175,6 +177,8 @@ The same namespace contains a distinct route family:
   `ValueTask` and `CancellationToken`.
 - `IDataGridRouteNavigationModel`: exposes command enablement, busy/current state,
   cancelable preview, execution, and completion telemetry.
+- `IDataGridRouteNavigationController`: sends ViewModel route requests back through
+  the bound grid so current item/column/position context is not reconstructed or lost.
 - `DataGridRouteNavigationModel`: the default orchestration implementation.
 - `DelegateDataGridRouteResolver` and `DelegateDataGridRouteNavigator`: AOT-safe
   composition seams for adapters and application-defined navigation services.
@@ -182,6 +186,9 @@ The same namespace contains a distinct route family:
 `DataGrid` adds:
 
 - `NavigationInputModel` for key, pointer, and wheel policy binding.
+- `RouteContextFactory` for stable item identity on grid-originated routes.
+- `GetRouteContext(position, origin)` for explicit target context and
+  `GetCurrentRouteContext(origin)` for current-cell context.
 - `NavigationModel` for binding or direct assignment.
 - `NavigationModelFactory` and `CreateNavigationModel()` for composition roots and
   control subclasses.

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -126,6 +126,9 @@ The new `Avalonia.Controls.DataGridNavigation` namespace contains:
 - `IDataGridNavigationModel`: resolves requests and publishes preview/completion.
 - `IDataGridNavigationQueryModel`: optional side-effect-free policy queries for
   command CanExecute evaluation.
+- `IDataGridNavigationController`: optional ViewModel-to-grid request channel used by
+  ReactiveCommand, RelayCommand, DelegateCommand, and plain `ICommand` without a
+  control reference.
 - `IDataGridNavigationModelFactory`: creates the per-grid default model.
 - `DataGridNavigationModel`: extensible default implementation and the home for
   reusable boundary, wrapping, RTL, editing, and traversal policies.

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -1,0 +1,167 @@
+# Navigation Model Design
+
+Status: implementation design for the model-driven DataGrid navigation subsystem.
+
+## Purpose
+
+ProDataGrid already has mature keyboard movement, current-cell, selection, editing,
+grouping, hierarchy, and virtualization behavior. The navigation model adds a stable
+policy boundary around that engine. Applications can observe, cancel, redirect, or
+programmatically issue navigation without duplicating DataGrid internals or handling
+view events in code-behind.
+
+The design preserves the current default behavior. Assigning no custom model must
+produce the same movement, selection, editing, scrolling, and focus results as today.
+
+## Research baseline
+
+The public contract combines the strongest conventions from established grids:
+
+- WPF DataGrid supplies the baseline arrow, Home/End, Page Up/Page Down, Enter,
+  editing, and Shift-selection behavior.
+- The WAI-ARIA grid pattern separates cell-to-cell navigation from interaction inside
+  an editor or embedded widget, with Enter/F2 entering interaction mode and Escape
+  restoring grid navigation.
+- AG Grid exposes current-cell APIs and interception points that can redirect or stop
+  navigation while leaving row-model and virtualization details in the grid.
+- Spreadsheet-oriented grids add Ctrl/Cmd edge jumps, row-major Tab traversal,
+  explicit wrapping policies, and predictable behavior for hidden/frozen columns.
+
+The resulting ProDataGrid contract is input-independent, model-driven, observable,
+and compatible with Avalonia routed input and focus management.
+
+## Architectural boundary
+
+```text
+keyboard / command / application API
+                 |
+                 v
+       DataGridNavigationRequest
+                 |
+                 v
+        IDataGridNavigationModel
+          |       |        |
+       default  redirect  cancel/stay
+          |       |        |
+          +-------+--------+
+                  |
+                  v
+       existing DataGrid movement engine
+                  |
+          selection/edit/focus/scroll
+                  |
+                  v
+       DataGridNavigationCompleted
+```
+
+The model decides policy; the grid owns mechanics. In particular, the model does not
+realize rows, mutate selection collections, commit editors, or calculate scroll
+offsets. This keeps virtualization and layout out of application ViewModels.
+
+## Public API shape
+
+The new `Avalonia.Controls.DataGridNavigation` namespace contains:
+
+- `DataGridNavigationCommand`: semantic operations such as Up, Down, Left, Right,
+  PageUp, PageDown, RowStart, RowEnd, GridStart, GridEnd, Next, Previous, Enter,
+  BeginEdit, CancelEdit, Expand, Collapse, and ExpandAll.
+- `DataGridNavigationOrigin`: Keyboard, Programmatic, Command, Automation, and
+  RestoredState.
+- `DataGridNavigationPosition`: immutable row/column coordinates for a data cell.
+- `DataGridNavigationRequest`: command, origin, current position, modifier state,
+  editing state, selection mode/unit, flow direction, and proposed default target
+  when one is available.
+- `DataGridNavigationDecision`: use the built-in route, move to an explicit target,
+  stay and consume, or leave the grid.
+- `DataGridNavigationResult`: immutable decision plus optional target and editing/
+  selection continuation hints.
+- `DataGridNavigationChangingEventArgs`: cancelable preview with the request and
+  resolved result.
+- `DataGridNavigationChangedEventArgs`: completion telemetry with old/new positions,
+  handled/moved status, and failure reason when a requested target is invalid.
+- `IDataGridNavigationModel`: resolves requests and publishes preview/completion.
+- `IDataGridNavigationModelFactory`: creates the per-grid default model.
+- `DataGridNavigationModel`: extensible default implementation and the home for
+  reusable boundary, wrapping, RTL, editing, and traversal policies.
+
+`DataGrid` adds:
+
+- `NavigationModel` for binding or direct assignment.
+- `NavigationModelFactory` and `CreateNavigationModel()` for composition roots and
+  control subclasses.
+- `Navigate(DataGridNavigationCommand, KeyModifiers)` as the programmatic entry point.
+- `CanNavigate(...)` for command enablement without causing side effects.
+
+The existing `KeyboardGestureOverrides`, `EnterKeyNavigationMode`, and
+`ContinueEditingOnEnter` APIs remain supported. Gesture mapping determines the
+semantic command; the navigation model determines policy; the existing movement
+engine applies the result.
+
+## Required behavior matrix
+
+The implementation and samples cover:
+
+| Area | Required behavior |
+| --- | --- |
+| Basic cells | Four-way arrows, Home/End, Ctrl/Cmd edges, page movement |
+| Tab | Forward/backward traversal, writable-cell skipping, boundary exit, new-row append |
+| Enter | Down or next-cell modes, commit, continue editing, multiline editor ownership |
+| Selection | Row/cell units, Shift extension, Ctrl/Cmd jumps, stable anchors |
+| Editing | Editor-first key ownership, failed validation, commit/cancel, F2/text entry |
+| Columns | Hidden, reordered, frozen-left, frozen-right, read-only, filler exclusion |
+| Rows | Empty grids, collection mutation, grouping headers, collapsed groups, new-row placeholder |
+| Hierarchy | Expand/collapse, parent/child movement, subtree expand, lazy rows |
+| Virtualization | Unrealized targets, variable heights, viewport page size, scroll-to-current |
+| Direction | LTR/RTL physical and logical horizontal movement |
+| Focus | One tab stop, entry/exit, descendant editors, nested grids |
+| Accessibility | Current-cell focus, automation updates, no keyboard trap |
+| Programmatic | MVVM command navigation, cancellation, redirection, completion telemetry |
+| State | Optional current-cell/model policy capture with stable item/column keys |
+
+## Compatibility and rollout
+
+1. Introduce the model types and a default pass-through implementation.
+2. Route every semantic keyboard command through the model while retaining the
+   current movement methods as the default executor.
+3. Centralize explicit-target application and programmatic navigation.
+4. Move reusable wrapping, boundary, RTL, and traversal policies into the default
+   model without changing existing defaults.
+5. Add state persistence only for opt-in navigation policy/current-cell sections;
+   existing state payloads remain readable.
+
+## Performance requirements
+
+- No allocation is permitted on an unobserved, default arrow-key path after model
+  initialization.
+- Requests, positions, and results are readonly structs where practical.
+- Navigation uses visible-column indexes and existing slot maps; it does not scan the
+  item source or realize off-screen containers.
+- Events are raised only when subscribed, and diagnostics remain opt-in.
+- Programmatic navigation is synchronous and UI-thread-affine, matching DataGrid.
+
+## Test strategy
+
+- Pure unit tests validate default and custom model decisions.
+- Avalonia Headless tests drive real key input and verify focus, editing, selection,
+  grouping, hierarchy, RTL, hidden/frozen columns, and virtualization.
+- Regression tests preserve the existing navigation matrix.
+- Sample ViewModel tests verify ReactiveCommand wiring and event-free views.
+- State tests verify round-trip, missing keys, reordered columns, filtered rows, and
+  backward-compatible payloads.
+
+## Sample plan
+
+The gallery receives focused pages rather than one overloaded demo:
+
+1. Navigation Model Basics: binding, programmatic commands, and completion status.
+2. Navigation Policies: contained, row-wrap, grid-wrap, and boundary exit.
+3. Editing and Spreadsheet Navigation: Tab/Enter/F2/editor ownership.
+4. Selection and Navigation: modifiers, anchors, row/cell units.
+5. Advanced Layout Navigation: hidden/reordered/frozen columns, RTL, grouping.
+6. Hierarchical Navigation: expand/collapse and lazy child traversal.
+7. Custom Navigation Model: cancel/redirection rules implemented in a ViewModel-owned
+   model with no code-behind handlers.
+8. Navigation State: capture/restore with stable row and column keys.
+
+All pages use compiled bindings with explicit `x:DataType`; code-behind contains only
+`InitializeComponent()`.

--- a/docfx/articles/navigation-model-design.md
+++ b/docfx/articles/navigation-model-design.md
@@ -4,12 +4,13 @@ Status: implemented architecture for the model-driven DataGrid navigation subsys
 
 ## Purpose
 
-ProDataGrid already has mature keyboard movement, current-cell, selection, editing,
+ProDataGrid already has mature input movement, current-cell, selection, editing,
 grouping, hierarchy, and virtualization behavior. The navigation model adds two
-composable boundaries around that engine:
+composable policy boundaries around that engine plus an optional input adapter:
 
-1. cell navigation resolves fast, synchronous movement inside the grid; and
-2. route navigation resolves a stable row/column context into an asynchronous
+1. input navigation normalizes key, pointer, and wheel events into semantic intent;
+2. cell navigation resolves fast, synchronous movement inside the grid; and
+3. route navigation resolves a stable row/column context into an asynchronous
    application route.
 
 Applications can observe, cancel, redirect, or programmatically issue either kind of
@@ -40,13 +41,28 @@ The public contract combines the strongest conventions from established grids:
   applications inject an application-defined navigation service and expose async
   commands, so no Toolkit-specific router type can be assumed.
 
-The resulting ProDataGrid contract is input-independent, model-driven, observable,
-and compatible with Avalonia routed input and focus management.
+The resulting ProDataGrid policy and route contracts remain input-independent. The
+optional input model consumes only normalized value objects, so all three layers are
+model-driven, observable, and compatible with Avalonia routed input and focus
+management without leaking UI objects into ViewModels.
 
 ## Architectural boundary
 
 ```text
-keyboard / command / application API
+key / pointer / wheel
+          |
+          v
+DataGridNavigationInputRequest
+          |
+          v
+IDataGridNavigationInputModel
+          |
+          v
+semantic command / explicit target / route operation
+          |
+          +-------------------------------+
+          v                               v
+command / application API       IDataGridRouteNavigationModel
                  |
                  v
        DataGridNavigationRequest
@@ -70,6 +86,12 @@ keyboard / command / application API
 The cell model decides policy; the grid owns mechanics. In particular, the model does not
 realize rows, mutate selection collections, commit editors, or calculate scroll
 offsets. This keeps virtualization and layout out of application ViewModels.
+
+The input request also contains no event args or visual objects. DataGrid performs
+routed-input normalization and semantic hit testing once, then delegates the stable
+request to the ViewModel model. `Ignore` preserves editor/legacy handling; handled
+semantic results enter the existing navigation pipeline once, so edit, boundary,
+selection, and layout policy are never double-resolved.
 
 Application routing is a separate, opt-in pipeline:
 
@@ -105,6 +127,12 @@ synchronous and allocation-free.
 ## Public API shape
 
 The new `Avalonia.Controls.DataGridNavigation` namespace contains:
+
+- `IDataGridNavigationInputModel`, `DataGridNavigationInputModel`, immutable input
+  requests/results, ordered key/pointer/wheel bindings, logical and physical keys,
+  modifiers, device kinds, and semantic target kinds. This optional layer translates
+  normalized input to cell commands, explicit targets, or route operations without
+  routed-event or visual-tree objects.
 
 - `DataGridNavigationCommand`: semantic operations such as Up, Down, Left, Right,
   PageUp, PageDown, RowStart, RowEnd, GridStart, GridEnd, Next, Previous, Enter,
@@ -153,6 +181,7 @@ The same namespace contains a distinct route family:
 
 `DataGrid` adds:
 
+- `NavigationInputModel` for key, pointer, and wheel policy binding.
 - `NavigationModel` for binding or direct assignment.
 - `NavigationModelFactory` and `CreateNavigationModel()` for composition roots and
   control subclasses.
@@ -162,7 +191,8 @@ The same namespace contains a distinct route family:
 The existing `KeyboardGestureOverrides`, `EnterKeyNavigationMode`, and
 `ContinueEditingOnEnter` APIs remain supported. Gesture mapping determines the
 semantic command; the navigation model determines policy; the existing movement
-engine applies the result.
+engine applies the result. An input-model `Ignore` decision deliberately falls back
+to those existing mappings.
 
 ## Framework adapter contract
 
@@ -205,6 +235,7 @@ The implementation and samples cover:
 | Focus | One tab stop, entry/exit, descendant editors, nested grids |
 | Accessibility | Current-cell focus, automation updates, no keyboard trap |
 | Programmatic | MVVM command navigation, cancellation, redirection, completion telemetry |
+| Input | Logical/physical keys, modifiers, key devices, pointer hit targets, wheel routes, editor fallback |
 | State | Optional current-cell/model policy capture with stable item/column keys |
 | Routes | Row/cell activation, stable paths, parameters, target regions, guards, cancellation |
 | History | Navigate, replace, reset, back, forward, deep-link restoration |
@@ -269,9 +300,10 @@ The gallery receives focused pages rather than one overloaded demo:
     route resolver and ViewModel tests.
 
 All pages use compiled bindings with explicit `x:DataType`; code-behind contains only
-`InitializeComponent()`.
+`InitializeComponent()`. The source-generated page also demonstrates a ViewModel-owned
+input table and dynamic resolver without a behavior or template override.
 
-The source generator additionally emits cell and route model factories, an opt-in
-cell-controller property, compiled bindings for both models, and `PDGSG141` contract
-validation. Its pre-existing `NavigationInteractionPropertyName` remains a separate
+The source generator additionally emits cell, input, and route model factories,
+opt-in cell/input properties, compiled bindings for all three models, and `PDGSG141`
+contract validation. Its pre-existing `NavigationInteractionPropertyName` remains a separate
 activated-view current-cell/scroll bridge and may coexist with both model bindings.

--- a/docfx/articles/navigation-model.md
+++ b/docfx/articles/navigation-model.md
@@ -51,6 +51,11 @@ Keyboard gestures are translated to these operations before policy runs. Existin
 `KeyboardGestureOverrides`, `EnterKeyNavigationMode`, and
 `ContinueEditingOnEnter` settings remain in effect.
 
+For ViewModel-owned key, pointer, physical-key, or wheel mappings, bind an
+`IDataGridNavigationInputModel`. It resolves framework-neutral input to one of these
+semantic commands before cell policy runs. See the
+[navigation input model](navigation-input-model.md).
+
 ## ViewModel commands
 
 `DataGridNavigationModel` implements `IDataGridNavigationController`. Its request
@@ -191,7 +196,9 @@ interaction inside a cell while preserving Avalonia focus and routed-input rules
 The gallery includes focused pages for basics, boundary and RTL policy, editing and
 selection, frozen/reordered/hidden columns, custom policy, hierarchy, state,
 framework-neutral routes, ReactiveUI routing, an executable MVVM framework wiring
-matrix, and source-generated navigation.
+matrix, and source-generated cell/input/route navigation. The generated sample maps
+logical and physical keys, pointer targets, and wheel history entirely in its
+ViewModel.
 
 ## Migrating existing grids
 
@@ -203,7 +210,8 @@ small steps:
 2. replace view event handlers with `RequestNavigate` calls from ViewModel commands;
 3. move boundary and Tab choices into model properties;
 4. override `ResolveCore` only for application-specific policy;
-5. add a separate `RouteNavigationModel` when row activation must change screens.
+5. add a bound `NavigationInputModel` when gestures must be ViewModel-owned; and
+6. add a separate `RouteNavigationModel` when row activation must change screens.
 
 `NavigationInteractionPropertyName` remains the source generator's legacy
 selection/current-cell callback. It can coexist with the new cell policy property
@@ -212,6 +220,7 @@ and application route property during migration.
 See also:
 
 - [Navigation model design](navigation-model-design.md)
+- [Navigation input model](navigation-input-model.md)
 - [Route navigation and MVVM frameworks](route-navigation.md)
 - [Source-generated navigation](source-generators/selection-navigation-state.md#navigation-model-generation)
 - [WAI-ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)

--- a/docfx/articles/navigation-model.md
+++ b/docfx/articles/navigation-model.md
@@ -1,0 +1,218 @@
+# Navigation model
+
+The navigation model separates **policy** from DataGrid mechanics. A ViewModel can
+choose whether a semantic operation uses the built-in route, moves to an explicit
+cell, redirects to another command, stays in the grid, or lets focus leave. The
+DataGrid still owns editing, selection, focus, virtualization, hidden and frozen
+columns, grouping, and scrolling.
+
+No model assignment is required. Every DataGrid creates a
+`DataGridNavigationModel` whose defaults preserve the existing keyboard behavior.
+
+## Bind a model
+
+Create one model per grid or per generated ViewModel instance:
+
+```csharp
+public sealed class OrdersViewModel : ReactiveObject
+{
+    public DataGridNavigationModel NavigationModel { get; } = new()
+    {
+        HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap,
+        VerticalBoundaryMode = DataGridNavigationBoundaryMode.Contained,
+        TabNavigationMode = DataGridTabNavigationMode.Always,
+        TabBoundaryMode = DataGridNavigationBoundaryMode.Exit
+    };
+}
+```
+
+```xml
+<DataGrid ItemsSource="{CompiledBinding Orders}"
+          NavigationModel="{CompiledBinding NavigationModel}"
+          SelectionUnit="Cell" />
+```
+
+Do not share one controller model between simultaneously active grids unless every
+request is intentionally broadcast to all of them.
+
+## Semantic commands
+
+`DataGridNavigationCommand` is independent of gestures:
+
+| Area | Commands |
+| --- | --- |
+| Cells | `Up`, `Down`, `Left`, `Right`, `PageUp`, `PageDown` |
+| Edges | `RowStart`, `RowEnd`, `ColumnStart`, `ColumnEnd`, `GridStart`, `GridEnd` |
+| Traversal | `Next`, `Previous`, `Enter` |
+| Editing | `BeginEdit`, `CancelEdit` |
+| Hierarchy | `Expand`, `Collapse`, `ExpandAll` |
+
+Keyboard gestures are translated to these operations before policy runs. Existing
+`KeyboardGestureOverrides`, `EnterKeyNavigationMode`, and
+`ContinueEditingOnEnter` settings remain in effect.
+
+## ViewModel commands
+
+`DataGridNavigationModel` implements `IDataGridNavigationController`. Its request
+channel is attached while it is bound to a DataGrid and detached when replaced.
+This lets any MVVM command request movement without receiving the control:
+
+```csharp
+NextCommand = ReactiveCommand.Create(() =>
+    NavigationModel.RequestNavigate(DataGridNavigationCommand.Next));
+
+ExtendDownCommand = ReactiveCommand.Create(() =>
+    NavigationModel.RequestNavigate(
+        DataGridNavigationCommand.Down,
+        KeyModifiers.Shift));
+```
+
+The same call works inside Prism `DelegateCommand`, CommunityToolkit
+`RelayCommand`, or a plain `ICommand`. `RequestNavigate` returns `false` when no
+grid is currently bound or the grid cannot handle the request.
+
+For control-side integration, use `DataGrid.Navigate` and `DataGrid.CanNavigate`.
+`CanNavigate` calls `IDataGridNavigationQueryModel.Query`, which is deliberately
+side-effect free and does not raise preview events.
+
+## Decisions and events
+
+The model receives an immutable `DataGridNavigationRequest` containing the current
+and proposed positions, modifiers, edit and selection state, flow direction, and
+visible boundaries. It returns one of these decisions:
+
+- `UseDefault`: run the mature built-in movement engine;
+- `MoveTo`: apply an explicit row/display-column target;
+- `RedirectTo`: execute another semantic command through the built-in engine;
+- `Stay`: consume the operation without moving;
+- `Cancel`: stay with a canceled failure reason;
+- `LeaveGrid`: leave the operation unhandled so normal focus traversal can continue.
+
+`NavigationChanging` is a cancelable preview. `NavigationChanged` reports old and
+new positions, handled/moved flags, and a typed failure reason such as no rows, no
+columns, invalid target, boundary, or cancellation.
+
+## Custom policy
+
+Override only `ResolveCore`; never calculate layout offsets or realize rows in a
+model:
+
+```csharp
+public sealed class GuardedNavigationModel : DataGridNavigationModel
+{
+    protected override DataGridNavigationResult ResolveCore(
+        DataGridNavigationRequest request)
+    {
+        if (request.Command == DataGridNavigationCommand.Down &&
+            request.CurrentPosition.RowIndex == 0)
+        {
+            return DataGridNavigationResult.MoveTo(
+                new DataGridNavigationPosition(
+                    rowIndex: 2,
+                    request.CurrentPosition.ColumnDisplayIndex));
+        }
+
+        return base.ResolveCore(request);
+    }
+}
+```
+
+Explicit targets use row indexes in the active view and **display** column indexes.
+The grid rejects hidden, filler, group, or out-of-range targets and reports
+`InvalidTarget` without partially changing selection.
+
+## Boundary, Tab, and RTL policy
+
+Horizontal, vertical, and Tab boundaries independently support `Contained`, `Wrap`,
+or `Exit`. `TabNavigationMode.EditingOnly` preserves the traditional editor-only Tab
+behavior; `Always` provides spreadsheet traversal outside edit mode.
+
+`HorizontalNavigationMode.Physical` treats Left and Right as physical directions.
+`Logical` reverses them for an RTL grid. Reordering, hidden columns, frozen-left and
+frozen-right columns, and filler exclusion continue through the existing column
+navigation engine.
+
+## Editing, selection, and hierarchy
+
+The model never commits an editor itself. `Enter`, `Next`, `Previous`, `BeginEdit`,
+and `CancelEdit` delegate mechanics to the existing edit pipeline, including failed
+validation and editor-first key ownership. Shift-modified commands use the existing
+selection anchor and transactional selection behavior.
+
+`Expand` and `Collapse` affect the current hierarchy node or row group only.
+`ExpandAll` expands its current subtree. The same commands work from keyboard,
+automation, or ViewModel commands.
+
+## State persistence
+
+`IDataGridNavigationStateModel` captures the model policy as a detached
+`DataGridNavigationPolicyState`:
+
+```csharp
+DataGridNavigationPolicyState policy = NavigationModel.CaptureState();
+NavigationModel.RestoreState(policy);
+```
+
+Current-cell identity is intentionally not duplicated in that object. It already
+lives in `DataGridSelectionState`, which supports stable item and column keys:
+
+```csharp
+var options = new DataGridStateOptions
+{
+    ItemKeySelector = item => ((Order)item).Id,
+    ItemKeyResolver = key => repository.Find((int)key),
+    ColumnKeySelector = column => column.ColumnKey
+};
+
+DataGridSelectionState current = grid.CaptureSelectionState(options);
+grid.RestoreSelectionState(current, options);
+```
+
+Generated applications should prefer the generated state controller and typed
+interaction described in
+[selection, navigation, and state](source-generators/selection-navigation-state.md).
+
+## Focus, accessibility, and performance
+
+- Keep one grid tab stop; do not make every realized cell an independent tab stop.
+- Return `LeaveGrid` at an exit boundary to avoid a keyboard trap.
+- Let editors own text-entry and embedded-widget keys until Enter/F2/Escape returns
+  control to the grid.
+- Keep `ResolveCore` synchronous and allocation-light. Application routes belong in
+  the separate asynchronous [route navigation](route-navigation.md) pipeline.
+- Use stable automation IDs on the grid and sample commands, and test keyboard-only
+  entry, exit, edit, and hierarchy flows with Avalonia Headless.
+
+These practices follow the WAI-ARIA grid distinction between grid navigation and
+interaction inside a cell while preserving Avalonia focus and routed-input rules.
+
+## Samples
+
+The gallery includes focused pages for basics, boundary and RTL policy, editing and
+selection, frozen/reordered/hidden columns, custom policy, hierarchy, state,
+framework-neutral routes, ReactiveUI routing, an executable MVVM framework wiring
+matrix, and source-generated navigation.
+
+## Migrating existing grids
+
+The navigation model is additive. A grid with no explicit `NavigationModel` keeps
+its existing gesture, edit, selection, focus, and boundary behavior. Adopt it in
+small steps:
+
+1. bind a default `DataGridNavigationModel` and verify behavior is unchanged;
+2. replace view event handlers with `RequestNavigate` calls from ViewModel commands;
+3. move boundary and Tab choices into model properties;
+4. override `ResolveCore` only for application-specific policy;
+5. add a separate `RouteNavigationModel` when row activation must change screens.
+
+`NavigationInteractionPropertyName` remains the source generator's legacy
+selection/current-cell callback. It can coexist with the new cell policy property
+and application route property during migration.
+
+See also:
+
+- [Navigation model design](navigation-model-design.md)
+- [Route navigation and MVVM frameworks](route-navigation.md)
+- [Source-generated navigation](source-generators/selection-navigation-state.md#navigation-model-generation)
+- [WAI-ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)
+- [WPF DataGrid keyboard behavior](https://learn.microsoft.com/dotnet/desktop/wpf/controls/default-keyboard-and-mouse-behavior-in-the-datagrid-control)

--- a/docfx/articles/route-navigation.md
+++ b/docfx/articles/route-navigation.md
@@ -40,25 +40,66 @@ RouteNavigationModel = new DataGridRouteNavigationModel(
 
 ```xml
 <DataGrid ItemsSource="{CompiledBinding Orders}"
-          RouteNavigationModel="{CompiledBinding RouteNavigationModel}" />
+          RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+          RouteContextFactory="{CompiledBinding RouteContextFactory}"
+          NavigationInputModel="{CompiledBinding NavigationInputModel}" />
 ```
 
-An application command can construct context from stable ViewModel state and call
-the model directly. A control behavior can call `DataGrid.NavigateRouteAsync`, which
-uses `GetCurrentRouteContext` for the current cell.
+Prefer `IDataGridRouteNavigationController.RequestNavigate` for toolbar, menu,
+automation, and ViewModel commands. `DataGridRouteNavigationModel` implements this
+optional controller interface. The request is raised back into the bound DataGrid,
+which supplies its authoritative current item, item key, column key, cell position,
+and origin. This avoids reconstructing context from `SelectedItem` and does not
+require a control reference in the ViewModel:
 
 ```csharp
-DataGridRouteNavigationResult result = await RouteNavigationModel.NavigateAsync(
-    DataGridRouteNavigationKind.Navigate,
-    new DataGridRouteContext(
-        selectedOrder,
-        selectedOrder?.Id,
-        "name",
-        DataGridNavigationPosition.Unset,
-        DataGridRouteNavigationOrigin.Command,
-        hasItem: selectedOrder is not null),
-    cancellationToken);
+OpenOrderCommand = ReactiveCommand.Create(() =>
+    RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
 ```
+
+Direct orchestration remains available for background workflows that already own a
+detached context. `DataGrid.NavigateRouteAsync` routes the current cell, while
+`GetRouteContext(position, origin)` builds context for an explicit cell.
+
+## Route from a click or key inside the grid
+
+Bind pointer release rather than pointer press when ordinary click selection should
+complete first. The input request still carries its hit-tested target, so the grid
+routes the clicked cell even if `CurrentCell` has not changed or another handler
+consumes the bubbling event:
+
+```csharp
+NavigationInputModel.SetBindings(
+    DataGridNavigationInputBinding.Pointer(
+        DataGridNavigationInputKind.PointerReleased,
+        DataGridNavigationPointerButton.Primary,
+        DataGridNavigationInputResult.NavigateRoute(
+            DataGridRouteNavigationKind.Navigate),
+        targetKind: DataGridNavigationInputTargetKind.Cell),
+    DataGridNavigationInputBinding.KeyDown(
+        DataGridNavigationInputKey.Enter,
+        DataGridNavigationInputResult.NavigateRoute(
+            DataGridRouteNavigationKind.Navigate)));
+```
+
+Pointer route execution uses `TargetPosition`; key and ViewModel-controller requests
+use the current cell. Back and Forward intentionally use an item-less history
+context while retaining the correct keyboard, pointer, or command origin.
+
+## Stable context identity
+
+`IDataGridRouteContextFactory` is the optional identity boundary used by DataGrid.
+The default context preserves item reference, column key, and position. Supply
+`DataGridRouteContextFactory` with an AOT-safe selector when route state must survive
+sorting, filtering, paging, reload, or virtualization:
+
+```csharp
+RouteContextFactory = new DataGridRouteContextFactory(
+    item => ((Order)item).Id);
+```
+
+The factory runs only for valid data-cell positions and does not inspect item
+members through reflection.
 
 Ordinary outcomes do not throw. Inspect `Succeeded`, `Canceled`, `RouteNotFound`,
 `NotSupported`, `Busy`, `InvalidRequest`, or `Failed`, plus the optional exception
@@ -137,28 +178,20 @@ ViewModels and the grid package. See Prism's official
 ## CommunityToolkit.Mvvm
 
 CommunityToolkit.Mvvm deliberately provides MVVM primitives rather than a router.
-Inject the application's navigation service or `IDataGridRouteNavigationModel` and
-invoke it from `AsyncRelayCommand`:
+Inject the grid-contextual controller implemented by the default route model and
+invoke it from a generated relay command:
 
 ```csharp
 public sealed partial class OrdersViewModel : ObservableObject
 {
-    private readonly IDataGridRouteNavigationModel _routes;
+    private readonly IDataGridRouteNavigationController _routes;
 
-    public OrdersViewModel(IDataGridRouteNavigationModel routes) =>
+    public OrdersViewModel(IDataGridRouteNavigationController routes) =>
         _routes = routes;
 
     [RelayCommand]
-    private async Task OpenOrderAsync(Order order, CancellationToken token)
-    {
-        var context = new DataGridRouteContext(
-            order, order.Id, "name", DataGridNavigationPosition.Unset,
-            DataGridRouteNavigationOrigin.Command);
-        await _routes.NavigateAsync(
-            DataGridRouteNavigationKind.Navigate,
-            context,
-            token);
-    }
+    private void OpenOrder() =>
+        _routes.RequestNavigate(DataGridRouteNavigationKind.Navigate);
 }
 ```
 
@@ -210,7 +243,11 @@ containers; sorting, filtering, paging, and virtualization make them transient.
 
 ## Source generation
 
-Generated schema providers expose `CreateRouteNavigationModel(resolver, navigator)`.
-Generated views validate and compile-bind an application-owned route property with
-`RouteNavigationModelPropertyName`. See
+Generated schema providers expose `CreateRouteNavigationModel(resolver, navigator)`
+and `CreateRouteContextFactory()`. When the row has `[DataGridKey]`, the latter uses
+the generated typed key accessor; otherwise it preserves reference/position context
+without inventing identity. `GenerateRouteContextFactory` emits a ViewModel
+property, and `RouteContextFactoryPropertyName` validates and compile-binds it to the
+generated DataGrid. Generated views also validate and compile-bind an
+application-owned route property with `RouteNavigationModelPropertyName`. See
 [source-generated navigation](source-generators/selection-navigation-state.md#navigation-model-generation).

--- a/docfx/articles/route-navigation.md
+++ b/docfx/articles/route-navigation.md
@@ -1,0 +1,211 @@
+# Route navigation and MVVM frameworks
+
+Application routing is distinct from cell movement. `IDataGridRouteNavigationModel`
+maps the current row/cell context to a stable route and asynchronously delegates it
+to the application's router. The core package contains no ReactiveUI, Prism,
+CommunityToolkit, service-locator, or view dependency.
+
+## Core pipeline
+
+```text
+DataGridRouteContext -> IDataGridRouteResolver -> DataGridRoute
+    -> DataGridRouteNavigationRequest -> IDataGridRouteNavigator
+    -> DataGridRouteNavigationResult
+```
+
+`DataGridRouteContext` carries the item, optional stable item key, column key,
+current position, and activation origin. `DataGridRoute` carries a stable path,
+optional immutable parameter/state, and optional target region/outlet/screen.
+
+The supported operations are `Navigate`, `Replace`, `Reset`, `Back`, and `Forward`.
+Navigators advertise their supported operations through
+`DataGridRouteNavigationCapabilities`; unsupported history operations return a
+typed `NotSupported` result.
+
+## Create and bind a route model
+
+```csharp
+var resolver = new DelegateDataGridRouteResolver(context =>
+    context.Item is Order order
+        ? new DataGridRoute(
+            path: $"orders/{order.Id}",
+            parameter: order.Id,
+            target: "details")
+        : null);
+
+RouteNavigationModel = new DataGridRouteNavigationModel(
+    resolver,
+    applicationNavigator);
+```
+
+```xml
+<DataGrid ItemsSource="{CompiledBinding Orders}"
+          RouteNavigationModel="{CompiledBinding RouteNavigationModel}" />
+```
+
+An application command can construct context from stable ViewModel state and call
+the model directly. A control behavior can call `DataGrid.NavigateRouteAsync`, which
+uses `GetCurrentRouteContext` for the current cell.
+
+```csharp
+DataGridRouteNavigationResult result = await RouteNavigationModel.NavigateAsync(
+    DataGridRouteNavigationKind.Navigate,
+    new DataGridRouteContext(
+        selectedOrder,
+        selectedOrder?.Id,
+        "name",
+        DataGridNavigationPosition.Unset,
+        DataGridRouteNavigationOrigin.Command,
+        hasItem: selectedOrder is not null),
+    cancellationToken);
+```
+
+Ordinary outcomes do not throw. Inspect `Succeeded`, `Canceled`, `RouteNotFound`,
+`NotSupported`, `Busy`, `InvalidRequest`, or `Failed`, plus the optional exception
+and message. The model converts adapter exceptions into `Failed`, resets
+`IsNavigating` in `finally`, and publishes completion telemetry.
+
+## ReactiveUI
+
+Use one `IScreen` and one `RoutingState` as the navigation root. Map a stable route
+to an `IRoutableViewModel`, then translate operations as follows:
+
+| ProDataGrid | ReactiveUI |
+| --- | --- |
+| `Navigate` | `RoutingState.Navigate.Execute(viewModel)` |
+| `Reset` | `RoutingState.NavigateAndReset.Execute(viewModel)` |
+| `Back` | `RoutingState.NavigateBack.Execute()` |
+| `Replace`, `Forward` | return `NotSupported` unless the application adds explicit history support |
+
+Host the router with `RoutedViewHost`. Keep route-to-ViewModel creation in an
+AOT-safe factory/type switch, not `Activator.CreateInstance` or reflection.
+
+The sample's `ReactiveUiDataGridRouteNavigator` is a working adapter and
+`ReactiveUiRouteViewLocator` is a reflection-free view locator. The
+`ReactiveUiRouteNavigationPage` demonstrates `IScreen`, `RoutingState`,
+`IRoutableViewModel`, and `RoutedViewHost` together.
+
+See the official [ReactiveUI routing guide](https://www.reactiveui.net/docs/handbook/routing.html).
+
+## Prism page or region navigation
+
+Prism owns URI registration, navigation parameters, regions/page hosts, and its
+journal. A Prism adapter should:
+
+1. map `DataGridRoute.Path` to the registered URI or view key;
+2. map `Target` to a region name or page host;
+3. copy the typed `Parameter` into `NavigationParameters`;
+4. map `Navigate`, `Back`, and supported journal operations to the native service;
+5. translate native success/cancellation/errors into
+   `DataGridRouteNavigationResult`.
+
+Keep the native service behind `IDataGridRouteNavigator`; the DataGrid and route
+resolver must not reference Prism:
+
+```csharp
+public sealed class PrismDataGridRouteNavigator : IDataGridRouteNavigator
+{
+    private readonly IApplicationNavigation _navigation;
+
+    public PrismDataGridRouteNavigator(IApplicationNavigation navigation) =>
+        _navigation = navigation;
+
+    public DataGridRouteNavigationCapabilities Capabilities =>
+        DataGridRouteNavigationCapabilities.Navigate |
+        DataGridRouteNavigationCapabilities.Back;
+
+    public async ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+        DataGridRouteNavigationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ApplicationNavigationResult native = await _navigation.NavigateAsync(
+            request.Kind,
+            request.Route.Path,
+            request.Route.Target,
+            request.Route.Parameter,
+            cancellationToken);
+        return native.ToDataGridResult();
+    }
+}
+```
+
+`IApplicationNavigation` in this example is an application boundary wrapping Prism's
+page or region service. This keeps Prism version and platform differences out of
+ViewModels and the grid package. See Prism's official
+[navigation documentation](https://docs.prismlibrary.com/docs/navigation/index.html).
+
+## CommunityToolkit.Mvvm
+
+CommunityToolkit.Mvvm deliberately provides MVVM primitives rather than a router.
+Inject the application's navigation service or `IDataGridRouteNavigationModel` and
+invoke it from `AsyncRelayCommand`:
+
+```csharp
+public sealed partial class OrdersViewModel : ObservableObject
+{
+    private readonly IDataGridRouteNavigationModel _routes;
+
+    public OrdersViewModel(IDataGridRouteNavigationModel routes) =>
+        _routes = routes;
+
+    [RelayCommand]
+    private async Task OpenOrderAsync(Order order, CancellationToken token)
+    {
+        var context = new DataGridRouteContext(
+            order, order.Id, "name", DataGridNavigationPosition.Unset,
+            DataGridRouteNavigationOrigin.Command);
+        await _routes.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            context,
+            token);
+    }
+}
+```
+
+See the official [MVVM Toolkit introduction](https://learn.microsoft.com/dotnet/communitytoolkit/mvvm/).
+
+## Plain MVVM and Microsoft DI
+
+Register the native navigator and resolver at their real lifetimes, then create one
+route model per navigation scope:
+
+```csharp
+services.AddSingleton<IDataGridRouteNavigator, ApplicationRouteNavigator>();
+services.AddSingleton<IDataGridRouteResolver, OrderRouteResolver>();
+services.AddScoped<IDataGridRouteNavigationModel>(provider =>
+    new DataGridRouteNavigationModel(
+        provider.GetRequiredService<IDataGridRouteResolver>(),
+        provider.GetRequiredService<IDataGridRouteNavigator>()));
+```
+
+The same arrangement works with plain `ICommand`, Caliburn.Micro actions, or another
+MVVM framework: only the command type and native adapter change.
+
+The gallery's **Navigation MVVM Frameworks** page runs the same resolver and route
+model through a framework mapping matrix. It complements the end-to-end ReactiveUI
+page and the production adapter recipes above without adding Prism or Toolkit
+dependencies to the core package.
+
+## Guards, cancellation, and concurrency
+
+- Use `NavigationChanging` for synchronous cancellation or route replacement.
+- Pass command/lifetime cancellation tokens through every adapter call.
+- A model rejects overlapping requests with a typed status; do not run two native
+  journal mutations concurrently.
+- Advertise only capabilities the native router actually implements.
+- Treat route paths as stable identifiers, not localized display text.
+
+## Deep links and restoration
+
+Inbound URIs or native history changes should update application ViewModel state.
+Restore the selected item/current cell by stable item and column keys through normal
+selection/state APIs, then call the route model with origin `RestoredState` when a
+route journal mutation is required. Routers should never search realized row
+containers; sorting, filtering, paging, and virtualization make them transient.
+
+## Source generation
+
+Generated schema providers expose `CreateRouteNavigationModel(resolver, navigator)`.
+Generated views validate and compile-bind an application-owned route property with
+`RouteNavigationModelPropertyName`. See
+[source-generated navigation](source-generators/selection-navigation-state.md#navigation-model-generation).

--- a/docfx/articles/route-navigation.md
+++ b/docfx/articles/route-navigation.md
@@ -186,6 +186,11 @@ model through a framework mapping matrix. It complements the end-to-end Reactive
 page and the production adapter recipes above without adding Prism or Toolkit
 dependencies to the core package.
 
+Key, pointer, remote, gamepad, or wheel gestures can also request these route
+operations through a bound `IDataGridNavigationInputModel`. The input layer returns
+`NavigateRoute(kind)`; route resolution and the native framework adapter remain in
+this asynchronous pipeline. See [navigation input model](navigation-input-model.md).
+
 ## Guards, cancellation, and concurrency
 
 - Use `NavigationChanging` for synchronous cancellation or route replacement.

--- a/docfx/articles/source-generators/attribute-reference.md
+++ b/docfx/articles/source-generators/attribute-reference.md
@@ -80,6 +80,10 @@ Constructors:
 | `FastPathOptionsPropertyName` | `FastPathOptions` | Generated fast-path options property. |
 | `GenerateNavigationModel` | `false` | Generate one `DataGridNavigationModel` controller property for this grid/ViewModel declaration. |
 | `NavigationModelPropertyName` | `NavigationModel` | Generated cell navigation model property name. |
+| `GenerateNavigationInputModel` | `false` | Generate one normalized `DataGridNavigationInputModel`. |
+| `NavigationInputModelPropertyName` | `NavigationInputModel` | Generated input-policy property name. |
+| `GenerateRouteContextFactory` | `false` | Generate an AOT-safe route-context factory using `[DataGridKey]` when available. |
+| `RouteContextFactoryPropertyName` | `RouteContextFactory` | Generated route-context factory property name. |
 | `ProviderName` | inferred | Existing/generated schema provider to use. |
 | `Strict` | `true` | Strict schema projection. |
 | `Streaming` | `false` | Streaming projection metadata. |
@@ -144,6 +148,8 @@ Constructors:
 | `SelectionModelPropertyName` | Selection model. |
 | `NavigationModelPropertyName` | `IDataGridNavigationModel` cell policy/controller. |
 | `RouteNavigationModelPropertyName` | `IDataGridRouteNavigationModel` application router. |
+| `NavigationInputModelPropertyName` | `IDataGridNavigationInputModel` normalized input policy. |
+| `RouteContextFactoryPropertyName` | `IDataGridRouteContextFactory` stable-key route context factory. |
 | `ClipboardImportModelPropertyName` | `IDataGridClipboardImportModel`. |
 | `FillModelPropertyName` | `IDataGridFillModel`. |
 | `FormulaModelPropertyName` | `IDataGridFormulaModel`. |

--- a/docfx/articles/source-generators/attribute-reference.md
+++ b/docfx/articles/source-generators/attribute-reference.md
@@ -78,6 +78,8 @@ Constructors:
 | `ColumnDefinitionsPropertyName` | `ColumnDefinitions` | Generated definitions property. |
 | `SchemaPropertyName` | `DataGridSchema` | Generated schema property. |
 | `FastPathOptionsPropertyName` | `FastPathOptions` | Generated fast-path options property. |
+| `GenerateNavigationModel` | `false` | Generate one `DataGridNavigationModel` controller property for this grid/ViewModel declaration. |
+| `NavigationModelPropertyName` | `NavigationModel` | Generated cell navigation model property name. |
 | `ProviderName` | inferred | Existing/generated schema provider to use. |
 | `Strict` | `true` | Strict schema projection. |
 | `Streaming` | `false` | Streaming projection metadata. |
@@ -140,6 +142,8 @@ Constructors:
 | `SearchModelPropertyName` | Search model. |
 | `SearchTextPropertyName` | Two-way search text. |
 | `SelectionModelPropertyName` | Selection model. |
+| `NavigationModelPropertyName` | `IDataGridNavigationModel` cell policy/controller. |
+| `RouteNavigationModelPropertyName` | `IDataGridRouteNavigationModel` application router. |
 | `ClipboardImportModelPropertyName` | `IDataGridClipboardImportModel`. |
 | `FillModelPropertyName` | `IDataGridFillModel`. |
 | `FormulaModelPropertyName` | `IDataGridFormulaModel`. |
@@ -176,7 +180,7 @@ Constructors:
 | `RoutedEventCommandPropertyName` | Command receiving `DataGridGeneratedViewEvent<TItem>`. |
 | `InteractionPropertyNames` | ReactiveUI interaction member names. |
 | `InteractionHandlerTypes` | Matching generated-view handler types. |
-| `NavigationInteractionPropertyName` | Typed current-cell/scroll interaction. |
+| `NavigationInteractionPropertyName` | ReactiveUI-only typed current-cell/scroll bridge; distinct from both navigation models. |
 
 ### Performance and presentation
 

--- a/docfx/articles/source-generators/generated-views.md
+++ b/docfx/articles/source-generators/generated-views.md
@@ -219,6 +219,19 @@ Interaction<
 
 The built-in handler supports current-cell query/set, bring-into-view by stable item, XY movement, and scroll capture/restore. See [selection, navigation, and state](selection-navigation-state.md#typed-current-cell-navigation).
 
+This legacy generated-view bridge is intentionally distinct from
+`NavigationModelPropertyName` and `RouteNavigationModelPropertyName`:
+
+- the interaction asynchronously reaches an activated view to perform precise
+  current-cell and scroll operations by typed item/key;
+- the cell navigation model synchronously decides policy for keyboard, command, and
+  programmatic operations and exposes a ViewModel-to-grid controller;
+- the route navigation model asynchronously leaves the grid workflow and invokes an
+  application router.
+
+They may be configured together. The generated names, subscriptions, and lifetimes
+do not overlap.
+
 ## Input maps and command feedback
 
 ```csharp

--- a/docfx/articles/source-generators/selection-navigation-state.md
+++ b/docfx/articles/source-generators/selection-navigation-state.md
@@ -159,11 +159,14 @@ to bind cell, input, and application-route models:
     GenerateNavigationModel = true,
     NavigationModelPropertyName = nameof(NavigationModel),
     GenerateNavigationInputModel = true,
-    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
+    NavigationInputModelPropertyName = nameof(NavigationInputModel),
+    GenerateRouteContextFactory = true,
+    RouteContextFactoryPropertyName = nameof(RouteContextFactory))]
 [GenerateDataGridView(
     typeof(Trade),
     NavigationModelPropertyName = nameof(NavigationModel),
     NavigationInputModelPropertyName = nameof(NavigationInputModel),
+    RouteContextFactoryPropertyName = nameof(RouteContextFactory),
     RouteNavigationModelPropertyName = nameof(RouteNavigationModel))]
 public sealed partial class TradesViewModel : ReactiveObject
 {
@@ -184,18 +187,22 @@ The generator emits:
 
 - `TradeSchema.CreateNavigationModel()`;
 - `TradeSchema.CreateNavigationInputModel()`;
+- `TradeSchema.CreateRouteContextFactory()` using the typed `[DataGridKey]` accessor;
 - `TradeSchema.CreateRouteNavigationModel(resolver, navigator)`;
 - the `NavigationModel` property when `GenerateNavigationModel = true`;
 - the `NavigationInputModel` property when
   `GenerateNavigationInputModel = true`;
+- the `RouteContextFactory` property when
+  `GenerateRouteContextFactory = true`;
 - reflection-free direct bindings to `DataGrid.NavigationModel`,
-  `DataGrid.NavigationInputModel`, and `DataGrid.RouteNavigationModel`;
+  `DataGrid.NavigationInputModel`, `DataGrid.RouteContextFactory`, and
+  `DataGrid.RouteNavigationModel`;
 - `PDGSG141` when a configured member does not implement the required interface.
 
 `GenerateDataGridViewModelsForNamespace` and
-`GenerateDataGridViewsForNamespace` expose the same input-model options for
-namespace policy. A manual view-model property is accepted when it implements
-`IDataGridNavigationInputModel`.
+`GenerateDataGridViewsForNamespace` expose the same input-model and route-context
+options for namespace policy. Manual ViewModel properties are accepted when they
+implement `IDataGridNavigationInputModel` or `IDataGridRouteContextFactory`.
 
 The route property stays application-owned because its resolver, native navigator,
 scope, and history lifetime belong in the composition root. The schema factory
@@ -211,9 +218,10 @@ above. It can coexist with the new model properties and should be retained when 
 ViewModel needs item-key current-cell lookup, bring-into-view, or scroll snapshots.
 
 The `GeneratedNavigationPage` sample exercises generated cell/input models, the
-route factory, and all three generated bindings as a real application consumer. Its
+route/context factories, and all four generated bindings as a real application consumer. Its
 ViewModel configures logical and physical keys, dynamic resolution, pointer target
-navigation, and wheel-driven route history.
+navigation, click/Enter route activation, stable-key context, and wheel-driven route
+history.
 
 ## Transactional selection events
 

--- a/docfx/articles/source-generators/selection-navigation-state.md
+++ b/docfx/articles/source-generators/selection-navigation-state.md
@@ -147,6 +147,52 @@ Results return a status enum, typed item, row index, display-column index, stabl
 
 Override `CreateGeneratedNavigationInteractionHandler` for application navigation policy or DI-backed construction.
 
+## Navigation model generation
+
+Opt into a per-ViewModel cell navigation model and ask the generated view to bind
+both cell and application-route models:
+
+```csharp
+[GenerateDataGridViewModel(
+    typeof(Trade),
+    ProviderName = "TradeSchema",
+    GenerateNavigationModel = true,
+    NavigationModelPropertyName = nameof(NavigationModel))]
+[GenerateDataGridView(
+    typeof(Trade),
+    NavigationModelPropertyName = nameof(NavigationModel),
+    RouteNavigationModelPropertyName = nameof(RouteNavigationModel))]
+public sealed partial class TradesViewModel : ReactiveObject
+{
+    public IDataGridRouteNavigationModel RouteNavigationModel { get; }
+}
+```
+
+The generator emits:
+
+- `TradeSchema.CreateNavigationModel()`;
+- `TradeSchema.CreateRouteNavigationModel(resolver, navigator)`;
+- the `NavigationModel` property when `GenerateNavigationModel = true`;
+- reflection-free compiled bindings to `DataGrid.NavigationModel` and
+  `DataGrid.RouteNavigationModel`;
+- `PDGSG141` when a configured member does not implement the required interface.
+
+The route property stays application-owned because its resolver, native navigator,
+scope, and history lifetime belong in the composition root. The schema factory
+constructs the framework-neutral orchestration model after those dependencies are
+selected.
+
+Generation is opt-in so existing ViewModels and snapshots do not gain an unexpected
+controller or change behavior. Use unique property names when one ViewModel declares
+multiple generated grids.
+
+`NavigationInteractionPropertyName` remains the activated-view bridge documented
+above. It can coexist with the new model properties and should be retained when the
+ViewModel needs item-key current-cell lookup, bring-into-view, or scroll snapshots.
+
+The `GeneratedNavigationPage` sample exercises both generated models and both
+compiled bindings as a real application consumer.
+
 ## Transactional selection events
 
 Generated view event bridges can forward the pre-commit `SelectionChanging` event:
@@ -176,3 +222,4 @@ Generated scroll sampling excludes the new-item placeholder before invoking the 
 - `GeneratedGroupedSharedSelectionPage`: one identity model shared by a grouped DataGrid and ListBox.
 - `PagingSelectionPage`: page/currency defaults and off-page key preservation.
 - `GeneratedVirtualizationInputMetricsPage`: current-cell, XY navigation, and scroll interactions.
+- `GeneratedNavigationPage`: generated cell model, route factory, compiled view bindings, and ViewModel commands.

--- a/docfx/articles/source-generators/selection-navigation-state.md
+++ b/docfx/articles/source-generators/selection-navigation-state.md
@@ -149,33 +149,53 @@ Override `CreateGeneratedNavigationInteractionHandler` for application navigatio
 
 ## Navigation model generation
 
-Opt into a per-ViewModel cell navigation model and ask the generated view to bind
-both cell and application-route models:
+Opt into per-ViewModel cell and input navigation models and ask the generated view
+to bind cell, input, and application-route models:
 
 ```csharp
 [GenerateDataGridViewModel(
     typeof(Trade),
     ProviderName = "TradeSchema",
     GenerateNavigationModel = true,
-    NavigationModelPropertyName = nameof(NavigationModel))]
+    NavigationModelPropertyName = nameof(NavigationModel),
+    GenerateNavigationInputModel = true,
+    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
 [GenerateDataGridView(
     typeof(Trade),
     NavigationModelPropertyName = nameof(NavigationModel),
+    NavigationInputModelPropertyName = nameof(NavigationInputModel),
     RouteNavigationModelPropertyName = nameof(RouteNavigationModel))]
 public sealed partial class TradesViewModel : ReactiveObject
 {
     public IDataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public TradesViewModel()
+    {
+        NavigationInputModel.SetBindings(
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.J,
+                DataGridNavigationInputResult.Navigate(
+                    DataGridNavigationCommand.Down)));
+    }
 }
 ```
 
 The generator emits:
 
 - `TradeSchema.CreateNavigationModel()`;
+- `TradeSchema.CreateNavigationInputModel()`;
 - `TradeSchema.CreateRouteNavigationModel(resolver, navigator)`;
 - the `NavigationModel` property when `GenerateNavigationModel = true`;
-- reflection-free compiled bindings to `DataGrid.NavigationModel` and
-  `DataGrid.RouteNavigationModel`;
+- the `NavigationInputModel` property when
+  `GenerateNavigationInputModel = true`;
+- reflection-free direct bindings to `DataGrid.NavigationModel`,
+  `DataGrid.NavigationInputModel`, and `DataGrid.RouteNavigationModel`;
 - `PDGSG141` when a configured member does not implement the required interface.
+
+`GenerateDataGridViewModelsForNamespace` and
+`GenerateDataGridViewsForNamespace` expose the same input-model options for
+namespace policy. A manual view-model property is accepted when it implements
+`IDataGridNavigationInputModel`.
 
 The route property stays application-owned because its resolver, native navigator,
 scope, and history lifetime belong in the composition root. The schema factory
@@ -190,8 +210,10 @@ multiple generated grids.
 above. It can coexist with the new model properties and should be retained when the
 ViewModel needs item-key current-cell lookup, bring-into-view, or scroll snapshots.
 
-The `GeneratedNavigationPage` sample exercises both generated models and both
-compiled bindings as a real application consumer.
+The `GeneratedNavigationPage` sample exercises generated cell/input models, the
+route factory, and all three generated bindings as a real application consumer. Its
+ViewModel configures logical and physical keys, dynamic resolution, pointer target
+navigation, and wheel-driven route history.
 
 ## Transactional selection events
 

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -205,6 +205,8 @@
     href: selection-and-navigation.md
   - name: Navigation Model
     href: navigation-model.md
+  - name: Navigation Input Model
+    href: navigation-input-model.md
   - name: Route Navigation and MVVM Frameworks
     href: route-navigation.md
   - name: Navigation Model Design

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -203,6 +203,12 @@
   items:
   - name: Selection and Navigation
     href: selection-and-navigation.md
+  - name: Navigation Model
+    href: navigation-model.md
+  - name: Route Navigation and MVVM Frameworks
+    href: route-navigation.md
+  - name: Navigation Model Design
+    href: navigation-model-design.md
   - name: Transactional Selection Veto
     href: selection-changing.md
   - name: Selection Model (End-to-End)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Input/DataGridInputNavigationTests.cs
@@ -1266,7 +1266,7 @@ public class DataGridInputNavigationTests
     {
         var method = typeof(DataGrid).GetMethod("ProcessDataGridKey", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
         var args = CreateKeyArgs(grid, key, modifiers, InputElement.KeyDownEvent);
-        return method != null && (bool)method.Invoke(grid, new object[] { args })!;
+        return method != null && (bool)method.Invoke(grid, new object[] { args, false })!;
     }
 
     private static bool InvokeKeyHandler(DataGrid grid, string methodName, Key key, KeyModifiers modifiers)

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
@@ -267,6 +267,51 @@ public class DataGridNavigationInputModelTests
     }
 
     [AvaloniaFact]
+    public void Pointer_Route_Uses_Clicked_Cell_Context_Instead_Of_Previous_Current_Cell()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            DataGridRouteNavigationRequest? routed = null;
+            var resolver = new DelegateDataGridRouteResolver(context =>
+                context.Item is Row row ? new DataGridRoute($"rows/{row.Id}") : null);
+            var navigator = new DelegateDataGridRouteNavigator(
+                DataGridRouteNavigationCapabilities.Navigate,
+                (request, _) =>
+                {
+                    routed = request;
+                    return ValueTask.FromResult(DataGridRouteNavigationResult.Success(request.Route));
+                });
+            grid.RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+            grid.RouteContextFactory = new DataGridRouteContextFactory(item => ((Row)item).Id);
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.Pointer(
+                    DataGridNavigationInputKind.PointerReleased,
+                    DataGridNavigationPointerButton.Primary,
+                    DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate),
+                    targetKind: DataGridNavigationInputTargetKind.Cell));
+            SetCurrentCell(grid, 0, 0);
+            DataGridCell target = grid.GetVisualDescendants()
+                .OfType<DataGridCell>()
+                .Single(cell => cell.RowIndex == 2 && cell.OwningColumn?.DisplayIndex == 1);
+
+            PointerReleasedEventArgs args = CreatePointerReleasedArgs(target, window);
+            target.RaiseEvent(args);
+
+            Assert.True(args.Handled);
+            Assert.NotNull(routed);
+            Assert.Equal("rows/2", routed.Value.Route.Path);
+            Assert.Equal(2, routed.Value.Context.ItemKey);
+            Assert.Equal(new DataGridNavigationPosition(2, 1), routed.Value.Context.Position);
+            Assert.Equal(DataGridRouteNavigationOrigin.Pointer, routed.Value.Context.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Wheel_Input_Can_Trigger_Application_History_Without_View_Code()
     {
         Window window = CreateWindow(out DataGrid grid);
@@ -388,6 +433,23 @@ public class DataGridNavigationInputModelTests
             properties,
             KeyModifiers.None,
             clickCount: 1);
+    }
+
+    private static PointerReleasedEventArgs CreatePointerReleasedArgs(Control source, Visual root)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var properties = new PointerPointProperties(
+            RawInputModifiers.None,
+            PointerUpdateKind.LeftButtonReleased);
+        return new PointerReleasedEventArgs(
+            source,
+            pointer,
+            root,
+            new Point(source.Bounds.Width / 2, source.Bounds.Height / 2),
+            0,
+            properties,
+            KeyModifiers.None,
+            MouseButton.Left);
     }
 
     private sealed record Row(int Id, string Name);

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
@@ -312,6 +312,45 @@ public class DataGridNavigationInputModelTests
     }
 
     [AvaloniaFact]
+    public void Key_Route_Uses_Current_Cell_Context()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            DataGridRouteNavigationRequest? routed = null;
+            var resolver = new DelegateDataGridRouteResolver(context =>
+                context.Item is Row row ? new DataGridRoute($"rows/{row.Id}") : null);
+            var navigator = new DelegateDataGridRouteNavigator(
+                DataGridRouteNavigationCapabilities.Navigate,
+                (request, _) =>
+                {
+                    routed = request;
+                    return ValueTask.FromResult(DataGridRouteNavigationResult.Success(request.Route));
+                });
+            grid.RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+            grid.RouteContextFactory = new DataGridRouteContextFactory(item => ((Row)item).Id);
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.KeyDown(
+                    DataGridNavigationInputKey.Enter,
+                    DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate)));
+            SetCurrentCell(grid, 1, 0);
+
+            KeyEventArgs args = RaiseKeyDown(grid, Key.Enter);
+
+            Assert.True(args.Handled);
+            Assert.NotNull(routed);
+            Assert.Equal("rows/1", routed.Value.Route.Path);
+            Assert.Equal(1, routed.Value.Context.ItemKey);
+            Assert.Equal(new DataGridNavigationPosition(1, 0), routed.Value.Context.Position);
+            Assert.Equal(DataGridRouteNavigationOrigin.Keyboard, routed.Value.Context.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Wheel_Input_Can_Trigger_Application_History_Without_View_Code()
     {
         Window window = CreateWindow(out DataGrid grid);

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Input.Raw;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
@@ -1,0 +1,392 @@
+using System.Collections;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Navigation;
+
+public class DataGridNavigationInputModelTests
+{
+    [Fact]
+    public void Binding_Matches_Required_Modifiers_And_Allows_Additional_Modifiers()
+    {
+        var model = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.J,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down),
+                DataGridNavigationInputModifiers.Control));
+
+        DataGridNavigationInputResult result = model.Resolve(CreateKeyRequest(
+            DataGridNavigationInputKey.J,
+            DataGridNavigationInputModifiers.Control | DataGridNavigationInputModifiers.Shift));
+
+        Assert.Equal(DataGridNavigationInputDecision.Navigate, result.Decision);
+        Assert.Equal(DataGridNavigationCommand.Down, result.Command);
+    }
+
+    [Fact]
+    public void Exact_Modifiers_Reject_Additional_Modifiers()
+    {
+        var model = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.J,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down),
+                DataGridNavigationInputModifiers.Control,
+                exactModifiers: true));
+
+        DataGridNavigationInputResult result = model.Resolve(CreateKeyRequest(
+            DataGridNavigationInputKey.J,
+            DataGridNavigationInputModifiers.Control | DataGridNavigationInputModifiers.Shift));
+
+        Assert.Equal(DataGridNavigationInputDecision.Ignore, result.Decision);
+    }
+
+    [Fact]
+    public void Physical_Key_Binding_Is_Independent_Of_Logical_Keyboard_Layout()
+    {
+        var model = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.PhysicalKeyDown(
+                DataGridNavigationInputKey.W,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Up)));
+
+        DataGridNavigationInputResult result = model.Resolve(CreateKeyRequest(
+            DataGridNavigationInputKey.Z,
+            physicalKey: DataGridNavigationInputKey.W));
+
+        Assert.Equal(DataGridNavigationCommand.Up, result.Command);
+    }
+
+    [Fact]
+    public void Pointer_Binding_Matches_Target_And_Click_Count()
+    {
+        var model = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerPressed,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateToTarget(),
+                clickCount: 2,
+                targetKind: DataGridNavigationInputTargetKind.Cell));
+        DataGridNavigationInputRequest request = new(
+            DataGridNavigationInputKind.PointerPressed,
+            DataGridNavigationInputKey.None,
+            DataGridNavigationInputKey.None,
+            DataGridNavigationKeyDeviceKind.Unknown,
+            DataGridNavigationInputModifiers.None,
+            DataGridNavigationPointerDeviceKind.Mouse,
+            DataGridNavigationPointerButton.Primary,
+            DataGridNavigationWheelDirection.None,
+            clickCount: 2,
+            x: 10,
+            y: 20,
+            wheelDeltaX: 0,
+            wheelDeltaY: 0,
+            DataGridNavigationInputTargetKind.Cell,
+            new DataGridNavigationPosition(3, 1),
+            DataGridNavigationPosition.Unset,
+            isEditing: false);
+
+        Assert.Equal(DataGridNavigationInputDecision.NavigateToTarget, model.Resolve(request).Decision);
+    }
+
+    [Fact]
+    public void Resolving_Event_Can_Replace_Table_Result_From_ViewModel()
+    {
+        var model = new DataGridNavigationInputModel();
+        model.InputResolving += (_, args) =>
+            args.Result = DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.GridEnd);
+
+        DataGridNavigationInputResult result = model.Resolve(CreateKeyRequest(DataGridNavigationInputKey.G));
+
+        Assert.Equal(DataGridNavigationCommand.GridEnd, result.Command);
+    }
+
+    [AvaloniaFact]
+    public void Custom_Key_Is_Normalized_And_Executed_Through_Navigation_Model()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            var navigation = new DataGridNavigationModel();
+            DataGridNavigationRequest? observed = null;
+            navigation.NavigationChanging += (_, args) => observed = args.Request;
+            grid.NavigationModel = navigation;
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.KeyDown(
+                    DataGridNavigationInputKey.J,
+                    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down)));
+            SetCurrentCell(grid, 0, 0);
+
+            KeyEventArgs args = RaiseKeyDown(grid, Key.J);
+
+            Assert.True(args.Handled);
+            Assert.Equal(1, grid.CurrentCell.RowIndex);
+            Assert.Equal(DataGridNavigationCommand.Down, observed?.Command);
+            Assert.Equal(DataGridNavigationOrigin.Keyboard, observed?.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Ignored_Input_Falls_Through_To_Legacy_Keyboard_Navigation()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            var input = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.KeyDown(
+                    DataGridNavigationInputKey.J,
+                    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down)));
+            int resolveCount = 0;
+            int navigationCount = 0;
+            input.InputResolving += (_, _) => resolveCount++;
+            grid.NavigationInputModel = input;
+            ((DataGridNavigationModel)grid.NavigationModel).NavigationChanging += (_, _) => navigationCount++;
+            SetCurrentCell(grid, 0, 0);
+
+            KeyEventArgs args = RaiseKeyDown(grid, Key.Down);
+
+            Assert.True(args.Handled);
+            Assert.Equal(1, resolveCount);
+            Assert.Equal(1, navigationCount);
+            Assert.Equal(1, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Consumed_Failed_Navigation_Prevents_Legacy_Fallback()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.KeyDown(
+                    DataGridNavigationInputKey.J,
+                    DataGridNavigationInputResult.Navigate(
+                        DataGridNavigationCommand.Up,
+                        consumeWhenNavigationFails: true)));
+            SetCurrentCell(grid, 0, 0);
+
+            KeyEventArgs args = RaiseKeyDown(grid, Key.J);
+
+            Assert.True(args.Handled);
+            Assert.Equal(0, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ViewModel_Sees_Tunneled_Key_Before_Descendant_Consumes_It()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            var input = new DataGridNavigationInputModel();
+            int resolveCount = 0;
+            input.InputResolving += (_, _) => resolveCount++;
+            grid.NavigationInputModel = input;
+            SetCurrentCell(grid, 0, 0);
+            DataGridCell source = grid.GetVisualDescendants()
+                .OfType<DataGridCell>()
+                .Single(cell => cell.RowIndex == 0 && cell.OwningColumn?.DisplayIndex == 0);
+            source.KeyDown += (_, args) => args.Handled = true;
+            var args = new KeyEventArgs
+            {
+                RoutedEvent = InputElement.KeyDownEvent,
+                Route = InputElement.KeyDownEvent.RoutingStrategies,
+                Key = Key.J,
+                Source = source,
+                KeyDeviceType = KeyDeviceType.Keyboard
+            };
+
+            source.RaiseEvent(args);
+
+            Assert.True(args.Handled);
+            Assert.Equal(1, resolveCount);
+            Assert.Equal(0, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Pointer_Target_Can_Establish_First_Current_Cell_Through_Model()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            var navigation = new DataGridNavigationModel();
+            DataGridNavigationRequest? observed = null;
+            navigation.NavigationChanging += (_, args) => observed = args.Request;
+            grid.NavigationModel = navigation;
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.Pointer(
+                    DataGridNavigationInputKind.PointerPressed,
+                    DataGridNavigationPointerButton.Primary,
+                    DataGridNavigationInputResult.NavigateToTarget(consumeWhenNavigationFails: true),
+                    targetKind: DataGridNavigationInputTargetKind.Cell));
+            grid.CurrentCell = default;
+            DataGridCell target = grid.GetVisualDescendants()
+                .OfType<DataGridCell>()
+                .Single(cell => cell.RowIndex == 1 && cell.OwningColumn?.DisplayIndex == 1);
+            Assert.False(grid.CurrentCell.IsValid);
+
+            PointerPressedEventArgs args = CreatePointerPressedArgs(target, window);
+            target.RaiseEvent(args);
+            grid.UpdateLayout();
+
+            Assert.True(args.Handled);
+            Assert.Equal(1, grid.CurrentCell.RowIndex);
+            Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+            Assert.Equal(DataGridNavigationOrigin.Pointer, observed?.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Wheel_Input_Can_Trigger_Application_History_Without_View_Code()
+    {
+        Window window = CreateWindow(out DataGrid grid);
+        try
+        {
+            DataGridRouteNavigationRequest? routed = null;
+            var resolver = new DelegateDataGridRouteResolver(static _ => null);
+            var navigator = new DelegateDataGridRouteNavigator(
+                DataGridRouteNavigationCapabilities.Back,
+                (request, _) =>
+                {
+                    routed = request;
+                    return ValueTask.FromResult(DataGridRouteNavigationResult.Success());
+                });
+            grid.RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+            DataGridNavigationInputRequest? observedInput = null;
+            var input = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.Wheel(
+                    DataGridNavigationWheelDirection.Down,
+                    DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Back)));
+            input.InputResolving += (_, args) => observedInput = args.Request;
+            grid.NavigationInputModel = input;
+            Point point = grid.TranslatePoint(
+                new Point(grid.Bounds.Width / 2, grid.Bounds.Height / 2),
+                window)!.Value;
+
+            window.MouseWheel(point, new Vector(0, -3));
+
+            Assert.Equal(DataGridNavigationWheelDirection.Down, observedInput?.WheelDirection);
+            Assert.Equal(-3, observedInput?.WheelDeltaY);
+            Assert.Equal(DataGridRouteNavigationKind.Back, routed?.Kind);
+            Assert.Equal(DataGridRouteNavigationOrigin.Pointer, routed?.Context.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static DataGridNavigationInputRequest CreateKeyRequest(
+        DataGridNavigationInputKey key,
+        DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+        DataGridNavigationInputKey? physicalKey = null) =>
+        new(
+            DataGridNavigationInputKind.KeyDown,
+            key,
+            physicalKey ?? key,
+            DataGridNavigationKeyDeviceKind.Keyboard,
+            modifiers,
+            DataGridNavigationPointerDeviceKind.Unknown,
+            DataGridNavigationPointerButton.None,
+            DataGridNavigationWheelDirection.None,
+            clickCount: 0,
+            x: double.NaN,
+            y: double.NaN,
+            wheelDeltaX: 0,
+            wheelDeltaY: 0,
+            DataGridNavigationInputTargetKind.Grid,
+            DataGridNavigationPosition.Unset,
+            DataGridNavigationPosition.Unset,
+            isEditing: false);
+
+    private static Window CreateWindow(out DataGrid grid, int rowCount = 3)
+    {
+        var window = new Window { Width = 640, Height = 480 };
+        window.SetThemeStyles();
+        var items = Enumerable.Range(0, rowCount).Select(index => new Row(index, $"Row {index}")).ToArray();
+        grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false,
+            CanUserAddRows = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            SelectionUnit = DataGridSelectionUnit.Cell
+        };
+        grid.Columns.Add(new DataGridTextColumn { Header = "Id", Binding = new Binding(nameof(Row.Id)) });
+        grid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = new Binding(nameof(Row.Name)) });
+        window.Content = grid;
+        window.Show();
+        window.UpdateLayout();
+        return window;
+    }
+
+    private static void SetCurrentCell(DataGrid grid, int rowIndex, int columnDisplayIndex)
+    {
+        DataGridColumn column = grid.Columns.Single(candidate => candidate.DisplayIndex == columnDisplayIndex);
+        object item = ((IList)grid.ItemsSource!)[rowIndex]!;
+        grid.CurrentCell = new DataGridCellInfo(item, column, rowIndex, column.Index, isValid: true);
+        grid.UpdateLayout();
+    }
+
+    private static KeyEventArgs RaiseKeyDown(DataGrid grid, Key key)
+    {
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = key,
+            Source = grid,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+        grid.RaiseEvent(args);
+        grid.UpdateLayout();
+        return args;
+    }
+
+    private static PointerPressedEventArgs CreatePointerPressedArgs(Control source, Visual root)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var properties = new PointerPointProperties(
+            RawInputModifiers.LeftMouseButton,
+            PointerUpdateKind.LeftButtonPressed);
+        return new PointerPressedEventArgs(
+            source,
+            pointer,
+            root,
+            new Point(source.Bounds.Width / 2, source.Bounds.Height / 2),
+            0,
+            properties,
+            KeyModifiers.None,
+            clickCount: 1);
+    }
+
+    private sealed record Row(int Id, string Name);
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
@@ -176,6 +176,14 @@ public class DataGridNavigationModelTests
     }
 
     [Fact]
+    public void RequestNavigate_Returns_False_Without_Bound_Grid()
+    {
+        var model = new DataGridNavigationModel();
+
+        Assert.False(model.RequestNavigate(DataGridNavigationCommand.Down));
+    }
+
+    [Fact]
     public void Settings_Raise_PropertyChanged_Only_For_Real_Changes()
     {
         var model = new DataGridNavigationModel();
@@ -234,6 +242,35 @@ public class DataGridNavigationModelTests
 
         Assert.True(handled);
         Assert.Equal(1, grid.CurrentCell.RowIndex);
+    }
+
+    [AvaloniaFact]
+    public void Model_Controller_Request_Moves_Bound_Grid()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        var model = new DataGridNavigationModel();
+        grid.NavigationModel = model;
+
+        bool handled = model.RequestNavigate(DataGridNavigationCommand.Down);
+
+        Assert.True(handled);
+        Assert.Equal(1, grid.CurrentCell.RowIndex);
+    }
+
+    [AvaloniaFact]
+    public void Replacing_Model_Detaches_Controller_Request()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        var oldModel = new DataGridNavigationModel();
+        grid.NavigationModel = oldModel;
+        grid.NavigationModel = new DataGridNavigationModel();
+
+        bool handled = oldModel.RequestNavigate(DataGridNavigationCommand.Down);
+
+        Assert.False(handled);
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
     }
 
     [AvaloniaFact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Navigation;
+
+public class DataGridNavigationModelTests
+{
+    [Fact]
+    public void Defaults_Preserve_Contained_Legacy_Policy()
+    {
+        var model = new DataGridNavigationModel();
+
+        Assert.Equal(DataGridNavigationBoundaryMode.Contained, model.HorizontalBoundaryMode);
+        Assert.Equal(DataGridNavigationBoundaryMode.Contained, model.VerticalBoundaryMode);
+        Assert.Equal(DataGridNavigationBoundaryMode.Exit, model.TabBoundaryMode);
+        Assert.Equal(DataGridTabNavigationMode.EditingOnly, model.TabNavigationMode);
+        Assert.Equal(DataGridHorizontalNavigationMode.Physical, model.HorizontalNavigationMode);
+    }
+
+    [Fact]
+    public void Resolve_Uses_Default_When_Grid_Has_Proposed_Target()
+    {
+        var model = new DataGridNavigationModel();
+        DataGridNavigationRequest request = CreateRequest(
+            DataGridNavigationCommand.Right,
+            proposed: new DataGridNavigationPosition(1, 2));
+
+        DataGridNavigationResult result = model.Resolve(request);
+
+        Assert.Equal(DataGridNavigationDecision.Default, result.Decision);
+    }
+
+    [Theory]
+    [InlineData(DataGridNavigationCommand.Left)]
+    [InlineData(DataGridNavigationCommand.Right)]
+    public void Resolve_Contains_Horizontal_Boundary(DataGridNavigationCommand command)
+    {
+        var model = new DataGridNavigationModel();
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(command));
+
+        Assert.Equal(DataGridNavigationDecision.Stay, result.Decision);
+    }
+
+    [Fact]
+    public void Resolve_Wraps_Horizontal_Boundary()
+    {
+        var model = new DataGridNavigationModel
+        {
+            HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+        };
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(DataGridNavigationCommand.Right));
+
+        Assert.Equal(DataGridNavigationDecision.Move, result.Decision);
+        Assert.Equal(new DataGridNavigationPosition(1, 0), result.Target);
+    }
+
+    [Fact]
+    public void Resolve_Wraps_Vertical_Boundary()
+    {
+        var model = new DataGridNavigationModel
+        {
+            VerticalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+        };
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(DataGridNavigationCommand.Down));
+
+        Assert.Equal(DataGridNavigationDecision.Move, result.Decision);
+        Assert.Equal(new DataGridNavigationPosition(0, 1), result.Target);
+    }
+
+    [Fact]
+    public void Resolve_Tab_EditingOnly_Uses_Default_Outside_Edit_Mode()
+    {
+        var model = new DataGridNavigationModel();
+        DataGridNavigationRequest request = CreateRequest(
+            DataGridNavigationCommand.Next,
+            proposed: new DataGridNavigationPosition(1, 2),
+            isEditing: false);
+
+        Assert.Equal(DataGridNavigationDecision.Default, model.Resolve(request).Decision);
+    }
+
+    [Fact]
+    public void Resolve_Tab_Always_Uses_Proposed_Target_Outside_Edit_Mode()
+    {
+        var model = new DataGridNavigationModel
+        {
+            TabNavigationMode = DataGridTabNavigationMode.Always
+        };
+        var proposed = new DataGridNavigationPosition(1, 2);
+        DataGridNavigationRequest request = CreateRequest(
+            DataGridNavigationCommand.Next,
+            proposed,
+            isEditing: false);
+
+        DataGridNavigationResult result = model.Resolve(request);
+
+        Assert.Equal(DataGridNavigationDecision.Move, result.Decision);
+        Assert.Equal(proposed, result.Target);
+    }
+
+    [Fact]
+    public void Resolve_Tab_Exits_At_Boundary()
+    {
+        var model = new DataGridNavigationModel
+        {
+            TabNavigationMode = DataGridTabNavigationMode.Always
+        };
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(DataGridNavigationCommand.Next));
+
+        Assert.Equal(DataGridNavigationDecision.LeaveGrid, result.Decision);
+    }
+
+    [Fact]
+    public void Resolve_Logical_Rtl_Redirects_Horizontal_Command()
+    {
+        var model = new DataGridNavigationModel
+        {
+            HorizontalNavigationMode = DataGridHorizontalNavigationMode.Logical
+        };
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(
+            DataGridNavigationCommand.Left,
+            flowDirection: FlowDirection.RightToLeft));
+
+        Assert.Equal(DataGridNavigationDecision.Redirect, result.Decision);
+        Assert.Equal(DataGridNavigationCommand.Right, result.RedirectedCommand);
+    }
+
+    [Fact]
+    public void NavigationChanging_Can_Redirect_Result()
+    {
+        var model = new DataGridNavigationModel();
+        model.NavigationChanging += (_, e) =>
+            e.Result = DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(2, 2));
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(DataGridNavigationCommand.Down));
+
+        Assert.Equal(new DataGridNavigationPosition(2, 2), result.Target);
+    }
+
+    [Fact]
+    public void NavigationChanging_Can_Cancel_Result()
+    {
+        var model = new DataGridNavigationModel();
+        model.NavigationChanging += (_, e) => e.Cancel = true;
+
+        DataGridNavigationResult result = model.Resolve(CreateRequest(DataGridNavigationCommand.Down));
+
+        Assert.Equal(DataGridNavigationDecision.Stay, result.Decision);
+        Assert.Equal(DataGridNavigationFailureReason.Canceled, result.FailureReason);
+    }
+
+    [Fact]
+    public void Query_Is_SideEffect_Free()
+    {
+        var model = new DataGridNavigationModel();
+        int previewCount = 0;
+        model.NavigationChanging += (_, _) => previewCount++;
+
+        DataGridNavigationResult result = model.Query(CreateRequest(DataGridNavigationCommand.Down));
+
+        Assert.Equal(DataGridNavigationDecision.Stay, result.Decision);
+        Assert.Equal(0, previewCount);
+    }
+
+    [Fact]
+    public void Settings_Raise_PropertyChanged_Only_For_Real_Changes()
+    {
+        var model = new DataGridNavigationModel();
+        var changes = new List<string?>();
+        model.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        model.HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
+        model.HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap;
+
+        Assert.Equal(new[] { nameof(model.HorizontalBoundaryMode) }, changes);
+    }
+
+    [Fact]
+    public void NotifyCompleted_Raises_Compact_Completion_Event()
+    {
+        var model = new DataGridNavigationModel();
+        DataGridNavigationCompleted? observed = null;
+        model.NavigationChanged += (_, e) => observed = e.Completed;
+        DataGridNavigationRequest request = CreateRequest(DataGridNavigationCommand.Down);
+        var completed = new DataGridNavigationCompleted(
+            request,
+            DataGridNavigationResult.UseDefault(),
+            request.CurrentPosition,
+            new DataGridNavigationPosition(2, 1),
+            handled: true,
+            DataGridNavigationFailureReason.None);
+
+        model.NotifyCompleted(completed);
+
+        Assert.True(observed.HasValue);
+        Assert.True(observed.Value.Moved);
+        Assert.True(observed.Value.Handled);
+    }
+
+    [AvaloniaFact]
+    public void Grid_Creates_Default_Model_And_Replaces_Null()
+    {
+        var grid = new DataGrid();
+
+        Assert.IsType<DataGridNavigationModel>(grid.NavigationModel);
+
+        IDataGridNavigationModel first = grid.NavigationModel;
+        grid.NavigationModel = null!;
+
+        Assert.NotNull(grid.NavigationModel);
+        Assert.NotSame(first, grid.NavigationModel);
+    }
+
+    [AvaloniaFact]
+    public void Programmatic_Navigate_Moves_Current_Cell()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+
+        bool handled = grid.Navigate(DataGridNavigationCommand.Down);
+
+        Assert.True(handled);
+        Assert.Equal(1, grid.CurrentCell.RowIndex);
+    }
+
+    [AvaloniaFact]
+    public void Programmatic_Navigate_Uses_Explicit_Custom_Target()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        grid.NavigationModel = new RedirectingNavigationModel(
+            DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(2, 2)));
+
+        bool handled = grid.Navigate(DataGridNavigationCommand.Down);
+
+        Assert.True(handled);
+        Assert.Equal(2, grid.CurrentCell.RowIndex);
+        Assert.Equal(2, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Programmatic_Navigate_Rejects_Hidden_Target()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        grid.Columns[1].IsVisible = false;
+        var model = new RedirectingNavigationModel(
+            DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(1, 1)));
+        grid.NavigationModel = model;
+        DataGridNavigationCompleted? completed = null;
+        model.NavigationChanged += (_, e) => completed = e.Completed;
+
+        bool handled = grid.Navigate(DataGridNavigationCommand.Down);
+
+        Assert.False(handled);
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
+        Assert.Equal(DataGridNavigationFailureReason.InvalidTarget, completed?.FailureReason);
+    }
+
+    [AvaloniaFact]
+    public void Programmatic_Navigate_Can_Be_Canceled()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        var model = new DataGridNavigationModel();
+        model.NavigationChanging += (_, e) => e.Cancel = true;
+        grid.NavigationModel = model;
+        DataGridNavigationCompleted? completed = null;
+        model.NavigationChanged += (_, e) => completed = e.Completed;
+
+        bool handled = grid.Navigate(DataGridNavigationCommand.Down);
+
+        Assert.True(handled);
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
+        Assert.Equal(DataGridNavigationFailureReason.Canceled, completed?.FailureReason);
+    }
+
+    [AvaloniaFact]
+    public void Programmatic_Redirect_Uses_Default_Engine()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        grid.NavigationModel = new RedirectingNavigationModel(
+            DataGridNavigationResult.RedirectTo(DataGridNavigationCommand.Right));
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
+        Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Horizontal_Wrap_Uses_Visible_Edge_Columns()
+    {
+        DataGrid grid = CreateGrid();
+        grid.Columns[1].IsVisible = false;
+        grid.Columns[2].DisplayIndex = 0;
+        grid.Columns[0].DisplayIndex = 2;
+        var model = new DataGridNavigationModel
+        {
+            HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+        };
+        grid.NavigationModel = model;
+        SetCurrentCell(grid, rowIndex: 1, columnDisplayIndex: 2);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+        Assert.Equal(0, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Vertical_Wrap_Preserves_Column()
+    {
+        DataGrid grid = CreateGrid();
+        grid.NavigationModel = new DataGridNavigationModel
+        {
+            VerticalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+        };
+        SetCurrentCell(grid, rowIndex: 2, columnDisplayIndex: 1);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
+        Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Tab_Always_Navigates_When_Not_Editing()
+    {
+        DataGrid grid = CreateGrid();
+        grid.NavigationModel = new DataGridNavigationModel
+        {
+            TabNavigationMode = DataGridTabNavigationMode.Always
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Next));
+        Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Shift_Navigation_Extends_Row_Selection()
+    {
+        DataGrid grid = CreateGrid(selectionMode: DataGridSelectionMode.Extended);
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Down, KeyModifiers.Shift));
+        Assert.Equal(2, grid.SelectedItems.Count);
+    }
+
+    [AvaloniaFact]
+    public void Logical_Rtl_Horizontal_Navigation_Uses_Layout_Direction()
+    {
+        DataGrid grid = CreateGrid();
+        grid.FlowDirection = FlowDirection.RightToLeft;
+        grid.NavigationModel = new DataGridNavigationModel
+        {
+            HorizontalNavigationMode = DataGridHorizontalNavigationMode.Logical
+        };
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 1);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Left));
+        Assert.Equal(2, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
+    public void Hidden_And_Frozen_Columns_Use_Existing_Default_Mechanics()
+    {
+        DataGrid grid = CreateGrid();
+        grid.FrozenColumnCount = 1;
+        grid.Columns[1].IsVisible = false;
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+        Assert.Same(grid.Columns[2], grid.CurrentCell.Column);
+    }
+
+    [AvaloniaFact]
+    public void Keyboard_Request_Flows_Through_Model()
+    {
+        DataGrid grid = CreateGrid();
+        SetCurrentCell(grid, rowIndex: 0, columnDisplayIndex: 0);
+        var model = new RedirectingNavigationModel(DataGridNavigationResult.Stay());
+        grid.NavigationModel = model;
+
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Route = InputElement.KeyDownEvent.RoutingStrategies,
+            Key = Key.Down,
+            Source = grid,
+            KeyDeviceType = KeyDeviceType.Keyboard
+        };
+        grid.RaiseEvent(args);
+
+        Assert.True(args.Handled);
+        Assert.Equal(DataGridNavigationCommand.Down, model.LastRequest?.Command);
+        Assert.Equal(DataGridNavigationOrigin.Keyboard, model.LastRequest?.Origin);
+        Assert.Equal(0, grid.CurrentCell.RowIndex);
+    }
+
+    private static DataGridNavigationRequest CreateRequest(
+        DataGridNavigationCommand command,
+        DataGridNavigationPosition? proposed = null,
+        bool isEditing = true,
+        FlowDirection flowDirection = FlowDirection.LeftToRight)
+    {
+        return new DataGridNavigationRequest(
+            command,
+            DataGridNavigationOrigin.Keyboard,
+            new DataGridNavigationPosition(1, 1),
+            proposed,
+            KeyModifiers.None,
+            isEditing,
+            DataGridSelectionMode.Extended,
+            DataGridSelectionUnit.Cell,
+            flowDirection,
+            firstRowIndex: 0,
+            lastRowIndex: 2,
+            firstColumnDisplayIndex: 0,
+            lastColumnDisplayIndex: 2);
+    }
+
+    private static DataGrid CreateGrid(DataGridSelectionMode selectionMode = DataGridSelectionMode.Single)
+    {
+        var window = new Window { Width = 640, Height = 480 };
+        window.SetThemeStyles();
+        var items = new[]
+        {
+            new Row(1, "One", true),
+            new Row(2, "Two", false),
+            new Row(3, "Three", true)
+        };
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false,
+            CanUserAddRows = false,
+            SelectionMode = selectionMode,
+            SelectionUnit = DataGridSelectionUnit.Cell
+        };
+        grid.Columns.Add(new DataGridTextColumn { Header = "Id", Binding = new Binding(nameof(Row.Id)) });
+        grid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = new Binding(nameof(Row.Name)) });
+        grid.Columns.Add(new DataGridCheckBoxColumn { Header = "Active", Binding = new Binding(nameof(Row.Active)) });
+        window.Content = grid;
+        window.Show();
+        grid.UpdateLayout();
+        return grid;
+    }
+
+    private static void SetCurrentCell(DataGrid grid, int rowIndex, int columnDisplayIndex)
+    {
+        DataGridColumn column = grid.Columns[columnDisplayIndex];
+        foreach (DataGridColumn candidate in grid.Columns)
+        {
+            if (candidate.DisplayIndex == columnDisplayIndex)
+            {
+                column = candidate;
+                break;
+            }
+        }
+
+        object item = ((System.Collections.IList)grid.ItemsSource!)[rowIndex]!;
+        grid.CurrentCell = new DataGridCellInfo(item, column, rowIndex, column.Index, isValid: true);
+        grid.UpdateLayout();
+    }
+
+    private sealed record Row(int Id, string Name, bool Active);
+
+    private sealed class RedirectingNavigationModel : DataGridNavigationModel
+    {
+        private readonly DataGridNavigationResult _result;
+
+        public RedirectingNavigationModel(DataGridNavigationResult result)
+        {
+            _result = result;
+        }
+
+        public DataGridNavigationRequest? LastRequest { get; private set; }
+
+        protected override DataGridNavigationResult ResolveCore(DataGridNavigationRequest request)
+        {
+            LastRequest = request;
+            return _result;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
@@ -194,6 +196,29 @@ public class DataGridNavigationModelTests
         model.HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap;
 
         Assert.Equal(new[] { nameof(model.HorizontalBoundaryMode) }, changes);
+    }
+
+    [Fact]
+    public void Policy_State_Round_Trips_All_Settings()
+    {
+        var source = new DataGridNavigationModel
+        {
+            HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap,
+            VerticalBoundaryMode = DataGridNavigationBoundaryMode.Exit,
+            TabBoundaryMode = DataGridNavigationBoundaryMode.Wrap,
+            TabNavigationMode = DataGridTabNavigationMode.Always,
+            HorizontalNavigationMode = DataGridHorizontalNavigationMode.Logical
+        };
+        DataGridNavigationPolicyState state = source.CaptureState();
+        var restored = new DataGridNavigationModel();
+
+        restored.RestoreState(state);
+
+        Assert.Equal(source.HorizontalBoundaryMode, restored.HorizontalBoundaryMode);
+        Assert.Equal(source.VerticalBoundaryMode, restored.VerticalBoundaryMode);
+        Assert.Equal(source.TabBoundaryMode, restored.TabBoundaryMode);
+        Assert.Equal(source.TabNavigationMode, restored.TabNavigationMode);
+        Assert.Equal(source.HorizontalNavigationMode, restored.HorizontalNavigationMode);
     }
 
     [Fact]
@@ -446,6 +471,45 @@ public class DataGridNavigationModelTests
         Assert.Equal(0, grid.CurrentCell.RowIndex);
     }
 
+    [AvaloniaFact]
+    public void Programmatic_Expand_And_Collapse_Control_Current_Hierarchical_Node()
+    {
+        var root = new TreeRow("Root");
+        root.Children.Add(new TreeRow("Child"));
+        var hierarchy = new HierarchicalModel<TreeRow>(new HierarchicalOptions<TreeRow>
+        {
+            ItemsSelector = static item => item.Children
+        });
+        hierarchy.SetRoot(root);
+        var grid = new DataGrid
+        {
+            HierarchicalModel = hierarchy,
+            HierarchicalRowsEnabled = true,
+            ItemsSource = hierarchy.Flattened,
+            AutoGenerateColumns = false
+        };
+        var column = new DataGridHierarchicalColumn
+        {
+            Header = "Name"
+        };
+        grid.Columns.Add(column);
+        var window = new Window { Width = 480, Height = 320, Content = grid };
+        window.SetThemeStyles();
+        window.Show();
+        grid.UpdateLayout();
+        grid.CurrentCell = new DataGridCellInfo(
+            hierarchy.Flattened[0],
+            column,
+            rowIndex: 0,
+            columnIndex: 0,
+            isValid: true);
+
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Expand));
+        Assert.True(hierarchy.Root!.Value.IsExpanded);
+        Assert.True(grid.Navigate(DataGridNavigationCommand.Collapse));
+        Assert.False(hierarchy.Root.Value.IsExpanded);
+    }
+
     private static DataGridNavigationRequest CreateRequest(
         DataGridNavigationCommand command,
         DataGridNavigationPosition? proposed = null,
@@ -513,6 +577,18 @@ public class DataGridNavigationModelTests
     }
 
     private sealed record Row(int Id, string Name, bool Active);
+
+    private sealed class TreeRow
+    {
+        public TreeRow(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public ObservableCollection<TreeRow> Children { get; } = [];
+    }
 
     private sealed class RedirectingNavigationModel : DataGridNavigationModel
     {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationModelTests.cs
@@ -270,6 +270,18 @@ public class DataGridNavigationModelTests
     }
 
     [AvaloniaFact]
+    public void Programmatic_NavigateTo_Can_Establish_First_Current_Cell()
+    {
+        DataGrid grid = CreateGrid();
+
+        bool handled = grid.NavigateTo(new DataGridNavigationPosition(1, 1));
+
+        Assert.True(handled);
+        Assert.Equal(1, grid.CurrentCell.RowIndex);
+        Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+    }
+
+    [AvaloniaFact]
     public void Model_Controller_Request_Moves_Bound_Grid()
     {
         DataGrid grid = CreateGrid();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
@@ -231,6 +231,40 @@ public class DataGridRouteNavigationModelTests
         Assert.Equal(DataGridRouteNavigationStatus.Canceled, result.Status);
     }
 
+    [Fact]
+    public async Task Overlapping_Request_Returns_Busy_Without_Second_Host_Call()
+    {
+        var completion = new TaskCompletionSource<DataGridRouteNavigationResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int callCount = 0;
+        var navigator = new DelegateDataGridRouteNavigator(
+            DataGridRouteNavigationCapabilities.All,
+            (request, _) =>
+            {
+                callCount++;
+                return new ValueTask<DataGridRouteNavigationResult>(completion.Task);
+            });
+        var model = new DataGridRouteNavigationModel(CreateResolver(), navigator);
+
+        ValueTask<DataGridRouteNavigationResult> first = model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext(1),
+            TestContext.Current.CancellationToken);
+        DataGridRouteNavigationResult second = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext(2),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(model.IsNavigating);
+        Assert.False(model.CanNavigate(DataGridRouteNavigationKind.Navigate, CreateContext(3)));
+        Assert.Equal(DataGridRouteNavigationStatus.Busy, second.Status);
+        Assert.Equal(1, callCount);
+
+        completion.SetResult(DataGridRouteNavigationResult.Success(new DataGridRoute("orders/1")));
+        Assert.True((await first).Succeeded);
+        Assert.False(model.IsNavigating);
+    }
+
     [AvaloniaFact]
     public void Grid_Creates_Current_Route_Context_With_Stable_Column_Key()
     {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Navigation;
+
+public class DataGridRouteNavigationModelTests
+{
+    [Fact]
+    public void Route_Preserves_Path_Parameter_And_Target()
+    {
+        object parameter = new();
+        var route = new DataGridRoute("orders/42", parameter, "details");
+
+        Assert.True(route.IsValid);
+        Assert.Equal("orders/42", route.Path);
+        Assert.Same(parameter, route.Parameter);
+        Assert.Equal("details", route.Target);
+    }
+
+    [Fact]
+    public void Delegate_Resolver_Returns_Route_Without_Reflection()
+    {
+        var resolver = new DelegateDataGridRouteResolver(context =>
+            context.ItemKey is int id ? new DataGridRoute($"orders/{id}") : null);
+        DataGridRouteContext context = CreateContext(itemKey: 42);
+
+        bool resolved = resolver.TryResolve(context, out DataGridRoute route);
+
+        Assert.True(resolved);
+        Assert.Equal("orders/42", route.Path);
+    }
+
+    [Fact]
+    public void CanNavigate_Requires_Capability_And_Resolvable_Route()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.Navigate,
+            out _);
+
+        Assert.True(model.CanNavigate(DataGridRouteNavigationKind.Navigate, CreateContext()));
+        Assert.False(model.CanNavigate(DataGridRouteNavigationKind.Back, CreateContext()));
+        Assert.False(model.CanNavigate(
+            DataGridRouteNavigationKind.Navigate,
+            new DataGridRouteContext(null, null, null, DataGridNavigationPosition.Unset,
+                DataGridRouteNavigationOrigin.Command, hasItem: false)));
+    }
+
+    [Fact]
+    public async Task NavigateAsync_Maps_Context_And_Updates_State()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        var changes = new List<string?>();
+        model.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext(itemKey: 42));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("orders/42", result.CurrentRoute.Path);
+        Assert.Equal("orders/42", model.CurrentRoute.Path);
+        Assert.Equal(DataGridRouteNavigationStatus.Succeeded, model.LastResult.Status);
+        Assert.Equal(DataGridRouteNavigationKind.Navigate, navigator.LastRequest.Kind);
+        Assert.Contains(nameof(model.IsNavigating), changes);
+        Assert.Contains(nameof(model.CurrentRoute), changes);
+        Assert.Contains(nameof(model.LastResult), changes);
+    }
+
+    [Theory]
+    [InlineData(DataGridRouteNavigationKind.Replace)]
+    [InlineData(DataGridRouteNavigationKind.Reset)]
+    [InlineData(DataGridRouteNavigationKind.Back)]
+    [InlineData(DataGridRouteNavigationKind.Forward)]
+    public async Task NavigateAsync_Preserves_History_Operation(DataGridRouteNavigationKind kind)
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(kind, CreateContext());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(kind, navigator.LastRequest.Kind);
+        if (kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward)
+        {
+            Assert.False(navigator.LastRequest.Route.IsValid);
+        }
+    }
+
+    [Fact]
+    public async Task NavigateAsync_Returns_NotSupported_Without_Calling_Host()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.Navigate,
+            out RecordingNavigator navigator);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Back,
+            DataGridRouteContext.Empty);
+
+        Assert.Equal(DataGridRouteNavigationStatus.NotSupported, result.Status);
+        Assert.Equal(0, navigator.CallCount);
+    }
+
+    [Fact]
+    public async Task NavigateAsync_Returns_RouteNotFound_Without_Calling_Host()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            new DataGridRouteContext(null, null, null, DataGridNavigationPosition.Unset,
+                DataGridRouteNavigationOrigin.Command, hasItem: false));
+
+        Assert.Equal(DataGridRouteNavigationStatus.RouteNotFound, result.Status);
+        Assert.Equal(0, navigator.CallCount);
+    }
+
+    [Fact]
+    public async Task NavigationChanging_Can_Redirect_Request()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        model.NavigationChanging += (_, e) =>
+            e.Request = new DataGridRouteNavigationRequest(
+                DataGridRouteNavigationKind.Replace,
+                new DataGridRoute("orders/redirected"),
+                e.Request.Context);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(DataGridRouteNavigationKind.Replace, navigator.LastRequest.Kind);
+        Assert.Equal("orders/redirected", navigator.LastRequest.Route.Path);
+    }
+
+    [Fact]
+    public async Task NavigationChanging_Can_Cancel_Request()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        model.NavigationChanging += (_, e) => e.Cancel = true;
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext());
+
+        Assert.Equal(DataGridRouteNavigationStatus.Canceled, result.Status);
+        Assert.Equal(0, navigator.CallCount);
+    }
+
+    [Fact]
+    public async Task NavigationChanged_Reports_Typed_Completion()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out _);
+        DataGridRouteNavigationChangedEventArgs? observed = null;
+        model.NavigationChanged += (_, e) => observed = e;
+
+        await model.NavigateAsync(DataGridRouteNavigationKind.Navigate, CreateContext(itemKey: 7));
+
+        Assert.NotNull(observed);
+        Assert.Equal("orders/7", observed.Request.Route.Path);
+        Assert.True(observed.Result.Succeeded);
+    }
+
+    [Fact]
+    public async Task Host_Exception_Becomes_Failed_Result()
+    {
+        var resolver = CreateResolver();
+        var navigator = new DelegateDataGridRouteNavigator(
+            DataGridRouteNavigationCapabilities.All,
+            (_, _) => throw new InvalidOperationException("router failed"));
+        var model = new DataGridRouteNavigationModel(resolver, navigator);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext());
+
+        Assert.Equal(DataGridRouteNavigationStatus.Failed, result.Status);
+        Assert.IsType<InvalidOperationException>(result.Error);
+    }
+
+    [Fact]
+    public async Task Canceled_Token_Does_Not_Call_Host()
+    {
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext(),
+            cancellation.Token);
+
+        Assert.Equal(DataGridRouteNavigationStatus.Canceled, result.Status);
+        Assert.Equal(0, navigator.CallCount);
+    }
+
+    [Fact]
+    public async Task Host_Cancellation_Becomes_Canceled_Result()
+    {
+        var resolver = CreateResolver();
+        var navigator = new DelegateDataGridRouteNavigator(
+            DataGridRouteNavigationCapabilities.All,
+            (_, token) => throw new OperationCanceledException(token));
+        var model = new DataGridRouteNavigationModel(resolver, navigator);
+
+        DataGridRouteNavigationResult result = await model.NavigateAsync(
+            DataGridRouteNavigationKind.Navigate,
+            CreateContext());
+
+        Assert.Equal(DataGridRouteNavigationStatus.Canceled, result.Status);
+    }
+
+    [AvaloniaFact]
+    public void Grid_Creates_Current_Route_Context_With_Stable_Column_Key()
+    {
+        (DataGrid grid, Row row) = CreateGrid();
+
+        DataGridRouteContext context = grid.GetCurrentRouteContext(DataGridRouteNavigationOrigin.Command);
+
+        Assert.True(context.HasItem);
+        Assert.Same(row, context.Item);
+        Assert.Equal("name", context.ColumnKey);
+        Assert.Equal(new DataGridNavigationPosition(0, 0), context.Position);
+        Assert.Equal(DataGridRouteNavigationOrigin.Command, context.Origin);
+    }
+
+    [AvaloniaFact]
+    public async Task Grid_NavigateRouteAsync_Uses_Bound_Model()
+    {
+        (DataGrid grid, _) = CreateGrid();
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        grid.RouteNavigationModel = model;
+
+        DataGridRouteNavigationResult result = await grid.NavigateRouteAsync(
+            DataGridRouteNavigationKind.Navigate,
+            DataGridRouteNavigationOrigin.Keyboard,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(DataGridRouteNavigationOrigin.Keyboard, navigator.LastRequest.Context.Origin);
+        Assert.Same(grid.CurrentCell.Item, navigator.LastRequest.Context.Item);
+    }
+
+    [AvaloniaFact]
+    public async Task Grid_NavigateRouteAsync_Returns_NotSupported_When_Unconfigured()
+    {
+        (DataGrid grid, _) = CreateGrid();
+
+        DataGridRouteNavigationResult result = await grid.NavigateRouteAsync(
+            DataGridRouteNavigationKind.Navigate,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(DataGridRouteNavigationStatus.NotSupported, result.Status);
+    }
+
+    private static DataGridRouteNavigationModel CreateModel(
+        DataGridRouteNavigationCapabilities capabilities,
+        out RecordingNavigator navigator)
+    {
+        navigator = new RecordingNavigator(capabilities);
+        return new DataGridRouteNavigationModel(CreateResolver(), navigator);
+    }
+
+    private static DelegateDataGridRouteResolver CreateResolver() =>
+        new(context => context.HasItem
+            ? new DataGridRoute($"orders/{context.ItemKey}", context.Item, "details")
+            : null);
+
+    private static DataGridRouteContext CreateContext(int itemKey = 1) =>
+        new(
+            new { Id = itemKey },
+            itemKey,
+            "status",
+            new DataGridNavigationPosition(0, 2),
+            DataGridRouteNavigationOrigin.Command);
+
+    private static (DataGrid Grid, Row Row) CreateGrid()
+    {
+        var row = new Row(1, "One");
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            CanUserAddRows = false,
+            ItemsSource = new[] { row }
+        };
+        var column = new DataGridTextColumn
+        {
+            ColumnKey = "name",
+            Binding = new Binding(nameof(Row.Name))
+        };
+        grid.Columns.Add(column);
+        grid.CurrentCell = new DataGridCellInfo(row, column, 0, 0);
+        return (grid, row);
+    }
+
+    private sealed record Row(int Id, string Name);
+
+    private sealed class RecordingNavigator : IDataGridRouteNavigator
+    {
+        public RecordingNavigator(DataGridRouteNavigationCapabilities capabilities)
+        {
+            Capabilities = capabilities;
+        }
+
+        public DataGridRouteNavigationCapabilities Capabilities { get; }
+
+        public DataGridRouteNavigationRequest LastRequest { get; private set; }
+
+        public int CallCount { get; private set; }
+
+        public ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            CallCount++;
+            return ValueTask.FromResult(DataGridRouteNavigationResult.Success(request.Route));
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridRouteNavigationModelTests.cs
@@ -280,6 +280,59 @@ public class DataGridRouteNavigationModelTests
     }
 
     [AvaloniaFact]
+    public void Grid_Route_Context_Factory_Enriches_Current_And_Explicit_Cell_Context()
+    {
+        (DataGrid grid, Row row) = CreateGrid();
+        grid.RouteContextFactory = new DataGridRouteContextFactory(item => ((Row)item).Id);
+
+        DataGridRouteContext current = grid.GetCurrentRouteContext(DataGridRouteNavigationOrigin.Command);
+        DataGridRouteContext explicitContext = grid.GetRouteContext(
+            new DataGridNavigationPosition(0, 0),
+            DataGridRouteNavigationOrigin.Pointer);
+
+        Assert.Equal(row.Id, current.ItemKey);
+        Assert.Equal(row.Id, explicitContext.ItemKey);
+        Assert.Equal(DataGridRouteNavigationOrigin.Pointer, explicitContext.Origin);
+    }
+
+    [AvaloniaFact]
+    public void ViewModel_Route_Request_Is_Executed_By_Grid_With_Current_Cell_Context()
+    {
+        (DataGrid grid, Row row) = CreateGrid();
+        DataGridRouteNavigationModel model = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator navigator);
+        grid.RouteContextFactory = new DataGridRouteContextFactory(item => ((Row)item).Id);
+        grid.RouteNavigationModel = model;
+
+        bool handled = model.RequestNavigate(DataGridRouteNavigationKind.Navigate);
+
+        Assert.True(handled);
+        Assert.Equal(row.Id, navigator.LastRequest.Context.ItemKey);
+        Assert.Equal(new DataGridNavigationPosition(0, 0), navigator.LastRequest.Context.Position);
+        Assert.Equal(DataGridRouteNavigationOrigin.Command, navigator.LastRequest.Context.Origin);
+    }
+
+    [AvaloniaFact]
+    public void Replacing_Route_Model_Detaches_Grid_Controller_From_Old_Model()
+    {
+        (DataGrid grid, _) = CreateGrid();
+        DataGridRouteNavigationModel oldModel = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator oldNavigator);
+        DataGridRouteNavigationModel newModel = CreateModel(
+            DataGridRouteNavigationCapabilities.All,
+            out RecordingNavigator newNavigator);
+        grid.RouteNavigationModel = oldModel;
+        grid.RouteNavigationModel = newModel;
+
+        Assert.False(oldModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
+        Assert.True(newModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
+        Assert.Equal(0, oldNavigator.CallCount);
+        Assert.Equal(1, newNavigator.CallCount);
+    }
+
+    [AvaloniaFact]
     public async Task Grid_NavigateRouteAsync_Uses_Bound_Model()
     {
         (DataGrid grid, _) = CreateGrid();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -49,9 +49,15 @@ internal
 
         //TODO TabStop
         //TODO FlowDirection
-        private bool ProcessDataGridKey(KeyEventArgs e)
+        private bool ProcessDataGridKey(KeyEventArgs e, bool navigationInputResolved = false)
         {
             using var _ = BeginSelectionChangeScope(DataGridSelectionChangeSource.Keyboard, e);
+
+            if (!navigationInputResolved &&
+                TryProcessKeyNavigationInput(e, DataGridNavigationInputKind.KeyDown, out bool inputHandled))
+            {
+                return inputHandled;
+            }
 
             var overrides = KeyboardGestureOverrides;
             var defaults = GetDefaultKeyboardGestures();
@@ -1073,16 +1079,6 @@ internal
 
         private void OnKeyDownRouteFinished(RoutedEventArgs e)
         {
-            if (e.Handled)
-            {
-                if (e is KeyEventArgs handledKeyEventArgs)
-                {
-                    ProcessHandledEditingTabKey(handledKeyEventArgs);
-                }
-
-                return;
-            }
-
             var route = e.Route;
             var isBubble = route.HasFlag(RoutingStrategies.Bubble);
             var isDirect = route == RoutingStrategies.Direct || route == 0;
@@ -1096,12 +1092,21 @@ internal
                 return;
             }
 
+            bool navigationInputResolved = TakeNavigationKeyInputResolved(
+                keyEventArgs,
+                DataGridNavigationInputKind.KeyDown);
+            if (e.Handled)
+            {
+                ProcessHandledEditingTabKey(keyEventArgs);
+                return;
+            }
+
             if (!IsKeyEventFromThisGrid(keyEventArgs))
             {
                 return;
             }
 
-            DataGrid_KeyDown(this, keyEventArgs);
+            ProcessDataGridKeyDown(keyEventArgs, navigationInputResolved);
         }
 
         private void ProcessHandledEditingTabKey(KeyEventArgs e)
@@ -1136,11 +1141,6 @@ internal
 
         private void OnKeyUpRouteFinished(RoutedEventArgs e)
         {
-            if (e.Handled)
-            {
-                return;
-            }
-
             var route = e.Route;
             var isBubble = route.HasFlag(RoutingStrategies.Bubble);
             var isDirect = route == RoutingStrategies.Direct || route == 0;
@@ -1151,6 +1151,12 @@ internal
 
             if (e is not KeyEventArgs keyEventArgs)
             {
+                return;
+            }
+
+            if (e.Handled)
+            {
+                TakeNavigationKeyInputResolved(keyEventArgs, DataGridNavigationInputKind.KeyUp);
                 return;
             }
 
@@ -1291,14 +1297,30 @@ internal
                 return;
             }
 
+            if (NavigationInputModel != null)
+            {
+                if (WasNavigationKeyInputResolved(e, DataGridNavigationInputKind.KeyDown))
+                {
+                    e.Handled = ProcessDataGridKey(e, navigationInputResolved: true);
+                }
+                return;
+            }
+
             e.Handled = ProcessDataGridKey(e);
         }
 
         private void DataGrid_KeyDown(object sender, KeyEventArgs e)
         {
+            ProcessDataGridKeyDown(
+                e,
+                TakeNavigationKeyInputResolved(e, DataGridNavigationInputKind.KeyDown));
+        }
+
+        private void ProcessDataGridKeyDown(KeyEventArgs e, bool navigationInputResolved)
+        {
             if (!e.Handled)
             {
-                e.Handled = ProcessDataGridKey(e);
+                e.Handled = ProcessDataGridKey(e, navigationInputResolved);
             }
         }
 
@@ -1310,8 +1332,18 @@ internal
 
         private void DataGrid_KeyUp(object sender, KeyEventArgs e)
         {
+            bool navigationInputResolved = TakeNavigationKeyInputResolved(
+                e,
+                DataGridNavigationInputKind.KeyUp);
             if (e.Handled)
             {
+                return;
+            }
+
+            if (!navigationInputResolved &&
+                TryProcessKeyNavigationInput(e, DataGridNavigationInputKind.KeyUp, out bool inputHandled))
+            {
+                e.Handled = inputHandled;
                 return;
             }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
 using Avalonia.Controls.DataGridInteractions;
 using Avalonia.Controls.DataGridEditing;
+using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Reactive;
@@ -59,54 +60,67 @@ internal
             var beginEditGesture = ResolveGesture(overrides?.BeginEdit, defaults.BeginEdit);
             if (MatchesGesture(tabGesture, e, allowAdditionalModifiers: true))
             {
-                return ProcessTabKey(e, allowCtrl: AllowsCtrlModifier(tabGesture));
+                KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool tabCtrl, out bool shift);
+                return ProcessNavigationCommand(
+                    shift ? DataGridNavigationCommand.Previous : DataGridNavigationCommand.Next,
+                    e,
+                    DataGridNavigationOrigin.Keyboard,
+                    allowCtrlForTab: AllowsCtrlModifier(tabGesture));
             }
 
             bool focusDataGrid = false;
 
             if (MatchesGesture(ResolveGesture(overrides?.MoveUp, defaults.MoveUp), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessUpKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.Up, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MoveDown, defaults.MoveDown), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessDownKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.Down, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MovePageDown, defaults.MovePageDown), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessNextKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.PageDown, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MovePageUp, defaults.MovePageUp), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessPriorKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.PageUp, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MoveLeft, defaults.MoveLeft), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessLeftKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.Left, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MoveRight, defaults.MoveRight), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessRightKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.Right, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(beginEditGesture, e, allowAdditionalModifiers: false))
             {
-                return ProcessF2Key(e);
+                return ProcessNavigationCommand(DataGridNavigationCommand.BeginEdit, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesDefaultBeginEditWithAlt(e, overrides, beginEditGesture))
             {
-                return ProcessF2Key(e);
+                return ProcessNavigationCommand(DataGridNavigationCommand.BeginEdit, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MoveHome, defaults.MoveHome), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessHomeKey(e);
+                KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool homeShift);
+                focusDataGrid = ProcessNavigationCommand(
+                    ctrl ? DataGridNavigationCommand.GridStart : DataGridNavigationCommand.RowStart,
+                    e,
+                    DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.MoveEnd, defaults.MoveEnd), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessEndKey(e);
+                KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool endShift);
+                focusDataGrid = ProcessNavigationCommand(
+                    ctrl ? DataGridNavigationCommand.GridEnd : DataGridNavigationCommand.RowEnd,
+                    e,
+                    DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.Enter, defaults.Enter), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessEnterKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.Enter, e, DataGridNavigationOrigin.Keyboard);
                 if (focusDataGrid && _editingColumnIndex != -1)
                 {
                     return true;
@@ -114,7 +128,7 @@ internal
             }
             else if (MatchesGesture(ResolveGesture(overrides?.CancelEdit, defaults.CancelEdit), e, allowAdditionalModifiers: true))
             {
-                return ProcessEscapeKey();
+                return ProcessNavigationCommand(DataGridNavigationCommand.CancelEdit, e, DataGridNavigationOrigin.Keyboard);
             }
             else if (MatchesGesture(ResolveGesture(overrides?.SelectAll, defaults.SelectAll), e, allowAdditionalModifiers: false))
             {
@@ -136,7 +150,7 @@ internal
             }
             else if (MatchesGesture(ResolveGesture(overrides?.ExpandAll, defaults.ExpandAll), e, allowAdditionalModifiers: true))
             {
-                focusDataGrid = ProcessMultiplyKey(e);
+                focusDataGrid = ProcessNavigationCommand(DataGridNavigationCommand.ExpandAll, e, DataGridNavigationOrigin.Keyboard);
             }
 
             if (focusDataGrid)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -497,6 +497,84 @@ internal
             return true;
         }
 
+        private bool ProcessExpandCommand(bool subtree)
+        {
+            if (!_hierarchicalRowsEnabled || _hierarchicalAdapter == null)
+            {
+                return false;
+            }
+
+            if (WaitForLostFocus(() => ProcessExpandCommand(subtree)))
+            {
+                return true;
+            }
+
+            if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Expand, subtree))
+            {
+                return true;
+            }
+
+            if (!TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex) ||
+                !_hierarchicalAdapter.IsExpandable(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            if (subtree)
+            {
+                var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
+                RunHierarchicalAction(() => _hierarchicalAdapter.ExpandAll(node));
+                return true;
+            }
+
+            if (_hierarchicalAdapter.IsExpanded(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            _hierarchicalAdapter.Expand(hierarchicalIndex);
+            return true;
+        }
+
+        private bool ProcessCollapseCommand(bool subtree)
+        {
+            if (!_hierarchicalRowsEnabled || _hierarchicalAdapter == null)
+            {
+                return false;
+            }
+
+            if (WaitForLostFocus(() => ProcessCollapseCommand(subtree)))
+            {
+                return true;
+            }
+
+            if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Collapse, subtree))
+            {
+                return true;
+            }
+
+            if (!TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex))
+            {
+                return false;
+            }
+
+            if (subtree)
+            {
+                var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
+                RunHierarchicalAction(() => _hierarchicalAdapter.CollapseAll(node));
+                return true;
+            }
+
+            if (!_hierarchicalAdapter.IsExpandable(hierarchicalIndex) ||
+                !_hierarchicalAdapter.IsExpanded(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            _hierarchicalAdapter.Collapse(hierarchicalIndex);
+            return true;
+        }
+
 
 
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Input.cs
@@ -1,0 +1,483 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Controls
+{
+    partial class DataGrid
+    {
+        private KeyEventArgs _lastNavigationInputKeyDown;
+        private KeyEventArgs _lastNavigationInputKeyUp;
+
+        private void DataGrid_NavigationKeyDown(object sender, KeyEventArgs e)
+        {
+            ProcessKeyNavigationInputOnTunnel(e, DataGridNavigationInputKind.KeyDown);
+        }
+
+        private void DataGrid_NavigationKeyUp(object sender, KeyEventArgs e)
+        {
+            ProcessKeyNavigationInputOnTunnel(e, DataGridNavigationInputKind.KeyUp);
+        }
+
+        private void ProcessKeyNavigationInputOnTunnel(KeyEventArgs e, DataGridNavigationInputKind kind)
+        {
+            if (e.Handled || NavigationInputModel == null)
+            {
+                return;
+            }
+
+            if (kind == DataGridNavigationInputKind.KeyDown)
+            {
+                _lastNavigationInputKeyDown = e;
+            }
+            else
+            {
+                _lastNavigationInputKeyUp = e;
+            }
+
+            using var _ = BeginSelectionChangeScope(DataGridSelectionChangeSource.Keyboard, e);
+            if (TryProcessKeyNavigationInput(e, kind, out bool handled))
+            {
+                e.Handled = handled;
+            }
+        }
+
+        private void DataGrid_NavigationPointerPressed(object sender, PointerPressedEventArgs e)
+        {
+            ProcessPointerNavigationInput(e, DataGridNavigationInputKind.PointerPressed);
+        }
+
+        private void DataGrid_NavigationPointerReleased(object sender, PointerReleasedEventArgs e)
+        {
+            ProcessPointerNavigationInput(e, DataGridNavigationInputKind.PointerReleased);
+        }
+
+        private void DataGrid_NavigationPointerWheel(object sender, PointerWheelEventArgs e)
+        {
+            if (e.Handled || NavigationInputModel == null)
+            {
+                return;
+            }
+
+            DataGridNavigationWheelDirection direction = GetWheelDirection(e.Delta.X, e.Delta.Y);
+            DataGridNavigationInputRequest request = CreatePointerNavigationInputRequest(
+                e,
+                DataGridNavigationInputKind.PointerWheel,
+                DataGridNavigationPointerButton.None,
+                direction,
+                clickCount: 0);
+            if (TryProcessNavigationInput(request, null, out bool handled))
+            {
+                e.Handled = handled;
+            }
+        }
+
+        private void ProcessPointerNavigationInput(PointerEventArgs e, DataGridNavigationInputKind kind)
+        {
+            if (e.Handled || NavigationInputModel == null)
+            {
+                return;
+            }
+
+            DataGridNavigationPointerButton button = GetPointerButton(e, kind);
+            int clickCount = e is PointerPressedEventArgs pressed ? pressed.ClickCount : 0;
+            DataGridNavigationInputRequest request = CreatePointerNavigationInputRequest(
+                e,
+                kind,
+                button,
+                DataGridNavigationWheelDirection.None,
+                clickCount);
+            using var _ = BeginSelectionChangeScope(DataGridSelectionChangeSource.Pointer, e);
+            if (TryProcessNavigationInput(request, null, out bool handled))
+            {
+                e.Handled = handled;
+            }
+        }
+
+        private bool TryProcessKeyNavigationInput(
+            KeyEventArgs e,
+            DataGridNavigationInputKind kind,
+            out bool handled)
+        {
+            handled = false;
+            if (NavigationInputModel == null)
+            {
+                return false;
+            }
+
+            ResolveNavigationInputTarget(
+                e.Source as Visual,
+                out DataGridNavigationInputTargetKind targetKind,
+                out DataGridNavigationPosition targetPosition);
+            DataGridNavigationInputRequest request = new(
+                kind,
+                NormalizeNavigationInputKey(e.Key),
+                NormalizeNavigationInputPhysicalKey(e.PhysicalKey),
+                e.KeyDeviceType switch
+                {
+                    KeyDeviceType.Keyboard => DataGridNavigationKeyDeviceKind.Keyboard,
+                    KeyDeviceType.Gamepad => DataGridNavigationKeyDeviceKind.Gamepad,
+                    KeyDeviceType.Remote => DataGridNavigationKeyDeviceKind.Remote,
+                    _ => DataGridNavigationKeyDeviceKind.Unknown
+                },
+                NormalizeNavigationInputModifiers(e.KeyModifiers),
+                DataGridNavigationPointerDeviceKind.Unknown,
+                DataGridNavigationPointerButton.None,
+                DataGridNavigationWheelDirection.None,
+                clickCount: 0,
+                x: double.NaN,
+                y: double.NaN,
+                wheelDeltaX: 0,
+                wheelDeltaY: 0,
+                targetKind,
+                targetPosition,
+                CreateNavigationPosition(),
+                _editingColumnIndex != -1);
+            return TryProcessNavigationInput(request, e, out handled);
+        }
+
+        private bool TakeNavigationKeyInputResolved(KeyEventArgs e, DataGridNavigationInputKind kind)
+        {
+            if (kind == DataGridNavigationInputKind.KeyDown)
+            {
+                bool resolved = ReferenceEquals(_lastNavigationInputKeyDown, e);
+                if (resolved)
+                {
+                    _lastNavigationInputKeyDown = null;
+                }
+                return resolved;
+            }
+
+            bool keyUpResolved = ReferenceEquals(_lastNavigationInputKeyUp, e);
+            if (keyUpResolved)
+            {
+                _lastNavigationInputKeyUp = null;
+            }
+            return keyUpResolved;
+        }
+
+        private bool WasNavigationKeyInputResolved(KeyEventArgs e, DataGridNavigationInputKind kind) =>
+            ReferenceEquals(
+                kind == DataGridNavigationInputKind.KeyDown
+                    ? _lastNavigationInputKeyDown
+                    : _lastNavigationInputKeyUp,
+                e);
+
+        private bool TryProcessNavigationInput(
+            in DataGridNavigationInputRequest request,
+            KeyEventArgs keyEventArgs,
+            out bool handled)
+        {
+            handled = false;
+            IDataGridNavigationInputModel model = NavigationInputModel;
+            if (model == null)
+            {
+                return false;
+            }
+
+            DataGridNavigationInputResult result = model.Resolve(request);
+            KeyModifiers modifiers = DenormalizeNavigationInputModifiers(request.Modifiers);
+            bool navigationHandled;
+            switch (result.Decision)
+            {
+                case DataGridNavigationInputDecision.Ignore:
+                    return false;
+                case DataGridNavigationInputDecision.Handle:
+                    handled = true;
+                    return true;
+                case DataGridNavigationInputDecision.Navigate:
+                    navigationHandled = result.Command != DataGridNavigationCommand.None &&
+                        ProcessNavigationCommand(
+                            result.Command,
+                            keyEventArgs,
+                            GetNavigationOrigin(request.Kind),
+                            modifiers,
+                            allowCtrlForTab: false);
+                    break;
+                case DataGridNavigationInputDecision.NavigateToTarget:
+                    navigationHandled = request.TargetPosition.IsValid &&
+                        ProcessNavigationCommand(
+                            DataGridNavigationCommand.GoTo,
+                            keyEventArgs,
+                            GetNavigationOrigin(request.Kind),
+                            modifiers,
+                            allowCtrlForTab: false,
+                            request.TargetPosition);
+                    break;
+                case DataGridNavigationInputDecision.NavigateToPosition:
+                    navigationHandled = result.Target.IsValid &&
+                        ProcessNavigationCommand(
+                            DataGridNavigationCommand.GoTo,
+                            keyEventArgs,
+                            GetNavigationOrigin(request.Kind),
+                            modifiers,
+                            allowCtrlForTab: false,
+                            result.Target);
+                    break;
+                case DataGridNavigationInputDecision.NavigateRoute:
+                    navigationHandled = TryNavigateRouteFromInput(result.RouteKind, request.Kind);
+                    break;
+                default:
+                    navigationHandled = false;
+                    break;
+            }
+
+            handled = navigationHandled || result.ConsumeWhenNavigationFails;
+            return true;
+        }
+
+        private static DataGridNavigationOrigin GetNavigationOrigin(DataGridNavigationInputKind kind) =>
+            kind is DataGridNavigationInputKind.KeyDown or DataGridNavigationInputKind.KeyUp
+                ? DataGridNavigationOrigin.Keyboard
+                : DataGridNavigationOrigin.Pointer;
+
+        private bool TryNavigateRouteFromInput(
+            DataGridRouteNavigationKind kind,
+            DataGridNavigationInputKind inputKind)
+        {
+            IDataGridRouteNavigationModel model = RouteNavigationModel;
+            if (model == null)
+            {
+                return false;
+            }
+
+            DataGridRouteNavigationOrigin origin = inputKind is DataGridNavigationInputKind.KeyDown or
+                DataGridNavigationInputKind.KeyUp
+                    ? DataGridRouteNavigationOrigin.Keyboard
+                    : DataGridRouteNavigationOrigin.Pointer;
+            DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward
+                ? DataGridRouteContext.Empty
+                : GetCurrentRouteContext(origin);
+            if (!model.CanNavigate(kind, context))
+            {
+                return false;
+            }
+
+            _ = NavigateRouteAsync(kind, origin);
+            return true;
+        }
+
+        private DataGridNavigationInputRequest CreatePointerNavigationInputRequest(
+            PointerEventArgs e,
+            DataGridNavigationInputKind kind,
+            DataGridNavigationPointerButton button,
+            DataGridNavigationWheelDirection wheelDirection,
+            int clickCount)
+        {
+            Point position = e.GetPosition(this);
+            ResolveNavigationInputTarget(
+                e.Source as Visual,
+                out DataGridNavigationInputTargetKind targetKind,
+                out DataGridNavigationPosition targetPosition);
+            return new DataGridNavigationInputRequest(
+                kind,
+                DataGridNavigationInputKey.None,
+                DataGridNavigationInputKey.None,
+                DataGridNavigationKeyDeviceKind.Unknown,
+                NormalizeNavigationInputModifiers(e.KeyModifiers),
+                e.Pointer.Type switch
+                {
+                    PointerType.Mouse => DataGridNavigationPointerDeviceKind.Mouse,
+                    PointerType.Pen => DataGridNavigationPointerDeviceKind.Pen,
+                    PointerType.Touch => DataGridNavigationPointerDeviceKind.Touch,
+                    _ => DataGridNavigationPointerDeviceKind.Unknown
+                },
+                button,
+                wheelDirection,
+                clickCount,
+                position.X,
+                position.Y,
+                e is PointerWheelEventArgs wheel ? wheel.Delta.X : 0,
+                e is PointerWheelEventArgs wheelY ? wheelY.Delta.Y : 0,
+                targetKind,
+                targetPosition,
+                CreateNavigationPosition(),
+                _editingColumnIndex != -1);
+        }
+
+        private void ResolveNavigationInputTarget(
+            Visual source,
+            out DataGridNavigationInputTargetKind targetKind,
+            out DataGridNavigationPosition targetPosition)
+        {
+            targetPosition = DataGridNavigationPosition.Unset;
+            if (source == null)
+            {
+                targetKind = DataGridNavigationInputTargetKind.Empty;
+                return;
+            }
+
+            DataGridCell cell = source as DataGridCell ?? source.FindAncestorOfType<DataGridCell>();
+            if (cell?.OwningGrid == this && cell.OwningRow != null && cell.OwningColumn != null)
+            {
+                targetKind = DataGridNavigationInputTargetKind.Cell;
+                targetPosition = new DataGridNavigationPosition(cell.RowIndex, cell.OwningColumn.DisplayIndex);
+                return;
+            }
+
+            if (source is DataGridRowHeader || source.FindAncestorOfType<DataGridRowHeader>() != null)
+            {
+                targetKind = DataGridNavigationInputTargetKind.RowHeader;
+                return;
+            }
+
+            if (source is DataGridColumnHeader || source.FindAncestorOfType<DataGridColumnHeader>() != null)
+            {
+                targetKind = DataGridNavigationInputTargetKind.ColumnHeader;
+                return;
+            }
+
+            if (source is DataGridRowGroupHeader || source.FindAncestorOfType<DataGridRowGroupHeader>() != null)
+            {
+                targetKind = DataGridNavigationInputTargetKind.GroupHeader;
+                return;
+            }
+
+            DataGridRow row = source as DataGridRow ?? source.FindAncestorOfType<DataGridRow>();
+            if (row?.OwningGrid == this)
+            {
+                targetKind = DataGridNavigationInputTargetKind.Row;
+                DataGridNavigationPosition current = CreateNavigationPosition();
+                if (current.ColumnDisplayIndex >= 0)
+                {
+                    targetPosition = new DataGridNavigationPosition(row.Index, current.ColumnDisplayIndex);
+                }
+                return;
+            }
+
+            targetKind = ReferenceEquals(source, this) || source.FindAncestorOfType<DataGrid>() == this
+                ? DataGridNavigationInputTargetKind.Grid
+                : DataGridNavigationInputTargetKind.Empty;
+        }
+
+        private static DataGridNavigationPointerButton GetPointerButton(
+            PointerEventArgs e,
+            DataGridNavigationInputKind kind)
+        {
+            PointerPointProperties properties = e.GetCurrentPoint(null).Properties;
+            if (kind == DataGridNavigationInputKind.PointerPressed)
+            {
+                if (properties.IsLeftButtonPressed) return DataGridNavigationPointerButton.Primary;
+                if (properties.IsRightButtonPressed) return DataGridNavigationPointerButton.Secondary;
+                if (properties.IsMiddleButtonPressed) return DataGridNavigationPointerButton.Middle;
+                if (properties.IsXButton1Pressed) return DataGridNavigationPointerButton.XButton1;
+                if (properties.IsXButton2Pressed) return DataGridNavigationPointerButton.XButton2;
+            }
+
+            return properties.PointerUpdateKind switch
+            {
+                PointerUpdateKind.LeftButtonReleased => DataGridNavigationPointerButton.Primary,
+                PointerUpdateKind.RightButtonReleased => DataGridNavigationPointerButton.Secondary,
+                PointerUpdateKind.MiddleButtonReleased => DataGridNavigationPointerButton.Middle,
+                PointerUpdateKind.XButton1Released => DataGridNavigationPointerButton.XButton1,
+                PointerUpdateKind.XButton2Released => DataGridNavigationPointerButton.XButton2,
+                _ => DataGridNavigationPointerButton.None
+            };
+        }
+
+        private static DataGridNavigationWheelDirection GetWheelDirection(double x, double y)
+        {
+            if (System.Math.Abs(y) >= System.Math.Abs(x) && y != 0)
+            {
+                return y > 0 ? DataGridNavigationWheelDirection.Up : DataGridNavigationWheelDirection.Down;
+            }
+
+            if (x != 0)
+            {
+                return x > 0 ? DataGridNavigationWheelDirection.Right : DataGridNavigationWheelDirection.Left;
+            }
+
+            return DataGridNavigationWheelDirection.None;
+        }
+
+        private static DataGridNavigationInputModifiers NormalizeNavigationInputModifiers(KeyModifiers modifiers)
+        {
+            DataGridNavigationInputModifiers result = DataGridNavigationInputModifiers.None;
+            if ((modifiers & KeyModifiers.Shift) != 0) result |= DataGridNavigationInputModifiers.Shift;
+            if ((modifiers & KeyModifiers.Control) != 0) result |= DataGridNavigationInputModifiers.Control;
+            if ((modifiers & KeyModifiers.Alt) != 0) result |= DataGridNavigationInputModifiers.Alt;
+            if ((modifiers & KeyModifiers.Meta) != 0) result |= DataGridNavigationInputModifiers.Meta;
+            return result;
+        }
+
+        private static KeyModifiers DenormalizeNavigationInputModifiers(DataGridNavigationInputModifiers modifiers)
+        {
+            KeyModifiers result = KeyModifiers.None;
+            if ((modifiers & DataGridNavigationInputModifiers.Shift) != 0) result |= KeyModifiers.Shift;
+            if ((modifiers & DataGridNavigationInputModifiers.Control) != 0) result |= KeyModifiers.Control;
+            if ((modifiers & DataGridNavigationInputModifiers.Alt) != 0) result |= KeyModifiers.Alt;
+            if ((modifiers & DataGridNavigationInputModifiers.Meta) != 0) result |= KeyModifiers.Meta;
+            return result;
+        }
+
+        private static DataGridNavigationInputKey NormalizeNavigationInputKey(Key key) => key switch
+        {
+            Key.Up => DataGridNavigationInputKey.Up,
+            Key.Down => DataGridNavigationInputKey.Down,
+            Key.Left => DataGridNavigationInputKey.Left,
+            Key.Right => DataGridNavigationInputKey.Right,
+            Key.PageUp => DataGridNavigationInputKey.PageUp,
+            Key.PageDown => DataGridNavigationInputKey.PageDown,
+            Key.Home => DataGridNavigationInputKey.Home,
+            Key.End => DataGridNavigationInputKey.End,
+            Key.Tab => DataGridNavigationInputKey.Tab,
+            Key.Enter => DataGridNavigationInputKey.Enter,
+            Key.Escape => DataGridNavigationInputKey.Escape,
+            Key.Space => DataGridNavigationInputKey.Space,
+            Key.Back => DataGridNavigationInputKey.Backspace,
+            Key.Insert => DataGridNavigationInputKey.Insert,
+            Key.Delete => DataGridNavigationInputKey.Delete,
+            Key.Add or Key.OemPlus => DataGridNavigationInputKey.Add,
+            Key.Subtract or Key.OemMinus => DataGridNavigationInputKey.Subtract,
+            Key.Multiply => DataGridNavigationInputKey.Multiply,
+            Key.Divide => DataGridNavigationInputKey.Divide,
+            Key.Decimal or Key.OemPeriod => DataGridNavigationInputKey.Decimal,
+            Key.BrowserBack => DataGridNavigationInputKey.BrowserBack,
+            Key.BrowserForward => DataGridNavigationInputKey.BrowserForward,
+            >= Key.A and <= Key.Z => (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.A + (key - Key.A)),
+            >= Key.D0 and <= Key.D9 => (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.D0 + (key - Key.D0)),
+            >= Key.F1 and <= Key.F12 => (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.F1 + (key - Key.F1)),
+            Key.None => DataGridNavigationInputKey.None,
+            _ => DataGridNavigationInputKey.Unknown
+        };
+
+        private static DataGridNavigationInputKey NormalizeNavigationInputPhysicalKey(PhysicalKey key) => key switch
+        {
+            PhysicalKey.ArrowUp => DataGridNavigationInputKey.Up,
+            PhysicalKey.ArrowDown => DataGridNavigationInputKey.Down,
+            PhysicalKey.ArrowLeft => DataGridNavigationInputKey.Left,
+            PhysicalKey.ArrowRight => DataGridNavigationInputKey.Right,
+            PhysicalKey.PageUp => DataGridNavigationInputKey.PageUp,
+            PhysicalKey.PageDown => DataGridNavigationInputKey.PageDown,
+            PhysicalKey.Home => DataGridNavigationInputKey.Home,
+            PhysicalKey.End => DataGridNavigationInputKey.End,
+            PhysicalKey.Tab => DataGridNavigationInputKey.Tab,
+            PhysicalKey.Enter or PhysicalKey.NumPadEnter => DataGridNavigationInputKey.Enter,
+            PhysicalKey.Escape => DataGridNavigationInputKey.Escape,
+            PhysicalKey.Space => DataGridNavigationInputKey.Space,
+            PhysicalKey.Backspace => DataGridNavigationInputKey.Backspace,
+            PhysicalKey.Insert => DataGridNavigationInputKey.Insert,
+            PhysicalKey.Delete => DataGridNavigationInputKey.Delete,
+            PhysicalKey.NumPadAdd or PhysicalKey.Equal => DataGridNavigationInputKey.Add,
+            PhysicalKey.NumPadSubtract or PhysicalKey.Minus => DataGridNavigationInputKey.Subtract,
+            PhysicalKey.NumPadMultiply => DataGridNavigationInputKey.Multiply,
+            PhysicalKey.NumPadDivide or PhysicalKey.Slash => DataGridNavigationInputKey.Divide,
+            PhysicalKey.NumPadDecimal or PhysicalKey.Period => DataGridNavigationInputKey.Decimal,
+            >= PhysicalKey.A and <= PhysicalKey.Z =>
+                (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.A + ((int)key - (int)PhysicalKey.A)),
+            >= PhysicalKey.Digit0 and <= PhysicalKey.Digit9 =>
+                (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.D0 + ((int)key - (int)PhysicalKey.Digit0)),
+            >= PhysicalKey.F1 and <= PhysicalKey.F12 =>
+                (DataGridNavigationInputKey)((int)DataGridNavigationInputKey.F1 + ((int)key - (int)PhysicalKey.F1)),
+            PhysicalKey.None => DataGridNavigationInputKey.None,
+            _ => DataGridNavigationInputKey.Unknown
+        };
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Input.cs
@@ -222,7 +222,7 @@ namespace Avalonia.Controls
                             result.Target);
                     break;
                 case DataGridNavigationInputDecision.NavigateRoute:
-                    navigationHandled = TryNavigateRouteFromInput(result.RouteKind, request.Kind);
+                    navigationHandled = TryNavigateRouteFromInput(result.RouteKind, request);
                     break;
                 default:
                     navigationHandled = false;
@@ -240,7 +240,7 @@ namespace Avalonia.Controls
 
         private bool TryNavigateRouteFromInput(
             DataGridRouteNavigationKind kind,
-            DataGridNavigationInputKind inputKind)
+            in DataGridNavigationInputRequest input)
         {
             IDataGridRouteNavigationModel model = RouteNavigationModel;
             if (model == null)
@@ -248,19 +248,36 @@ namespace Avalonia.Controls
                 return false;
             }
 
-            DataGridRouteNavigationOrigin origin = inputKind is DataGridNavigationInputKind.KeyDown or
+            DataGridRouteNavigationOrigin origin = input.Kind is DataGridNavigationInputKind.KeyDown or
                 DataGridNavigationInputKind.KeyUp
                     ? DataGridRouteNavigationOrigin.Keyboard
                     : DataGridRouteNavigationOrigin.Pointer;
-            DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward
-                ? DataGridRouteContext.Empty
-                : GetCurrentRouteContext(origin);
+            DataGridRouteContext context;
+            if (kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward)
+            {
+                context = new DataGridRouteContext(
+                    null,
+                    null,
+                    null,
+                    DataGridNavigationPosition.Unset,
+                    origin,
+                    hasItem: false);
+            }
+            else
+            {
+                bool pointerInput = input.Kind is DataGridNavigationInputKind.PointerPressed or
+                    DataGridNavigationInputKind.PointerReleased or
+                    DataGridNavigationInputKind.PointerWheel;
+                context = pointerInput && input.TargetPosition.IsValid
+                    ? GetRouteContext(input.TargetPosition, origin)
+                    : GetCurrentRouteContext(origin);
+            }
             if (!model.CanNavigate(kind, context))
             {
                 return false;
             }
 
-            _ = NavigateRouteAsync(kind, origin);
+            _ = model.NavigateAsync(kind, context);
             return true;
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -169,6 +169,8 @@ namespace Avalonia.Controls
                 DataGridNavigationCommand.Enter => ProcessEnterKey(keyEventArgs, shift, ctrl),
                 DataGridNavigationCommand.BeginEdit => ProcessF2Key(keyEventArgs),
                 DataGridNavigationCommand.CancelEdit => ProcessEscapeKey(),
+                DataGridNavigationCommand.Expand => ProcessExpandCommand(subtree: false),
+                DataGridNavigationCommand.Collapse => ProcessCollapseCommand(subtree: false),
                 DataGridNavigationCommand.ExpandAll => ProcessMultiplyKey(keyEventArgs),
                 _ => false
             };
@@ -424,6 +426,8 @@ namespace Avalonia.Controls
         private bool CanExecuteNavigationWithoutTarget(DataGridNavigationCommand command) =>
             command is DataGridNavigationCommand.BeginEdit or
                 DataGridNavigationCommand.CancelEdit or
+                DataGridNavigationCommand.Expand or
+                DataGridNavigationCommand.Collapse or
                 DataGridNavigationCommand.ExpandAll;
 
         private DataGridNavigationFailureReason ResolveUnavailableNavigationReason()

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -32,6 +32,28 @@ namespace Avalonia.Controls
                 allowCtrlForTab: false);
         }
 
+        /// <summary>Attempts to move to an explicit data-cell position through the current navigation model.</summary>
+        /// <param name="target">The collection-view row and column display indexes to activate.</param>
+        /// <param name="modifiers">Modifiers used for selection extension.</param>
+        /// <returns><see langword="true"/> when the request was handled by the grid.</returns>
+        public bool NavigateTo(
+            DataGridNavigationPosition target,
+            KeyModifiers modifiers = KeyModifiers.None)
+        {
+            if (!target.IsValid)
+            {
+                return false;
+            }
+
+            return ProcessNavigationCommand(
+                DataGridNavigationCommand.GoTo,
+                null,
+                DataGridNavigationOrigin.Programmatic,
+                modifiers,
+                allowCtrlForTab: false,
+                target);
+        }
+
         /// <summary>
         /// Determines whether a semantic navigation command currently has a valid route.
         /// </summary>
@@ -80,9 +102,14 @@ namespace Avalonia.Controls
             KeyEventArgs keyEventArgs,
             DataGridNavigationOrigin origin,
             KeyModifiers modifiers,
-            bool allowCtrlForTab)
+            bool allowCtrlForTab,
+            DataGridNavigationPosition? proposedPosition = null)
         {
-            DataGridNavigationRequest request = CreateNavigationRequest(command, origin, modifiers);
+            DataGridNavigationRequest request = CreateNavigationRequest(
+                command,
+                origin,
+                modifiers,
+                proposedPosition);
             DataGridNavigationPosition oldPosition = request.CurrentPosition;
             DataGridNavigationResult result = NavigationModel.Resolve(request);
             bool handled;
@@ -179,12 +206,14 @@ namespace Avalonia.Controls
         private DataGridNavigationRequest CreateNavigationRequest(
             DataGridNavigationCommand command,
             DataGridNavigationOrigin origin,
-            KeyModifiers modifiers)
+            KeyModifiers modifiers,
+            DataGridNavigationPosition? proposedPosition = null)
         {
             DataGridNavigationPosition current = CreateNavigationPosition();
-            DataGridNavigationPosition? proposed = TryGetProposedNavigationPosition(command, modifiers, out DataGridNavigationPosition target)
-                ? target
-                : null;
+            DataGridNavigationPosition? proposed = proposedPosition ??
+                (TryGetProposedNavigationPosition(command, modifiers, out DataGridNavigationPosition target)
+                    ? target
+                    : null);
             DataGridColumn firstColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
             DataGridColumn lastColumn = GetLastVisibleNonFillerNavigationColumn();
             int lastRowIndex = DataConnection?.Count > 0 ? DataConnection.Count - 1 : -1;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -1,0 +1,444 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Controls.Utils;
+using Avalonia.Input;
+
+namespace Avalonia.Controls
+{
+    partial class DataGrid
+    {
+        /// <summary>
+        /// Attempts to execute a semantic navigation command through the current <see cref="NavigationModel"/>.
+        /// </summary>
+        /// <param name="command">The semantic navigation command.</param>
+        /// <param name="modifiers">Modifiers used for selection extension and edge movement.</param>
+        /// <returns><see langword="true"/> when the request was handled by the grid; otherwise, <see langword="false"/>.</returns>
+        public bool Navigate(DataGridNavigationCommand command, KeyModifiers modifiers = KeyModifiers.None)
+        {
+            if (command == DataGridNavigationCommand.None)
+            {
+                return false;
+            }
+
+            return ProcessNavigationCommand(
+                command,
+                null,
+                DataGridNavigationOrigin.Programmatic,
+                modifiers,
+                allowCtrlForTab: false);
+        }
+
+        /// <summary>
+        /// Determines whether a semantic navigation command currently has a valid route.
+        /// </summary>
+        /// <param name="command">The semantic navigation command.</param>
+        /// <param name="modifiers">Modifiers used to resolve the proposed target.</param>
+        /// <returns><see langword="true"/> when the model or default engine can handle the request.</returns>
+        public bool CanNavigate(DataGridNavigationCommand command, KeyModifiers modifiers = KeyModifiers.None)
+        {
+            if (command == DataGridNavigationCommand.None)
+            {
+                return false;
+            }
+
+            DataGridNavigationRequest request = CreateNavigationRequest(
+                command,
+                DataGridNavigationOrigin.Programmatic,
+                modifiers);
+            if (NavigationModel is not IDataGridNavigationQueryModel queryModel)
+            {
+                return request.ProposedPosition.HasValue || CanExecuteNavigationWithoutTarget(command);
+            }
+
+            DataGridNavigationResult result = queryModel.Query(request);
+            return result.Decision switch
+            {
+                DataGridNavigationDecision.Move => result.Target.IsValid,
+                DataGridNavigationDecision.Redirect => result.RedirectedCommand != DataGridNavigationCommand.None,
+                DataGridNavigationDecision.Stay => false,
+                DataGridNavigationDecision.LeaveGrid => false,
+                _ => request.ProposedPosition.HasValue || CanExecuteNavigationWithoutTarget(command)
+            };
+        }
+
+        private bool ProcessNavigationCommand(
+            DataGridNavigationCommand command,
+            KeyEventArgs keyEventArgs,
+            DataGridNavigationOrigin origin,
+            bool allowCtrlForTab = false)
+        {
+            KeyModifiers modifiers = keyEventArgs?.KeyModifiers ?? KeyModifiers.None;
+            return ProcessNavigationCommand(command, keyEventArgs, origin, modifiers, allowCtrlForTab);
+        }
+
+        private bool ProcessNavigationCommand(
+            DataGridNavigationCommand command,
+            KeyEventArgs keyEventArgs,
+            DataGridNavigationOrigin origin,
+            KeyModifiers modifiers,
+            bool allowCtrlForTab)
+        {
+            DataGridNavigationRequest request = CreateNavigationRequest(command, origin, modifiers);
+            DataGridNavigationPosition oldPosition = request.CurrentPosition;
+            DataGridNavigationResult result = NavigationModel.Resolve(request);
+            bool handled;
+            DataGridNavigationFailureReason failureReason = DataGridNavigationFailureReason.None;
+
+            switch (result.Decision)
+            {
+                case DataGridNavigationDecision.Move:
+                    handled = TryApplyNavigationTarget(result.Target, modifiers);
+                    if (!handled)
+                    {
+                        failureReason = DataGridNavigationFailureReason.InvalidTarget;
+                    }
+                    break;
+
+                case DataGridNavigationDecision.Redirect:
+                    handled = result.RedirectedCommand != DataGridNavigationCommand.None &&
+                        ExecuteDefaultNavigation(result.RedirectedCommand, keyEventArgs, modifiers, allowCtrlForTab);
+                    if (!handled)
+                    {
+                        failureReason = DataGridNavigationFailureReason.BoundaryReached;
+                    }
+                    break;
+
+                case DataGridNavigationDecision.Stay:
+                    handled = true;
+                    failureReason = result.FailureReason == DataGridNavigationFailureReason.None
+                        ? DataGridNavigationFailureReason.BoundaryReached
+                        : result.FailureReason;
+                    break;
+
+                case DataGridNavigationDecision.LeaveGrid:
+                    handled = false;
+                    failureReason = DataGridNavigationFailureReason.BoundaryReached;
+                    break;
+
+                default:
+                    handled = ExecuteDefaultNavigation(command, keyEventArgs, modifiers, allowCtrlForTab);
+                    if (!handled && !CreateNavigationPosition().IsValid)
+                    {
+                        failureReason = ResolveUnavailableNavigationReason();
+                    }
+                    else if (!handled)
+                    {
+                        failureReason = DataGridNavigationFailureReason.BoundaryReached;
+                    }
+                    break;
+            }
+
+            DataGridNavigationPosition newPosition = CreateNavigationPosition();
+            NavigationModel.NotifyCompleted(new DataGridNavigationCompleted(
+                request,
+                result,
+                oldPosition,
+                newPosition,
+                handled,
+                failureReason));
+            return handled;
+        }
+
+        private bool ExecuteDefaultNavigation(
+            DataGridNavigationCommand command,
+            KeyEventArgs keyEventArgs,
+            KeyModifiers modifiers,
+            bool allowCtrlForTab)
+        {
+            KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out bool shift, out bool alt);
+            return command switch
+            {
+                DataGridNavigationCommand.Up => ProcessUpKey(shift, ctrl),
+                DataGridNavigationCommand.Down => ProcessDownKeyInternal(shift, ctrl),
+                DataGridNavigationCommand.Left => ProcessLeftKey(shift, ctrl, alt),
+                DataGridNavigationCommand.Right => ProcessRightKey(shift, ctrl, alt),
+                DataGridNavigationCommand.PageUp => ProcessPriorKey(shift, ctrl),
+                DataGridNavigationCommand.PageDown => ProcessNextKey(shift, ctrl),
+                DataGridNavigationCommand.RowStart => ProcessHomeKey(shift, ctrl: false),
+                DataGridNavigationCommand.RowEnd => ProcessEndKey(shift, ctrl: false),
+                DataGridNavigationCommand.ColumnStart => ProcessUpKey(shift, ctrl: true),
+                DataGridNavigationCommand.ColumnEnd => ProcessDownKeyInternal(shift, ctrl: true),
+                DataGridNavigationCommand.GridStart => ProcessHomeKey(shift, ctrl: true),
+                DataGridNavigationCommand.GridEnd => ProcessEndKey(shift, ctrl: true),
+                DataGridNavigationCommand.Next => ProcessTabKey(keyEventArgs, shift: false, ctrl, allowCtrlForTab),
+                DataGridNavigationCommand.Previous => ProcessTabKey(keyEventArgs, shift: true, ctrl, allowCtrlForTab),
+                DataGridNavigationCommand.Enter => ProcessEnterKey(keyEventArgs, shift, ctrl),
+                DataGridNavigationCommand.BeginEdit => ProcessF2Key(keyEventArgs),
+                DataGridNavigationCommand.CancelEdit => ProcessEscapeKey(),
+                DataGridNavigationCommand.ExpandAll => ProcessMultiplyKey(keyEventArgs),
+                _ => false
+            };
+        }
+
+        private DataGridNavigationRequest CreateNavigationRequest(
+            DataGridNavigationCommand command,
+            DataGridNavigationOrigin origin,
+            KeyModifiers modifiers)
+        {
+            DataGridNavigationPosition current = CreateNavigationPosition();
+            DataGridNavigationPosition? proposed = TryGetProposedNavigationPosition(command, modifiers, out DataGridNavigationPosition target)
+                ? target
+                : null;
+            DataGridColumn firstColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
+            DataGridColumn lastColumn = GetLastVisibleNonFillerNavigationColumn();
+            int lastRowIndex = DataConnection?.Count > 0 ? DataConnection.Count - 1 : -1;
+
+            return new DataGridNavigationRequest(
+                command,
+                origin,
+                current,
+                proposed,
+                modifiers,
+                _editingColumnIndex != -1,
+                SelectionMode,
+                SelectionUnit,
+                FlowDirection,
+                lastRowIndex >= 0 ? 0 : -1,
+                lastRowIndex,
+                firstColumn?.DisplayIndex ?? -1,
+                lastColumn?.DisplayIndex ?? -1);
+        }
+
+        private DataGridNavigationPosition CreateNavigationPosition()
+        {
+            if (CurrentColumnIndex < 0 || CurrentSlot < 0 || IsGroupSlot(CurrentSlot))
+            {
+                return DataGridNavigationPosition.Unset;
+            }
+
+            int rowIndex = RowIndexFromSlot(CurrentSlot);
+            if (rowIndex < 0 || CurrentColumn == null)
+            {
+                return DataGridNavigationPosition.Unset;
+            }
+
+            return new DataGridNavigationPosition(rowIndex, CurrentColumn.DisplayIndex);
+        }
+
+        private bool TryGetProposedNavigationPosition(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers,
+            out DataGridNavigationPosition target)
+        {
+            target = DataGridNavigationPosition.Unset;
+            DataGridNavigationPosition current = CreateNavigationPosition();
+            if (!current.IsValid || CurrentColumn == null)
+            {
+                return false;
+            }
+
+            KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out _, out _);
+            int targetSlot = CurrentSlot;
+            DataGridColumn targetColumn = CurrentColumn;
+
+            switch (command)
+            {
+                case DataGridNavigationCommand.Up:
+                    targetSlot = ctrl ? FirstVisibleSlot : GetPreviousVisibleSlot(CurrentSlot);
+                    break;
+                case DataGridNavigationCommand.Down:
+                    targetSlot = ctrl ? LastVisibleSlot : GetNextVisibleSlot(CurrentSlot);
+                    break;
+                case DataGridNavigationCommand.Left:
+                    targetColumn = ctrl
+                        ? ColumnsInternal.FirstVisibleNonFillerColumn
+                        : ColumnsInternal.GetPreviousVisibleNonFillerColumn(CurrentColumn);
+                    break;
+                case DataGridNavigationCommand.Right:
+                    targetColumn = ctrl
+                        ? GetLastVisibleNonFillerNavigationColumn()
+                        : ColumnsInternal.GetNextVisibleColumn(CurrentColumn);
+                    if (targetColumn is DataGridFillerColumn)
+                    {
+                        targetColumn = null;
+                    }
+                    break;
+                case DataGridNavigationCommand.RowStart:
+                    targetColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
+                    break;
+                case DataGridNavigationCommand.RowEnd:
+                    targetColumn = GetLastVisibleNonFillerNavigationColumn();
+                    break;
+                case DataGridNavigationCommand.ColumnStart:
+                    targetSlot = FirstVisibleSlot;
+                    break;
+                case DataGridNavigationCommand.ColumnEnd:
+                    targetSlot = LastVisibleSlot;
+                    break;
+                case DataGridNavigationCommand.GridStart:
+                    targetSlot = FirstVisibleSlot;
+                    targetColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
+                    break;
+                case DataGridNavigationCommand.GridEnd:
+                    targetSlot = LastVisibleSlot;
+                    targetColumn = GetLastVisibleNonFillerNavigationColumn();
+                    break;
+                case DataGridNavigationCommand.PageUp:
+                    targetSlot = GetPageNavigationSlot(forward: false);
+                    break;
+                case DataGridNavigationCommand.PageDown:
+                    targetSlot = GetPageNavigationSlot(forward: true);
+                    break;
+                case DataGridNavigationCommand.Next:
+                case DataGridNavigationCommand.Previous:
+                    return TryGetTabNavigationPosition(command == DataGridNavigationCommand.Previous, out target);
+                case DataGridNavigationCommand.Enter:
+                    if (_editingColumnIndex != -1 && EnterKeyNavigationMode == DataGridEnterKeyNavigationMode.NextCell)
+                    {
+                        return TryGetTabNavigationPosition(previous: false, out target);
+                    }
+                    targetSlot = GetNextVisibleSlot(CurrentSlot);
+                    break;
+                default:
+                    return false;
+            }
+
+            return TryCreateNavigationPosition(targetSlot, targetColumn, out target) && target != current;
+        }
+
+        private bool TryGetTabNavigationPosition(bool previous, out DataGridNavigationPosition target)
+        {
+            target = DataGridNavigationPosition.Unset;
+            DataGridColumn targetColumn = _editingColumnIndex != -1
+                ? (previous
+                    ? ColumnsInternal.GetPreviousVisibleWritableColumn(CurrentColumn)
+                    : ColumnsInternal.GetNextVisibleWritableColumn(CurrentColumn))
+                : (previous
+                    ? ColumnsInternal.GetPreviousVisibleNonFillerColumn(CurrentColumn)
+                    : ColumnsInternal.GetNextVisibleColumn(CurrentColumn));
+            int targetSlot = CurrentSlot;
+
+            if (targetColumn is DataGridFillerColumn)
+            {
+                targetColumn = null;
+            }
+
+            if (targetColumn == null)
+            {
+                targetSlot = previous ? GetPreviousVisibleSlot(CurrentSlot) : GetNextVisibleSlot(CurrentSlot);
+                while (targetSlot >= 0 && targetSlot < SlotCount && IsGroupSlot(targetSlot))
+                {
+                    targetSlot = previous ? GetPreviousVisibleSlot(targetSlot) : GetNextVisibleSlot(targetSlot);
+                }
+
+                targetColumn = _editingColumnIndex != -1
+                    ? (previous ? ColumnsInternal.LastVisibleWritableColumn : ColumnsInternal.FirstVisibleWritableColumn)
+                    : (previous ? GetLastVisibleNonFillerNavigationColumn() : ColumnsInternal.FirstVisibleNonFillerColumn);
+            }
+
+            return TryCreateNavigationPosition(targetSlot, targetColumn, out target);
+        }
+
+        private int GetPageNavigationSlot(bool forward)
+        {
+            int pageSlot = CurrentSlot == -1 ? DisplayData.FirstScrollingSlot : CurrentSlot;
+            int remaining = DisplayData.NumTotallyDisplayedScrollingElements;
+            int slot = forward ? GetNextVisibleSlot(pageSlot) : GetPreviousVisibleSlot(pageSlot);
+            while (remaining > 0 && slot >= 0 && slot < SlotCount)
+            {
+                pageSlot = slot;
+                remaining--;
+                slot = forward ? GetNextVisibleSlot(slot) : GetPreviousVisibleSlot(slot);
+            }
+
+            return pageSlot;
+        }
+
+        private bool TryCreateNavigationPosition(
+            int slot,
+            DataGridColumn column,
+            out DataGridNavigationPosition target)
+        {
+            target = DataGridNavigationPosition.Unset;
+            if (column == null || !column.IsVisible || column is DataGridFillerColumn ||
+                slot < 0 || slot >= SlotCount || IsGroupSlot(slot) || IsSlotOutOfBounds(slot))
+            {
+                return false;
+            }
+
+            int rowIndex = RowIndexFromSlot(slot);
+            if (rowIndex < 0 || rowIndex >= DataConnection.Count)
+            {
+                return false;
+            }
+
+            target = new DataGridNavigationPosition(rowIndex, column.DisplayIndex);
+            return true;
+        }
+
+        private bool TryApplyNavigationTarget(DataGridNavigationPosition target, KeyModifiers modifiers)
+        {
+            if (!target.IsValid || target.RowIndex >= DataConnection.Count ||
+                target.ColumnDisplayIndex >= ColumnsInternal.DisplayIndexMap.Count)
+            {
+                return false;
+            }
+
+            DataGridColumn column = ColumnsInternal.GetColumnAtDisplayIndex(target.ColumnDisplayIndex);
+            if (column == null || !column.IsVisible || column is DataGridFillerColumn)
+            {
+                return false;
+            }
+
+            int slot = SlotFromRowIndex(target.RowIndex);
+            if (slot < 0 || IsSlotOutOfBounds(slot))
+            {
+                return false;
+            }
+
+            KeyboardHelper.GetMetaKeyState(this, modifiers, out _, out bool shift);
+            DataGridSelectionAction action = shift && SelectionMode == DataGridSelectionMode.Extended
+                ? DataGridSelectionAction.SelectFromAnchorToCurrent
+                : target.RowIndex != RowIndexFromSlot(CurrentSlot) || CurrentColumnIndex == -1
+                    ? DataGridSelectionAction.SelectCurrent
+                    : DataGridSelectionAction.None;
+
+            _noSelectionChangeCount++;
+            try
+            {
+                UpdateSelectionAndCurrency(column.Index, slot, action, scrollIntoView: true);
+            }
+            finally
+            {
+                NoSelectionChangeCount--;
+            }
+
+            return _successfullyUpdatedSelection || CreateNavigationPosition() == target;
+        }
+
+        private DataGridColumn GetLastVisibleNonFillerNavigationColumn()
+        {
+            DataGridColumn column = ColumnsInternal.LastVisibleColumn;
+            while (column is DataGridFillerColumn)
+            {
+                column = ColumnsInternal.GetPreviousVisibleNonFillerColumn(column);
+            }
+
+            return column;
+        }
+
+        private bool CanExecuteNavigationWithoutTarget(DataGridNavigationCommand command) =>
+            command is DataGridNavigationCommand.BeginEdit or
+                DataGridNavigationCommand.CancelEdit or
+                DataGridNavigationCommand.ExpandAll;
+
+        private DataGridNavigationFailureReason ResolveUnavailableNavigationReason()
+        {
+            if (DataConnection == null || DataConnection.Count == 0)
+            {
+                return DataGridNavigationFailureReason.NoRows;
+            }
+
+            if (ColumnsInternal.FirstVisibleNonFillerColumn == null)
+            {
+                return DataGridNavigationFailureReason.NoColumns;
+            }
+
+            return DataGridNavigationFailureReason.NoCurrentCell;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -1403,6 +1403,13 @@ internal
                 (o, v) => o.NavigationModel = v,
                 defaultBindingMode: BindingMode.TwoWay);
 
+        /// <summary>Identifies the <see cref="NavigationInputModel"/> direct property.</summary>
+        public static readonly DirectProperty<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridNavigationInputModel> NavigationInputModelProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridNavigationInputModel>(
+                nameof(NavigationInputModel),
+                o => o.NavigationInputModel,
+                (o, v) => o.NavigationInputModel = v);
+
         /// <summary>
         /// Identifies the <see cref="RouteNavigationModel"/> direct property.
         /// </summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -1419,6 +1419,13 @@ internal
                 o => o.RouteNavigationModel,
                 (o, v) => o.RouteNavigationModel = v);
 
+        /// <summary>Identifies the <see cref="RouteContextFactory"/> direct property.</summary>
+        public static readonly DirectProperty<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridRouteContextFactory> RouteContextFactoryProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridRouteContextFactory>(
+                nameof(RouteContextFactory),
+                o => o.RouteContextFactory,
+                (o, v) => o.RouteContextFactory = v);
+
         /// <summary>
         /// Gets or sets the hierarchical model that drives tree-like rows. If not provided, a default
         /// hierarchical model is created.

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Properties.cs
@@ -1394,6 +1394,25 @@ internal
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
+        /// Gets or sets the model that resolves keyboard and programmatic navigation policy.
+        /// </summary>
+        public static readonly DirectProperty<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel> NavigationModelProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel>(
+                nameof(NavigationModel),
+                o => o.NavigationModel,
+                (o, v) => o.NavigationModel = v,
+                defaultBindingMode: BindingMode.TwoWay);
+
+        /// <summary>
+        /// Identifies the <see cref="RouteNavigationModel"/> direct property.
+        /// </summary>
+        public static readonly DirectProperty<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridRouteNavigationModel> RouteNavigationModelProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, Avalonia.Controls.DataGridNavigation.IDataGridRouteNavigationModel>(
+                nameof(RouteNavigationModel),
+                o => o.RouteNavigationModel,
+                (o, v) => o.RouteNavigationModel = v);
+
+        /// <summary>
         /// Gets or sets the hierarchical model that drives tree-like rows. If not provided, a default
         /// hierarchical model is created.
         /// </summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+
+namespace Avalonia.Controls
+{
+    partial class DataGrid
+    {
+        /// <summary>
+        /// Creates a framework-neutral route context for the current cell.
+        /// </summary>
+        /// <param name="origin">The route activation source.</param>
+        /// <returns>
+        /// A context containing the current item, stable column key, and position, or an empty
+        /// context when no data cell is current.
+        /// </returns>
+        public DataGridRouteContext GetCurrentRouteContext(DataGridRouteNavigationOrigin origin)
+        {
+            DataGridCellInfo cell = CurrentCell;
+            if (!cell.IsValid)
+            {
+                return new DataGridRouteContext(
+                    null,
+                    null,
+                    null,
+                    DataGridNavigationPosition.Unset,
+                    origin,
+                    hasItem: false);
+            }
+
+            object columnKey = cell.Column.ColumnKey;
+            if (columnKey == null && !string.IsNullOrWhiteSpace(cell.Column.SortMemberPath))
+            {
+                columnKey = cell.Column.SortMemberPath;
+            }
+
+            return new DataGridRouteContext(
+                cell.Item,
+                null,
+                columnKey,
+                new DataGridNavigationPosition(cell.RowIndex, cell.Column.DisplayIndex),
+                origin);
+        }
+
+        /// <summary>
+        /// Resolves and executes an application-route operation for the current cell.
+        /// </summary>
+        /// <param name="kind">The route or history operation.</param>
+        /// <param name="origin">The route activation source.</param>
+        /// <param name="cancellationToken">Cancels navigation or a route guard.</param>
+        /// <returns>A typed non-throwing route result.</returns>
+        public ValueTask<DataGridRouteNavigationResult> NavigateRouteAsync(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteNavigationOrigin origin = DataGridRouteNavigationOrigin.Programmatic,
+            CancellationToken cancellationToken = default)
+        {
+            IDataGridRouteNavigationModel model = RouteNavigationModel;
+            if (model == null)
+            {
+                return ValueTask.FromResult(DataGridRouteNavigationResult.FromStatus(
+                    DataGridRouteNavigationStatus.NotSupported));
+            }
+
+            DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or
+                DataGridRouteNavigationKind.Forward
+                    ? DataGridRouteContext.Empty
+                    : GetCurrentRouteContext(origin);
+            return model.NavigateAsync(kind, context, cancellationToken);
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
@@ -68,7 +68,13 @@ namespace Avalonia.Controls
 
             DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or
                 DataGridRouteNavigationKind.Forward
-                    ? DataGridRouteContext.Empty
+                    ? new DataGridRouteContext(
+                        null,
+                        null,
+                        null,
+                        DataGridNavigationPosition.Unset,
+                        origin,
+                        hasItem: false)
                     : GetCurrentRouteContext(origin);
             return model.NavigateAsync(kind, context, cancellationToken);
         }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.RouteNavigation.cs
@@ -33,18 +33,55 @@ namespace Avalonia.Controls
                     hasItem: false);
             }
 
-            object columnKey = cell.Column.ColumnKey;
-            if (columnKey == null && !string.IsNullOrWhiteSpace(cell.Column.SortMemberPath))
-            {
-                columnKey = cell.Column.SortMemberPath;
-            }
-
-            return new DataGridRouteContext(
-                cell.Item,
-                null,
-                columnKey,
+            return GetRouteContext(
                 new DataGridNavigationPosition(cell.RowIndex, cell.Column.DisplayIndex),
                 origin);
+        }
+
+        /// <summary>Creates a framework-neutral route context for an explicit data-cell position.</summary>
+        /// <param name="position">The collection-view row and display-column indexes.</param>
+        /// <param name="origin">The route activation source.</param>
+        /// <returns>A context for the requested cell, or an empty context when it is invalid.</returns>
+        public DataGridRouteContext GetRouteContext(
+            DataGridNavigationPosition position,
+            DataGridRouteNavigationOrigin origin)
+        {
+            if (!position.IsValid || DataConnection == null ||
+                position.RowIndex >= DataConnection.Count ||
+                position.ColumnDisplayIndex >= ColumnsInternal.DisplayIndexMap.Count)
+            {
+                return new DataGridRouteContext(
+                    null,
+                    null,
+                    null,
+                    DataGridNavigationPosition.Unset,
+                    origin,
+                    hasItem: false);
+            }
+
+            DataGridColumn column = ColumnsInternal.GetColumnAtDisplayIndex(position.ColumnDisplayIndex);
+            if (column == null || column is DataGridFillerColumn || !column.IsVisible)
+            {
+                return new DataGridRouteContext(
+                    null,
+                    null,
+                    null,
+                    DataGridNavigationPosition.Unset,
+                    origin,
+                    hasItem: false);
+            }
+
+            object item = DataConnection.GetDataItem(position.RowIndex);
+            object columnKey = column.ColumnKey;
+            if (columnKey == null && !string.IsNullOrWhiteSpace(column.SortMemberPath))
+            {
+                columnKey = column.SortMemberPath;
+            }
+
+            IDataGridRouteContextFactory factory = RouteContextFactory;
+            return factory != null
+                ? factory.Create(item, columnKey, position, origin)
+                : new DataGridRouteContext(item, null, columnKey, position, origin);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -18,6 +18,7 @@ using Avalonia.Controls.DataGridConditionalFormatting;
 using Avalonia.Controls.DataGridClipboard;
 using Avalonia.Controls.DataGridEditing;
 using Avalonia.Controls.DataGridInteractions;
+using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Controls.DataGridHierarchical;
 using Avalonia.Controls.DataGridDragDrop;
 using Avalonia.Input;
@@ -341,6 +342,9 @@ internal
         private Avalonia.Controls.DataGridClipboard.IDataGridClipboardImportModelFactory _clipboardImportModelFactory;
         private Avalonia.Controls.DataGridEditing.IDataGridEditingInteractionModel _editingInteractionModel;
         private Avalonia.Controls.DataGridEditing.IDataGridEditingInteractionModelFactory _editingInteractionModelFactory;
+        private IDataGridNavigationModel _navigationModel;
+        private IDataGridNavigationModelFactory _navigationModelFactory;
+        private IDataGridRouteNavigationModel _routeNavigationModel;
         private readonly Dictionary<SearchCellKey, SearchResult> _searchResultsMap = new();
         private readonly HashSet<int> _searchRowMatches = new();
         private SearchCellKey? _currentSearchCell;
@@ -647,6 +651,7 @@ internal
             SetRangeInteractionModel(CreateRangeInteractionModel());
             SetClipboardImportModel(CreateClipboardImportModel());
             SetEditingInteractionModel(CreateEditingInteractionModel());
+            SetNavigationModel(CreateNavigationModel());
 
             AnchorSlot = -1;
             _lastEstimatedRow = -1;
@@ -2134,6 +2139,15 @@ internal
         }
 
         /// <summary>
+        /// Creates the default navigation model for the grid. Override or set
+        /// <see cref="NavigationModelFactory"/> before construction completes to supply a custom implementation.
+        /// </summary>
+        protected virtual IDataGridNavigationModel CreateNavigationModel()
+        {
+            return _navigationModelFactory?.Create() ?? new DataGridNavigationModel();
+        }
+
+        /// <summary>
         /// Optional factory used when creating the default sorting model.
         /// </summary>
         public IDataGridSortingModelFactory SortingModelFactory
@@ -2203,6 +2217,15 @@ internal
         {
             get => _editingInteractionModelFactory;
             set => _editingInteractionModelFactory = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the optional factory used to create the default navigation model.
+        /// </summary>
+        public IDataGridNavigationModelFactory NavigationModelFactory
+        {
+            get => _navigationModelFactory;
+            set => _navigationModelFactory = value;
         }
 
         /// <summary>
@@ -2540,6 +2563,38 @@ internal
         {
             get => _editingInteractionModel;
             set => SetEditingInteractionModel(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the model that resolves keyboard and programmatic navigation policy.
+        /// </summary>
+        public IDataGridNavigationModel NavigationModel
+        {
+            get => _navigationModel;
+            set => SetNavigationModel(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the optional framework-neutral application-route model associated with this grid.
+        /// </summary>
+        /// <remarks>
+        /// The model can be shared with a ViewModel command. The grid does not require ReactiveUI,
+        /// Prism, CommunityToolkit.Mvvm, or another navigation framework.
+        /// </remarks>
+        public IDataGridRouteNavigationModel RouteNavigationModel
+        {
+            get => _routeNavigationModel;
+            set
+            {
+                if (ReferenceEquals(_routeNavigationModel, value))
+                {
+                    return;
+                }
+
+                IDataGridRouteNavigationModel oldModel = _routeNavigationModel;
+                _routeNavigationModel = value;
+                RaisePropertyChanged(RouteNavigationModelProperty, oldModel, value);
+            }
         }
 
         /// <summary>
@@ -5716,6 +5771,20 @@ internal
 
             _editingInteractionModel = newModel;
             RaisePropertyChanged(EditingInteractionModelProperty, oldModel, _editingInteractionModel);
+        }
+
+        private void SetNavigationModel(IDataGridNavigationModel model)
+        {
+            IDataGridNavigationModel oldModel = _navigationModel;
+            IDataGridNavigationModel newModel = model ?? CreateNavigationModel();
+
+            if (ReferenceEquals(oldModel, newModel))
+            {
+                return;
+            }
+
+            _navigationModel = newModel;
+            RaisePropertyChanged(NavigationModelProperty, oldModel, _navigationModel);
         }
 
         private void FilteringModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -5783,8 +5783,36 @@ internal
                 return;
             }
 
+            if (oldModel is IDataGridNavigationController oldController)
+            {
+                WeakEventHandlerManager.Unsubscribe<DataGridNavigationRequestedEventArgs, DataGrid>(
+                    oldController,
+                    nameof(IDataGridNavigationController.NavigationRequested),
+                    NavigationController_NavigationRequested);
+            }
+
             _navigationModel = newModel;
+            if (newModel is IDataGridNavigationController newController)
+            {
+                WeakEventHandlerManager.Subscribe<IDataGridNavigationController, DataGridNavigationRequestedEventArgs, DataGrid>(
+                    newController,
+                    nameof(IDataGridNavigationController.NavigationRequested),
+                    NavigationController_NavigationRequested);
+            }
+
             RaisePropertyChanged(NavigationModelProperty, oldModel, _navigationModel);
+        }
+
+        private void NavigationController_NavigationRequested(
+            object sender,
+            DataGridNavigationRequestedEventArgs e)
+        {
+            e.Handled = ProcessNavigationCommand(
+                e.Command,
+                null,
+                e.Origin,
+                e.Modifiers,
+                allowCtrlForTab: false);
         }
 
         private void FilteringModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -346,6 +346,7 @@ internal
         private IDataGridNavigationModelFactory _navigationModelFactory;
         private IDataGridNavigationInputModel _navigationInputModel;
         private IDataGridRouteNavigationModel _routeNavigationModel;
+        private IDataGridRouteContextFactory _routeContextFactory;
         private readonly Dictionary<SearchCellKey, SearchResult> _searchResultsMap = new();
         private readonly HashSet<int> _searchRowMatches = new();
         private SearchCellKey? _currentSearchCell;
@@ -2617,9 +2618,26 @@ internal
                     return;
                 }
 
-                IDataGridRouteNavigationModel oldModel = _routeNavigationModel;
-                _routeNavigationModel = value;
-                RaisePropertyChanged(RouteNavigationModelProperty, oldModel, value);
+                SetRouteNavigationModel(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the optional factory that enriches route contexts with stable item keys.
+        /// </summary>
+        public IDataGridRouteContextFactory RouteContextFactory
+        {
+            get => _routeContextFactory;
+            set
+            {
+                if (ReferenceEquals(_routeContextFactory, value))
+                {
+                    return;
+                }
+
+                IDataGridRouteContextFactory oldFactory = _routeContextFactory;
+                _routeContextFactory = value;
+                RaisePropertyChanged(RouteContextFactoryProperty, oldFactory, value);
             }
         }
 
@@ -5839,6 +5857,61 @@ internal
                 e.Origin,
                 e.Modifiers,
                 allowCtrlForTab: false);
+        }
+
+        private void SetRouteNavigationModel(IDataGridRouteNavigationModel model)
+        {
+            IDataGridRouteNavigationModel oldModel = _routeNavigationModel;
+            if (ReferenceEquals(oldModel, model))
+            {
+                return;
+            }
+
+            if (oldModel is IDataGridRouteNavigationController oldController)
+            {
+                WeakEventHandlerManager.Unsubscribe<DataGridRouteNavigationRequestedEventArgs, DataGrid>(
+                    oldController,
+                    nameof(IDataGridRouteNavigationController.NavigationRequested),
+                    RouteNavigationController_NavigationRequested);
+            }
+
+            _routeNavigationModel = model;
+            if (model is IDataGridRouteNavigationController newController)
+            {
+                WeakEventHandlerManager.Subscribe<IDataGridRouteNavigationController, DataGridRouteNavigationRequestedEventArgs, DataGrid>(
+                    newController,
+                    nameof(IDataGridRouteNavigationController.NavigationRequested),
+                    RouteNavigationController_NavigationRequested);
+            }
+
+            RaisePropertyChanged(RouteNavigationModelProperty, oldModel, _routeNavigationModel);
+        }
+
+        private void RouteNavigationController_NavigationRequested(
+            object sender,
+            DataGridRouteNavigationRequestedEventArgs e)
+        {
+            if (e.Handled || _routeNavigationModel == null)
+            {
+                return;
+            }
+
+            DataGridRouteContext context = e.Kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward
+                ? new DataGridRouteContext(
+                    null,
+                    null,
+                    null,
+                    DataGridNavigationPosition.Unset,
+                    e.Origin,
+                    hasItem: false)
+                : GetCurrentRouteContext(e.Origin);
+            if (!_routeNavigationModel.CanNavigate(e.Kind, context))
+            {
+                return;
+            }
+
+            e.Handled = true;
+            _ = _routeNavigationModel.NavigateAsync(e.Kind, context);
         }
 
         private void FilteringModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -344,6 +344,7 @@ internal
         private Avalonia.Controls.DataGridEditing.IDataGridEditingInteractionModelFactory _editingInteractionModelFactory;
         private IDataGridNavigationModel _navigationModel;
         private IDataGridNavigationModelFactory _navigationModelFactory;
+        private IDataGridNavigationInputModel _navigationInputModel;
         private IDataGridRouteNavigationModel _routeNavigationModel;
         private readonly Dictionary<SearchCellKey, SearchResult> _searchResultsMap = new();
         private readonly HashSet<int> _searchRowMatches = new();
@@ -606,6 +607,11 @@ internal
             AddHandler(InputElement.PointerMovedEvent, DataGrid_PointerActivity, RoutingStrategies.Tunnel, handledEventsToo: true);
             AddHandler(InputElement.PointerPressedEvent, DataGrid_PointerActivity, RoutingStrategies.Tunnel, handledEventsToo: true);
             AddHandler(InputElement.PointerReleasedEvent, DataGrid_PointerActivity, RoutingStrategies.Tunnel, handledEventsToo: true);
+            AddHandler(InputElement.KeyDownEvent, DataGrid_NavigationKeyDown, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.KeyUpEvent, DataGrid_NavigationKeyUp, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerPressedEvent, DataGrid_NavigationPointerPressed, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerReleasedEvent, DataGrid_NavigationPointerReleased, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerWheelChangedEvent, DataGrid_NavigationPointerWheel, RoutingStrategies.Tunnel);
             AddHandler(InputElement.PointerExitedEvent, DataGrid_PointerExited, handledEventsToo: true);
             AddHandler(InputElement.PointerMovedEvent, DataGrid_DragSelectionPointerMoved, RoutingStrategies.Tunnel, handledEventsToo: true);
             AddHandler(InputElement.PointerReleasedEvent, DataGrid_DragSelectionPointerReleased, RoutingStrategies.Tunnel, handledEventsToo: true);
@@ -2572,6 +2578,26 @@ internal
         {
             get => _navigationModel;
             set => SetNavigationModel(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the optional framework-neutral model that maps normalized key and pointer
+        /// input to cell or application-route navigation.
+        /// </summary>
+        public IDataGridNavigationInputModel NavigationInputModel
+        {
+            get => _navigationInputModel;
+            set
+            {
+                if (ReferenceEquals(_navigationInputModel, value))
+                {
+                    return;
+                }
+
+                IDataGridNavigationInputModel oldModel = _navigationInputModel;
+                _navigationInputModel = value;
+                RaisePropertyChanged(NavigationInputModelProperty, oldModel, value);
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationInput.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationInput.cs
@@ -1,0 +1,782 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System;
+
+namespace Avalonia.Controls.DataGridNavigation
+{
+    /// <summary>Identifies a normalized input event independently of a UI framework.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationInputKind
+    {
+        /// <summary>A key was pressed.</summary>
+        KeyDown,
+        /// <summary>A key was released.</summary>
+        KeyUp,
+        /// <summary>A pointer button was pressed.</summary>
+        PointerPressed,
+        /// <summary>A pointer button was released.</summary>
+        PointerReleased,
+        /// <summary>A pointer wheel changed.</summary>
+        PointerWheel
+    }
+
+    /// <summary>Identifies a stable logical key used by a navigation input model.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationInputKey
+    {
+        /// <summary>No key.</summary>
+        None,
+        /// <summary>A platform key without a normalized representation.</summary>
+        Unknown,
+        /// <summary>The Up Arrow key.</summary>
+        Up,
+        /// <summary>The Down Arrow key.</summary>
+        Down,
+        /// <summary>The Left Arrow key.</summary>
+        Left,
+        /// <summary>The Right Arrow key.</summary>
+        Right,
+        /// <summary>The Page Up key.</summary>
+        PageUp,
+        /// <summary>The Page Down key.</summary>
+        PageDown,
+        /// <summary>The Home key.</summary>
+        Home,
+        /// <summary>The End key.</summary>
+        End,
+        /// <summary>The Tab key.</summary>
+        Tab,
+        /// <summary>The Enter or Return key.</summary>
+        Enter,
+        /// <summary>The Escape key.</summary>
+        Escape,
+        /// <summary>The Space key.</summary>
+        Space,
+        /// <summary>The Backspace key.</summary>
+        Backspace,
+        /// <summary>The Insert key.</summary>
+        Insert,
+        /// <summary>The Delete key.</summary>
+        Delete,
+        /// <summary>The add or plus key.</summary>
+        Add,
+        /// <summary>The subtract or minus key.</summary>
+        Subtract,
+        /// <summary>The multiply key.</summary>
+        Multiply,
+        /// <summary>The divide key.</summary>
+        Divide,
+        /// <summary>The decimal-point key.</summary>
+        Decimal,
+        /// <summary>The browser-history Back key.</summary>
+        BrowserBack,
+        /// <summary>The browser-history Forward key.</summary>
+        BrowserForward,
+        /// <summary>The A key.</summary>
+        A,
+        /// <summary>The B key.</summary>
+        B,
+        /// <summary>The C key.</summary>
+        C,
+        /// <summary>The D key.</summary>
+        D,
+        /// <summary>The E key.</summary>
+        E,
+        /// <summary>The F key.</summary>
+        F,
+        /// <summary>The G key.</summary>
+        G,
+        /// <summary>The H key.</summary>
+        H,
+        /// <summary>The I key.</summary>
+        I,
+        /// <summary>The J key.</summary>
+        J,
+        /// <summary>The K key.</summary>
+        K,
+        /// <summary>The L key.</summary>
+        L,
+        /// <summary>The M key.</summary>
+        M,
+        /// <summary>The N key.</summary>
+        N,
+        /// <summary>The O key.</summary>
+        O,
+        /// <summary>The P key.</summary>
+        P,
+        /// <summary>The Q key.</summary>
+        Q,
+        /// <summary>The R key.</summary>
+        R,
+        /// <summary>The S key.</summary>
+        S,
+        /// <summary>The T key.</summary>
+        T,
+        /// <summary>The U key.</summary>
+        U,
+        /// <summary>The V key.</summary>
+        V,
+        /// <summary>The W key.</summary>
+        W,
+        /// <summary>The X key.</summary>
+        X,
+        /// <summary>The Y key.</summary>
+        Y,
+        /// <summary>The Z key.</summary>
+        Z,
+        /// <summary>The 0 digit key.</summary>
+        D0,
+        /// <summary>The 1 digit key.</summary>
+        D1,
+        /// <summary>The 2 digit key.</summary>
+        D2,
+        /// <summary>The 3 digit key.</summary>
+        D3,
+        /// <summary>The 4 digit key.</summary>
+        D4,
+        /// <summary>The 5 digit key.</summary>
+        D5,
+        /// <summary>The 6 digit key.</summary>
+        D6,
+        /// <summary>The 7 digit key.</summary>
+        D7,
+        /// <summary>The 8 digit key.</summary>
+        D8,
+        /// <summary>The 9 digit key.</summary>
+        D9,
+        /// <summary>The F1 function key.</summary>
+        F1,
+        /// <summary>The F2 function key.</summary>
+        F2,
+        /// <summary>The F3 function key.</summary>
+        F3,
+        /// <summary>The F4 function key.</summary>
+        F4,
+        /// <summary>The F5 function key.</summary>
+        F5,
+        /// <summary>The F6 function key.</summary>
+        F6,
+        /// <summary>The F7 function key.</summary>
+        F7,
+        /// <summary>The F8 function key.</summary>
+        F8,
+        /// <summary>The F9 function key.</summary>
+        F9,
+        /// <summary>The F10 function key.</summary>
+        F10,
+        /// <summary>The F11 function key.</summary>
+        F11,
+        /// <summary>The F12 function key.</summary>
+        F12
+    }
+
+    /// <summary>Identifies the normalized device that produced a key event.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationKeyDeviceKind
+    {
+        /// <summary>A keyboard produced the event.</summary>
+        Keyboard,
+        /// <summary>A gamepad produced the event.</summary>
+        Gamepad,
+        /// <summary>A remote-control device produced the event.</summary>
+        Remote,
+        /// <summary>The input system did not identify the key device.</summary>
+        Unknown
+    }
+
+    /// <summary>Identifies normalized input modifiers.</summary>
+    [Flags]
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationInputModifiers
+    {
+        /// <summary>No modifier is active.</summary>
+        None = 0,
+        /// <summary>The Shift modifier is active.</summary>
+        Shift = 1 << 0,
+        /// <summary>The Control modifier is active.</summary>
+        Control = 1 << 1,
+        /// <summary>The Alt modifier is active.</summary>
+        Alt = 1 << 2,
+        /// <summary>The platform Meta or Command modifier is active.</summary>
+        Meta = 1 << 3
+    }
+
+    /// <summary>Identifies the normalized pointer device family.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationPointerDeviceKind
+    {
+        /// <summary>The pointer device is unknown.</summary>
+        Unknown,
+        /// <summary>A mouse produced the event.</summary>
+        Mouse,
+        /// <summary>A pen produced the event.</summary>
+        Pen,
+        /// <summary>A touch contact produced the event.</summary>
+        Touch
+    }
+
+    /// <summary>Identifies a normalized pointer button.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationPointerButton
+    {
+        /// <summary>No pointer button applies.</summary>
+        None,
+        /// <summary>The primary pointer button.</summary>
+        Primary,
+        /// <summary>The secondary pointer button.</summary>
+        Secondary,
+        /// <summary>The middle pointer button.</summary>
+        Middle,
+        /// <summary>The first extended pointer button.</summary>
+        XButton1,
+        /// <summary>The second extended pointer button.</summary>
+        XButton2
+    }
+
+    /// <summary>Identifies pointer-wheel movement for input matching.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationWheelDirection
+    {
+        /// <summary>No wheel movement applies.</summary>
+        None,
+        /// <summary>The wheel moved upward.</summary>
+        Up,
+        /// <summary>The wheel moved downward.</summary>
+        Down,
+        /// <summary>The wheel moved left.</summary>
+        Left,
+        /// <summary>The wheel moved right.</summary>
+        Right
+    }
+
+    /// <summary>Identifies the semantic grid target under an input event.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationInputTargetKind
+    {
+        /// <summary>Matches every target kind in a binding.</summary>
+        Any,
+        /// <summary>The grid background or root.</summary>
+        Grid,
+        /// <summary>A data cell.</summary>
+        Cell,
+        /// <summary>A data row outside a cell.</summary>
+        Row,
+        /// <summary>A row header.</summary>
+        RowHeader,
+        /// <summary>A column header.</summary>
+        ColumnHeader,
+        /// <summary>A row-group header.</summary>
+        GroupHeader,
+        /// <summary>No semantic grid target was found.</summary>
+        Empty
+    }
+
+    /// <summary>Describes normalized key or pointer input without routed-event or visual-tree objects.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationInputRequest
+    {
+        /// <summary>Initializes a complete normalized input request.</summary>
+        /// <param name="kind">The normalized event kind.</param>
+        /// <param name="key">The logical key, or <see cref="DataGridNavigationInputKey.None"/> for pointer input.</param>
+        /// <param name="physicalKey">The layout-independent physical key, when available.</param>
+        /// <param name="keyDevice">The device family for key input.</param>
+        /// <param name="modifiers">The active normalized modifiers.</param>
+        /// <param name="pointerDevice">The pointer device family.</param>
+        /// <param name="pointerButton">The pointer button involved in the event.</param>
+        /// <param name="wheelDirection">The dominant pointer-wheel direction.</param>
+        /// <param name="clickCount">The pointer click count, or zero when not applicable.</param>
+        /// <param name="x">The pointer X coordinate relative to the grid, or <see cref="double.NaN"/> for key input.</param>
+        /// <param name="y">The pointer Y coordinate relative to the grid, or <see cref="double.NaN"/> for key input.</param>
+        /// <param name="wheelDeltaX">The horizontal wheel delta.</param>
+        /// <param name="wheelDeltaY">The vertical wheel delta.</param>
+        /// <param name="targetKind">The semantic target under the event source.</param>
+        /// <param name="targetPosition">The target data-cell position, when one can be resolved.</param>
+        /// <param name="currentPosition">The current data-cell position.</param>
+        /// <param name="isEditing">Whether the grid is editing a cell.</param>
+        public DataGridNavigationInputRequest(
+            DataGridNavigationInputKind kind,
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputKey physicalKey,
+            DataGridNavigationKeyDeviceKind keyDevice,
+            DataGridNavigationInputModifiers modifiers,
+            DataGridNavigationPointerDeviceKind pointerDevice,
+            DataGridNavigationPointerButton pointerButton,
+            DataGridNavigationWheelDirection wheelDirection,
+            int clickCount,
+            double x,
+            double y,
+            double wheelDeltaX,
+            double wheelDeltaY,
+            DataGridNavigationInputTargetKind targetKind,
+            DataGridNavigationPosition targetPosition,
+            DataGridNavigationPosition currentPosition,
+            bool isEditing)
+        {
+            Kind = kind;
+            Key = key;
+            PhysicalKey = physicalKey;
+            KeyDevice = keyDevice;
+            Modifiers = modifiers;
+            PointerDevice = pointerDevice;
+            PointerButton = pointerButton;
+            WheelDirection = wheelDirection;
+            ClickCount = clickCount;
+            X = x;
+            Y = y;
+            WheelDeltaX = wheelDeltaX;
+            WheelDeltaY = wheelDeltaY;
+            TargetKind = targetKind;
+            TargetPosition = targetPosition;
+            CurrentPosition = currentPosition;
+            IsEditing = isEditing;
+        }
+
+        /// <summary>Gets the normalized event kind.</summary>
+        public DataGridNavigationInputKind Kind { get; }
+        /// <summary>Gets the normalized logical key.</summary>
+        public DataGridNavigationInputKey Key { get; }
+        /// <summary>Gets the normalized layout-independent physical key.</summary>
+        public DataGridNavigationInputKey PhysicalKey { get; }
+        /// <summary>Gets the normalized key-device family.</summary>
+        public DataGridNavigationKeyDeviceKind KeyDevice { get; }
+        /// <summary>Gets the active modifiers.</summary>
+        public DataGridNavigationInputModifiers Modifiers { get; }
+        /// <summary>Gets the pointer-device family.</summary>
+        public DataGridNavigationPointerDeviceKind PointerDevice { get; }
+        /// <summary>Gets the pointer button involved in the event.</summary>
+        public DataGridNavigationPointerButton PointerButton { get; }
+        /// <summary>Gets the dominant wheel direction.</summary>
+        public DataGridNavigationWheelDirection WheelDirection { get; }
+        /// <summary>Gets the pointer click count.</summary>
+        public int ClickCount { get; }
+        /// <summary>Gets the pointer X coordinate relative to the grid.</summary>
+        public double X { get; }
+        /// <summary>Gets the pointer Y coordinate relative to the grid.</summary>
+        public double Y { get; }
+        /// <summary>Gets the horizontal pointer-wheel delta.</summary>
+        public double WheelDeltaX { get; }
+        /// <summary>Gets the vertical pointer-wheel delta.</summary>
+        public double WheelDeltaY { get; }
+        /// <summary>Gets the semantic target kind.</summary>
+        public DataGridNavigationInputTargetKind TargetKind { get; }
+        /// <summary>Gets the data-cell target under the event, when available.</summary>
+        public DataGridNavigationPosition TargetPosition { get; }
+        /// <summary>Gets the current data-cell position.</summary>
+        public DataGridNavigationPosition CurrentPosition { get; }
+        /// <summary>Gets whether the grid is editing a cell.</summary>
+        public bool IsEditing { get; }
+    }
+
+    /// <summary>Identifies how a navigation input result is executed.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationInputDecision
+    {
+        /// <summary>Leaves the event available to controls and built-in grid input.</summary>
+        Ignore,
+        /// <summary>Consumes the event without navigating.</summary>
+        Handle,
+        /// <summary>Executes a semantic cell-navigation command.</summary>
+        Navigate,
+        /// <summary>Navigates to the cell or row resolved under the event source.</summary>
+        NavigateToTarget,
+        /// <summary>Navigates to an explicit data-cell position.</summary>
+        NavigateToPosition,
+        /// <summary>Executes an application-route operation.</summary>
+        NavigateRoute
+    }
+
+    /// <summary>Contains the framework-neutral result of resolving normalized input.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationInputResult
+    {
+        private DataGridNavigationInputResult(
+            DataGridNavigationInputDecision decision,
+            DataGridNavigationCommand command,
+            DataGridNavigationPosition target,
+            DataGridRouteNavigationKind routeKind,
+            bool consumeWhenNavigationFails)
+        {
+            Decision = decision;
+            Command = command;
+            Target = target;
+            RouteKind = routeKind;
+            ConsumeWhenNavigationFails = consumeWhenNavigationFails;
+        }
+
+        /// <summary>Gets how the resolved input is executed.</summary>
+        public DataGridNavigationInputDecision Decision { get; }
+        /// <summary>Gets the semantic cell-navigation command.</summary>
+        public DataGridNavigationCommand Command { get; }
+        /// <summary>Gets the explicit cell target.</summary>
+        public DataGridNavigationPosition Target { get; }
+        /// <summary>Gets the application-route operation.</summary>
+        public DataGridRouteNavigationKind RouteKind { get; }
+        /// <summary>Gets whether the routed input is consumed when navigation cannot be completed.</summary>
+        public bool ConsumeWhenNavigationFails { get; }
+
+        /// <summary>Creates a result that preserves existing input processing.</summary>
+        public static DataGridNavigationInputResult Ignore() => default;
+        /// <summary>Creates a result that consumes input without navigating.</summary>
+        public static DataGridNavigationInputResult Handle() =>
+            new(DataGridNavigationInputDecision.Handle, DataGridNavigationCommand.None, default, default, true);
+        /// <summary>Creates a semantic cell-navigation result.</summary>
+        /// <param name="command">The semantic command to execute.</param>
+        /// <param name="consumeWhenNavigationFails">Whether to consume input if the command cannot be completed.</param>
+        public static DataGridNavigationInputResult Navigate(
+            DataGridNavigationCommand command,
+            bool consumeWhenNavigationFails = false) =>
+            new(DataGridNavigationInputDecision.Navigate, command, default, default, consumeWhenNavigationFails);
+        /// <summary>Creates a result that navigates to the event's resolved cell or row target.</summary>
+        /// <param name="consumeWhenNavigationFails">Whether to consume input if the target cannot be activated.</param>
+        public static DataGridNavigationInputResult NavigateToTarget(bool consumeWhenNavigationFails = false) =>
+            new(DataGridNavigationInputDecision.NavigateToTarget, DataGridNavigationCommand.None, default, default, consumeWhenNavigationFails);
+        /// <summary>Creates an explicit cell-target result.</summary>
+        /// <param name="target">The target row and column display indexes.</param>
+        /// <param name="consumeWhenNavigationFails">Whether to consume input if the target cannot be activated.</param>
+        public static DataGridNavigationInputResult NavigateTo(
+            DataGridNavigationPosition target,
+            bool consumeWhenNavigationFails = false) =>
+            new(DataGridNavigationInputDecision.NavigateToPosition, DataGridNavigationCommand.None, target, default, consumeWhenNavigationFails);
+        /// <summary>Creates an application-route navigation result.</summary>
+        /// <param name="kind">The route operation to execute.</param>
+        /// <param name="consumeWhenNavigationFails">Whether to consume input if route navigation cannot start.</param>
+        public static DataGridNavigationInputResult NavigateRoute(
+            DataGridRouteNavigationKind kind,
+            bool consumeWhenNavigationFails = false) =>
+            new(DataGridNavigationInputDecision.NavigateRoute, DataGridNavigationCommand.None, default, kind, consumeWhenNavigationFails);
+    }
+
+    /// <summary>Resolves normalized input into cell or application-route navigation.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationInputModel
+    {
+        /// <summary>Resolves normalized key or pointer input into a navigation decision.</summary>
+        /// <param name="request">The immutable, framework-neutral input context.</param>
+        /// <returns>The decision to execute.</returns>
+        DataGridNavigationInputResult Resolve(in DataGridNavigationInputRequest request);
+    }
+
+    /// <summary>Provides mutable framework-neutral preview data for a resolved input request.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridNavigationInputResolvingEventArgs : EventArgs
+    {
+        /// <summary>Initializes resolving event data.</summary>
+        /// <param name="request">The normalized input request.</param>
+        /// <param name="result">The binding table's initial result.</param>
+        public DataGridNavigationInputResolvingEventArgs(
+            DataGridNavigationInputRequest request,
+            DataGridNavigationInputResult result)
+        {
+            Request = request;
+            Result = result;
+        }
+
+        /// <summary>Gets the normalized input request.</summary>
+        public DataGridNavigationInputRequest Request { get; }
+        /// <summary>Gets or sets the decision that the grid will execute.</summary>
+        public DataGridNavigationInputResult Result { get; set; }
+    }
+
+    /// <summary>Defines an immutable normalized input binding.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationInputBinding
+    {
+        private DataGridNavigationInputBinding(
+            DataGridNavigationInputKind kind,
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputKey physicalKey,
+            DataGridNavigationPointerButton pointerButton,
+            DataGridNavigationWheelDirection wheelDirection,
+            DataGridNavigationInputModifiers modifiers,
+            bool exactModifiers,
+            int clickCount,
+            DataGridNavigationInputTargetKind targetKind,
+            DataGridNavigationInputResult result)
+        {
+            Kind = kind;
+            Key = key;
+            PhysicalKey = physicalKey;
+            PointerButton = pointerButton;
+            WheelDirection = wheelDirection;
+            Modifiers = modifiers;
+            ExactModifiers = exactModifiers;
+            ClickCount = clickCount;
+            TargetKind = targetKind;
+            Result = result;
+        }
+
+        /// <summary>Gets the event kind matched by the binding.</summary>
+        public DataGridNavigationInputKind Kind { get; }
+        /// <summary>Gets the logical key matched by the binding.</summary>
+        public DataGridNavigationInputKey Key { get; }
+        /// <summary>Gets the layout-independent physical key matched by the binding.</summary>
+        public DataGridNavigationInputKey PhysicalKey { get; }
+        /// <summary>Gets the pointer button matched by the binding.</summary>
+        public DataGridNavigationPointerButton PointerButton { get; }
+        /// <summary>Gets the wheel direction matched by the binding.</summary>
+        public DataGridNavigationWheelDirection WheelDirection { get; }
+        /// <summary>Gets the required modifiers.</summary>
+        public DataGridNavigationInputModifiers Modifiers { get; }
+        /// <summary>Gets whether modifiers must match exactly instead of containing the required flags.</summary>
+        public bool ExactModifiers { get; }
+        /// <summary>Gets the required click count, or zero to match every count.</summary>
+        public int ClickCount { get; }
+        /// <summary>Gets the required semantic target, or <see cref="DataGridNavigationInputTargetKind.Any"/>.</summary>
+        public DataGridNavigationInputTargetKind TargetKind { get; }
+        /// <summary>Gets the result returned when the binding matches.</summary>
+        public DataGridNavigationInputResult Result { get; }
+
+        /// <summary>Creates a key-down binding.</summary>
+        /// <param name="key">The logical key to match.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        public static DataGridNavigationInputBinding KeyDown(
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputResult result,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false) =>
+            new(DataGridNavigationInputKind.KeyDown, key, default, default, default, modifiers, exactModifiers, 0,
+                DataGridNavigationInputTargetKind.Any, result);
+
+        /// <summary>Creates a layout-independent physical key-down binding.</summary>
+        /// <param name="key">The normalized physical key to match.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        public static DataGridNavigationInputBinding PhysicalKeyDown(
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputResult result,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false) =>
+            new(DataGridNavigationInputKind.KeyDown, default, key, default, default, modifiers, exactModifiers, 0,
+                DataGridNavigationInputTargetKind.Any, result);
+
+        /// <summary>Creates a key-up binding.</summary>
+        /// <param name="key">The logical key to match.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        public static DataGridNavigationInputBinding KeyUp(
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputResult result,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false) =>
+            new(DataGridNavigationInputKind.KeyUp, key, default, default, default, modifiers, exactModifiers, 0,
+                DataGridNavigationInputTargetKind.Any, result);
+
+        /// <summary>Creates a layout-independent physical key-up binding.</summary>
+        /// <param name="key">The normalized physical key to match.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        public static DataGridNavigationInputBinding PhysicalKeyUp(
+            DataGridNavigationInputKey key,
+            DataGridNavigationInputResult result,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false) =>
+            new(DataGridNavigationInputKind.KeyUp, default, key, default, default, modifiers, exactModifiers, 0,
+                DataGridNavigationInputTargetKind.Any, result);
+
+        /// <summary>Creates a pointer press or release binding.</summary>
+        /// <param name="kind">Either <see cref="DataGridNavigationInputKind.PointerPressed"/> or <see cref="DataGridNavigationInputKind.PointerReleased"/>.</param>
+        /// <param name="button">The pointer button to match, or <see cref="DataGridNavigationPointerButton.None"/> for any button.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="clickCount">The click count to match, or zero for every count.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        /// <param name="targetKind">The semantic target to match.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="kind"/> is not a pointer press or release, or <paramref name="clickCount"/> is negative.</exception>
+        public static DataGridNavigationInputBinding Pointer(
+            DataGridNavigationInputKind kind,
+            DataGridNavigationPointerButton button,
+            DataGridNavigationInputResult result,
+            int clickCount = 0,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false,
+            DataGridNavigationInputTargetKind targetKind = DataGridNavigationInputTargetKind.Any)
+        {
+            if (kind is not DataGridNavigationInputKind.PointerPressed and
+                not DataGridNavigationInputKind.PointerReleased)
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            if (clickCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(clickCount));
+            }
+
+            return new DataGridNavigationInputBinding(
+                kind,
+                default,
+                default,
+                button,
+                default,
+                modifiers,
+                exactModifiers,
+                clickCount,
+                targetKind,
+                result);
+        }
+
+        /// <summary>Creates a pointer-wheel binding.</summary>
+        /// <param name="direction">The dominant wheel direction to match.</param>
+        /// <param name="result">The result returned on a match.</param>
+        /// <param name="modifiers">The required modifiers.</param>
+        /// <param name="exactModifiers">Whether additional modifiers prevent a match.</param>
+        /// <param name="targetKind">The semantic target to match.</param>
+        public static DataGridNavigationInputBinding Wheel(
+            DataGridNavigationWheelDirection direction,
+            DataGridNavigationInputResult result,
+            DataGridNavigationInputModifiers modifiers = DataGridNavigationInputModifiers.None,
+            bool exactModifiers = false,
+            DataGridNavigationInputTargetKind targetKind = DataGridNavigationInputTargetKind.Any) =>
+            new(DataGridNavigationInputKind.PointerWheel, default, default, default, direction, modifiers, exactModifiers, 0,
+                targetKind, result);
+
+        internal bool Matches(in DataGridNavigationInputRequest request)
+        {
+            if (Kind != request.Kind ||
+                Key != DataGridNavigationInputKey.None && Key != request.Key ||
+                PhysicalKey != DataGridNavigationInputKey.None && PhysicalKey != request.PhysicalKey ||
+                PointerButton != DataGridNavigationPointerButton.None && PointerButton != request.PointerButton ||
+                WheelDirection != DataGridNavigationWheelDirection.None && WheelDirection != request.WheelDirection ||
+                ClickCount > 0 && ClickCount != request.ClickCount ||
+                TargetKind != DataGridNavigationInputTargetKind.Any && TargetKind != request.TargetKind)
+            {
+                return false;
+            }
+
+            return ExactModifiers
+                ? request.Modifiers == Modifiers
+                : (request.Modifiers & Modifiers) == Modifiers;
+        }
+    }
+
+    /// <summary>
+    /// Provides an allocation-free binding table and an optional ViewModel-owned resolving event.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    class DataGridNavigationInputModel : IDataGridNavigationInputModel
+    {
+        private DataGridNavigationInputBinding[] _bindings;
+
+        /// <summary>Initializes a model with an ordered first-match-wins binding table.</summary>
+        /// <param name="bindings">The bindings to evaluate.</param>
+        public DataGridNavigationInputModel(params DataGridNavigationInputBinding[] bindings)
+        {
+            _bindings = bindings ?? Array.Empty<DataGridNavigationInputBinding>();
+        }
+
+        /// <summary>
+        /// Occurs after the static table is evaluated and permits a ViewModel to replace the decision.
+        /// </summary>
+        public event EventHandler<DataGridNavigationInputResolvingEventArgs> InputResolving;
+
+        /// <summary>Gets the ordered binding table without allocating a copy.</summary>
+        public ReadOnlySpan<DataGridNavigationInputBinding> Bindings => _bindings;
+
+        /// <summary>Replaces the ordered binding table.</summary>
+        /// <param name="bindings">The bindings to evaluate.</param>
+        public void SetBindings(params DataGridNavigationInputBinding[] bindings)
+        {
+            _bindings = bindings ?? Array.Empty<DataGridNavigationInputBinding>();
+        }
+
+        /// <inheritdoc />
+        public DataGridNavigationInputResult Resolve(in DataGridNavigationInputRequest request)
+        {
+            DataGridNavigationInputResult result = ResolveCore(request);
+            EventHandler<DataGridNavigationInputResolvingEventArgs> handler = InputResolving;
+            if (handler == null)
+            {
+                return result;
+            }
+
+            var args = new DataGridNavigationInputResolvingEventArgs(request, result);
+            handler(this, args);
+            return args.Result;
+        }
+
+        /// <summary>Resolves the binding table before <see cref="InputResolving"/> observers run.</summary>
+        /// <param name="request">The normalized input request.</param>
+        /// <returns>The first matching result, or <see cref="DataGridNavigationInputResult.Ignore"/>.</returns>
+        protected virtual DataGridNavigationInputResult ResolveCore(in DataGridNavigationInputRequest request)
+        {
+            DataGridNavigationInputBinding[] bindings = _bindings;
+            for (int index = 0; index < bindings.Length; index++)
+            {
+                if (bindings[index].Matches(request))
+                {
+                    return bindings[index].Result;
+                }
+            }
+
+            return DataGridNavigationInputResult.Ignore();
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -1,0 +1,808 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System;
+using System.ComponentModel;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace Avalonia.Controls.DataGridNavigation
+{
+    /// <summary>
+    /// Identifies a semantic DataGrid navigation operation independently of its input gesture.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationCommand
+    {
+        /// <summary>No navigation operation.</summary>
+        None,
+        /// <summary>Moves to the preceding visible row.</summary>
+        Up,
+        /// <summary>Moves to the following visible row.</summary>
+        Down,
+        /// <summary>Moves to the visible column on the physical left.</summary>
+        Left,
+        /// <summary>Moves to the visible column on the physical right.</summary>
+        Right,
+        /// <summary>Moves backward by one viewport page.</summary>
+        PageUp,
+        /// <summary>Moves forward by one viewport page.</summary>
+        PageDown,
+        /// <summary>Moves to the first visible column in the current row.</summary>
+        RowStart,
+        /// <summary>Moves to the last visible column in the current row.</summary>
+        RowEnd,
+        /// <summary>Moves to the first visible row in the current column.</summary>
+        ColumnStart,
+        /// <summary>Moves to the last visible row in the current column.</summary>
+        ColumnEnd,
+        /// <summary>Moves to the first visible data cell.</summary>
+        GridStart,
+        /// <summary>Moves to the last visible data cell.</summary>
+        GridEnd,
+        /// <summary>Moves to the next cell in row-major order.</summary>
+        Next,
+        /// <summary>Moves to the previous cell in row-major order.</summary>
+        Previous,
+        /// <summary>Commits editing and applies the configured Enter behavior.</summary>
+        Enter,
+        /// <summary>Begins editing the current cell.</summary>
+        BeginEdit,
+        /// <summary>Cancels the current cell or row edit.</summary>
+        CancelEdit,
+        /// <summary>Expands all expandable hierarchy nodes.</summary>
+        ExpandAll
+    }
+
+    /// <summary>
+    /// Identifies the source that initiated a navigation request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationOrigin
+    {
+        /// <summary>A keyboard gesture initiated the request.</summary>
+        Keyboard,
+        /// <summary>The DataGrid programmatic API initiated the request.</summary>
+        Programmatic,
+        /// <summary>An MVVM command initiated the request.</summary>
+        Command,
+        /// <summary>An accessibility or automation peer initiated the request.</summary>
+        Automation,
+        /// <summary>State restoration initiated the request.</summary>
+        RestoredState
+    }
+
+    /// <summary>
+    /// Describes how navigation behaves when it reaches an edge.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationBoundaryMode
+    {
+        /// <summary>Consumes navigation at the boundary and keeps the current cell.</summary>
+        Contained,
+        /// <summary>Wraps navigation to the opposite boundary.</summary>
+        Wrap,
+        /// <summary>Leaves the request unhandled so focus may leave the grid.</summary>
+        Exit
+    }
+
+    /// <summary>
+    /// Controls whether Tab traversal is active only while editing or for every current cell.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridTabNavigationMode
+    {
+        /// <summary>Uses grid-managed Tab traversal only while a cell is editing.</summary>
+        EditingOnly,
+        /// <summary>Uses grid-managed Tab traversal whenever a data cell is current.</summary>
+        Always
+    }
+
+    /// <summary>
+    /// Controls whether Left and Right are interpreted physically or relative to layout direction.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridHorizontalNavigationMode
+    {
+        /// <summary>Left and Right always identify physical directions.</summary>
+        Physical,
+        /// <summary>Left and Right follow the grid flow direction.</summary>
+        Logical
+    }
+
+    /// <summary>
+    /// Identifies the action the grid should take after a model resolves a request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationDecision
+    {
+        /// <summary>Executes the existing built-in movement engine.</summary>
+        Default,
+        /// <summary>Moves to an explicit data-cell position.</summary>
+        Move,
+        /// <summary>Executes a different semantic command through the built-in engine.</summary>
+        Redirect,
+        /// <summary>Consumes the request and keeps the current cell.</summary>
+        Stay,
+        /// <summary>Leaves the request unhandled so focus may leave the grid.</summary>
+        LeaveGrid
+    }
+
+    /// <summary>
+    /// Identifies why a completed request did not move to its requested target.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridNavigationFailureReason
+    {
+        /// <summary>The request completed without a failure.</summary>
+        None,
+        /// <summary>A policy or observer canceled the request.</summary>
+        Canceled,
+        /// <summary>The requested movement crossed a configured boundary.</summary>
+        BoundaryReached,
+        /// <summary>The explicit target was not a visible data cell.</summary>
+        InvalidTarget,
+        /// <summary>No data cell is current.</summary>
+        NoCurrentCell,
+        /// <summary>The active view contains no rows.</summary>
+        NoRows,
+        /// <summary>The grid contains no visible data columns.</summary>
+        NoColumns,
+        /// <summary>Editing validation prevented the grid from leaving the cell.</summary>
+        EditCommitFailed
+    }
+
+    /// <summary>
+    /// Represents a data-cell position by collection-view row index and column display index.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationPosition : IEquatable<DataGridNavigationPosition>
+    {
+        /// <summary>Initializes a data-cell position.</summary>
+        /// <param name="rowIndex">The collection-view row index.</param>
+        /// <param name="columnDisplayIndex">The column display index.</param>
+        public DataGridNavigationPosition(int rowIndex, int columnDisplayIndex)
+        {
+            RowIndex = rowIndex;
+            ColumnDisplayIndex = columnDisplayIndex;
+        }
+
+        /// <summary>Gets the collection-view row index.</summary>
+        public int RowIndex { get; }
+
+        /// <summary>Gets the column display index.</summary>
+        public int ColumnDisplayIndex { get; }
+
+        /// <summary>Gets whether both coordinates are non-negative.</summary>
+        public bool IsValid => RowIndex >= 0 && ColumnDisplayIndex >= 0;
+
+        /// <summary>Gets an invalid position that does not identify a cell.</summary>
+        public static DataGridNavigationPosition Unset => new(-1, -1);
+
+        /// <inheritdoc />
+        public bool Equals(DataGridNavigationPosition other) =>
+            RowIndex == other.RowIndex && ColumnDisplayIndex == other.ColumnDisplayIndex;
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) =>
+            obj is DataGridNavigationPosition other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (RowIndex * 397) ^ ColumnDisplayIndex;
+            }
+        }
+
+        /// <summary>Compares two positions for equality.</summary>
+        public static bool operator ==(DataGridNavigationPosition left, DataGridNavigationPosition right) =>
+            left.Equals(right);
+
+        /// <summary>Compares two positions for inequality.</summary>
+        public static bool operator !=(DataGridNavigationPosition left, DataGridNavigationPosition right) =>
+            !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Describes a semantic navigation request and the grid state relevant to policy decisions.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationRequest
+    {
+        /// <summary>Initializes a complete semantic navigation request.</summary>
+        /// <param name="command">The semantic operation.</param>
+        /// <param name="origin">The request source.</param>
+        /// <param name="currentPosition">The current data-cell position.</param>
+        /// <param name="proposedPosition">The built-in engine's proposed target, when one exists.</param>
+        /// <param name="modifiers">Active keyboard modifiers.</param>
+        /// <param name="isEditing">Whether a cell is currently editing.</param>
+        /// <param name="selectionMode">The active selection mode.</param>
+        /// <param name="selectionUnit">The active selection unit.</param>
+        /// <param name="flowDirection">The grid layout direction.</param>
+        /// <param name="firstRowIndex">The first navigable row index.</param>
+        /// <param name="lastRowIndex">The last navigable row index.</param>
+        /// <param name="firstColumnDisplayIndex">The first navigable column display index.</param>
+        /// <param name="lastColumnDisplayIndex">The last navigable column display index.</param>
+        public DataGridNavigationRequest(
+            DataGridNavigationCommand command,
+            DataGridNavigationOrigin origin,
+            DataGridNavigationPosition currentPosition,
+            DataGridNavigationPosition? proposedPosition,
+            KeyModifiers modifiers,
+            bool isEditing,
+            DataGridSelectionMode selectionMode,
+            DataGridSelectionUnit selectionUnit,
+            FlowDirection flowDirection,
+            int firstRowIndex,
+            int lastRowIndex,
+            int firstColumnDisplayIndex,
+            int lastColumnDisplayIndex)
+        {
+            Command = command;
+            Origin = origin;
+            CurrentPosition = currentPosition;
+            ProposedPosition = proposedPosition;
+            Modifiers = modifiers;
+            IsEditing = isEditing;
+            SelectionMode = selectionMode;
+            SelectionUnit = selectionUnit;
+            FlowDirection = flowDirection;
+            FirstRowIndex = firstRowIndex;
+            LastRowIndex = lastRowIndex;
+            FirstColumnDisplayIndex = firstColumnDisplayIndex;
+            LastColumnDisplayIndex = lastColumnDisplayIndex;
+        }
+
+        /// <summary>Gets the semantic operation.</summary>
+        public DataGridNavigationCommand Command { get; }
+
+        /// <summary>Gets the request source.</summary>
+        public DataGridNavigationOrigin Origin { get; }
+
+        /// <summary>Gets the current data-cell position.</summary>
+        public DataGridNavigationPosition CurrentPosition { get; }
+
+        /// <summary>Gets the built-in engine's proposed target, when one exists.</summary>
+        public DataGridNavigationPosition? ProposedPosition { get; }
+
+        /// <summary>Gets the active keyboard modifiers.</summary>
+        public KeyModifiers Modifiers { get; }
+
+        /// <summary>Gets whether a cell is currently editing.</summary>
+        public bool IsEditing { get; }
+
+        /// <summary>Gets the active selection mode.</summary>
+        public DataGridSelectionMode SelectionMode { get; }
+
+        /// <summary>Gets the active selection unit.</summary>
+        public DataGridSelectionUnit SelectionUnit { get; }
+
+        /// <summary>Gets the grid layout direction.</summary>
+        public FlowDirection FlowDirection { get; }
+
+        /// <summary>Gets the first navigable row index.</summary>
+        public int FirstRowIndex { get; }
+
+        /// <summary>Gets the last navigable row index.</summary>
+        public int LastRowIndex { get; }
+
+        /// <summary>Gets the first navigable column display index.</summary>
+        public int FirstColumnDisplayIndex { get; }
+
+        /// <summary>Gets the last navigable column display index.</summary>
+        public int LastColumnDisplayIndex { get; }
+
+        /// <summary>Gets whether the request describes at least one navigable row.</summary>
+        public bool HasRows => FirstRowIndex >= 0 && LastRowIndex >= FirstRowIndex;
+
+        /// <summary>Gets whether the request describes at least one navigable column.</summary>
+        public bool HasColumns => FirstColumnDisplayIndex >= 0 && LastColumnDisplayIndex >= FirstColumnDisplayIndex;
+    }
+
+    /// <summary>
+    /// Contains the policy decision returned by an <see cref="IDataGridNavigationModel"/>.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationResult : IEquatable<DataGridNavigationResult>
+    {
+        private DataGridNavigationResult(
+            DataGridNavigationDecision decision,
+            DataGridNavigationPosition target,
+            DataGridNavigationCommand redirectedCommand,
+            DataGridNavigationFailureReason failureReason)
+        {
+            Decision = decision;
+            Target = target;
+            RedirectedCommand = redirectedCommand;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>Gets the action the grid should apply.</summary>
+        public DataGridNavigationDecision Decision { get; }
+
+        /// <summary>Gets the explicit target for a Move decision.</summary>
+        public DataGridNavigationPosition Target { get; }
+
+        /// <summary>Gets the semantic command for a Redirect decision.</summary>
+        public DataGridNavigationCommand RedirectedCommand { get; }
+
+        /// <summary>Gets the policy-level reason for staying in place, when supplied.</summary>
+        public DataGridNavigationFailureReason FailureReason { get; }
+
+        /// <summary>Creates a decision that uses the existing built-in movement engine.</summary>
+        /// <returns>A default-engine decision.</returns>
+        public static DataGridNavigationResult UseDefault() =>
+            new(DataGridNavigationDecision.Default, DataGridNavigationPosition.Unset, DataGridNavigationCommand.None,
+                DataGridNavigationFailureReason.None);
+
+        /// <summary>Creates a decision that moves to an explicit data cell.</summary>
+        /// <param name="target">The target row and column display indexes.</param>
+        /// <returns>An explicit move decision.</returns>
+        public static DataGridNavigationResult MoveTo(DataGridNavigationPosition target) =>
+            new(DataGridNavigationDecision.Move, target, DataGridNavigationCommand.None,
+                DataGridNavigationFailureReason.None);
+
+        /// <summary>Creates a decision that redirects to another semantic command.</summary>
+        /// <param name="command">The command executed by the built-in engine.</param>
+        /// <returns>A redirect decision.</returns>
+        public static DataGridNavigationResult RedirectTo(DataGridNavigationCommand command) =>
+            new(DataGridNavigationDecision.Redirect, DataGridNavigationPosition.Unset, command,
+                DataGridNavigationFailureReason.None);
+
+        /// <summary>Creates a decision that consumes a boundary request without moving.</summary>
+        /// <returns>A boundary stay decision.</returns>
+        public static DataGridNavigationResult Stay() =>
+            new(DataGridNavigationDecision.Stay, DataGridNavigationPosition.Unset, DataGridNavigationCommand.None,
+                DataGridNavigationFailureReason.BoundaryReached);
+
+        /// <summary>Creates a decision that consumes a canceled request without moving.</summary>
+        /// <returns>A canceled stay decision.</returns>
+        public static DataGridNavigationResult Cancel() =>
+            new(DataGridNavigationDecision.Stay, DataGridNavigationPosition.Unset, DataGridNavigationCommand.None,
+                DataGridNavigationFailureReason.Canceled);
+
+        /// <summary>Creates a decision that permits focus to leave the grid.</summary>
+        /// <returns>A leave-grid decision.</returns>
+        public static DataGridNavigationResult LeaveGrid() =>
+            new(DataGridNavigationDecision.LeaveGrid, DataGridNavigationPosition.Unset, DataGridNavigationCommand.None,
+                DataGridNavigationFailureReason.BoundaryReached);
+
+        /// <inheritdoc />
+        public bool Equals(DataGridNavigationResult other) =>
+            Decision == other.Decision && Target == other.Target && RedirectedCommand == other.RedirectedCommand &&
+            FailureReason == other.FailureReason;
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is DataGridNavigationResult other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = (int)Decision;
+                hash = (hash * 397) ^ Target.GetHashCode();
+                hash = (hash * 397) ^ (int)RedirectedCommand;
+                hash = (hash * 397) ^ (int)FailureReason;
+                return hash;
+            }
+        }
+
+        /// <summary>Compares two results for equality.</summary>
+        public static bool operator ==(DataGridNavigationResult left, DataGridNavigationResult right) => left.Equals(right);
+
+        /// <summary>Compares two results for inequality.</summary>
+        public static bool operator !=(DataGridNavigationResult left, DataGridNavigationResult right) => !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Describes the completed outcome of a navigation request without requiring event allocation.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridNavigationCompleted
+    {
+        /// <summary>Initializes a completed navigation outcome.</summary>
+        /// <param name="request">The original semantic request.</param>
+        /// <param name="result">The resolved policy decision.</param>
+        /// <param name="oldPosition">The position before execution.</param>
+        /// <param name="newPosition">The position after execution.</param>
+        /// <param name="handled">Whether the grid consumed the request.</param>
+        /// <param name="failureReason">Why execution did not move as requested.</param>
+        public DataGridNavigationCompleted(
+            DataGridNavigationRequest request,
+            DataGridNavigationResult result,
+            DataGridNavigationPosition oldPosition,
+            DataGridNavigationPosition newPosition,
+            bool handled,
+            DataGridNavigationFailureReason failureReason)
+        {
+            Request = request;
+            Result = result;
+            OldPosition = oldPosition;
+            NewPosition = newPosition;
+            Handled = handled;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>Gets the original semantic request.</summary>
+        public DataGridNavigationRequest Request { get; }
+
+        /// <summary>Gets the resolved policy decision.</summary>
+        public DataGridNavigationResult Result { get; }
+
+        /// <summary>Gets the position before execution.</summary>
+        public DataGridNavigationPosition OldPosition { get; }
+
+        /// <summary>Gets the position after execution.</summary>
+        public DataGridNavigationPosition NewPosition { get; }
+
+        /// <summary>Gets whether the grid consumed the request.</summary>
+        public bool Handled { get; }
+
+        /// <summary>Gets whether execution changed to a valid data-cell position.</summary>
+        public bool Moved => OldPosition != NewPosition && NewPosition.IsValid;
+
+        /// <summary>Gets why execution did not move as requested.</summary>
+        public DataGridNavigationFailureReason FailureReason { get; }
+    }
+
+    /// <summary>
+    /// Provides cancelable preview data for a navigation request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridNavigationChangingEventArgs : CancelEventArgs
+    {
+        /// <summary>Initializes cancelable navigation preview data.</summary>
+        /// <param name="request">The semantic navigation request.</param>
+        /// <param name="result">The initial policy result.</param>
+        public DataGridNavigationChangingEventArgs(
+            DataGridNavigationRequest request,
+            DataGridNavigationResult result)
+        {
+            Request = request;
+            Result = result;
+        }
+
+        /// <summary>Gets the semantic navigation request.</summary>
+        public DataGridNavigationRequest Request { get; }
+
+        /// <summary>Gets or sets the result applied when the preview is not canceled.</summary>
+        public DataGridNavigationResult Result { get; set; }
+    }
+
+    /// <summary>
+    /// Provides completion data after the grid applies a navigation request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridNavigationChangedEventArgs : EventArgs
+    {
+        /// <summary>Initializes completion event data.</summary>
+        /// <param name="completed">The completed navigation outcome.</param>
+        public DataGridNavigationChangedEventArgs(DataGridNavigationCompleted completed)
+        {
+            Completed = completed;
+        }
+
+        /// <summary>Gets the completed navigation outcome.</summary>
+        public DataGridNavigationCompleted Completed { get; }
+    }
+
+    /// <summary>
+    /// Resolves DataGrid navigation policy independently of input gesture and layout mechanics.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationModel
+    {
+        /// <summary>Raised before a policy decision is applied.</summary>
+        event EventHandler<DataGridNavigationChangingEventArgs> NavigationChanging;
+
+        /// <summary>Raised after the grid applies a policy decision.</summary>
+        event EventHandler<DataGridNavigationChangedEventArgs> NavigationChanged;
+
+        /// <summary>Resolves policy and raises cancelable preview observers.</summary>
+        /// <param name="request">The semantic navigation request.</param>
+        /// <returns>The policy decision applied by the grid.</returns>
+        DataGridNavigationResult Resolve(DataGridNavigationRequest request);
+
+        /// <summary>Publishes completion after the grid applies a request.</summary>
+        /// <param name="completed">The completed navigation outcome.</param>
+        void NotifyCompleted(DataGridNavigationCompleted completed);
+    }
+
+    /// <summary>
+    /// Provides side-effect-free navigation queries for command enablement.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationQueryModel
+    {
+        /// <summary>
+        /// Resolves a request without raising preview or completion events.
+        /// </summary>
+        /// <param name="request">The semantic navigation request.</param>
+        /// <returns>The current navigation policy decision.</returns>
+        DataGridNavigationResult Query(DataGridNavigationRequest request);
+    }
+
+    /// <summary>
+    /// Creates a navigation model for a DataGrid instance.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationModelFactory
+    {
+        /// <summary>Creates a navigation model for one DataGrid.</summary>
+        /// <returns>A new navigation model.</returns>
+        IDataGridNavigationModel Create();
+    }
+
+    /// <summary>
+    /// Default, extensible navigation policy. Its default settings preserve the legacy DataGrid behavior.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    class DataGridNavigationModel : IDataGridNavigationModel, IDataGridNavigationQueryModel, INotifyPropertyChanged
+    {
+        private DataGridNavigationBoundaryMode _horizontalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
+        private DataGridNavigationBoundaryMode _verticalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
+        private DataGridNavigationBoundaryMode _tabBoundaryMode = DataGridNavigationBoundaryMode.Exit;
+        private DataGridTabNavigationMode _tabNavigationMode = DataGridTabNavigationMode.EditingOnly;
+        private DataGridHorizontalNavigationMode _horizontalNavigationMode = DataGridHorizontalNavigationMode.Physical;
+
+        /// <inheritdoc />
+        public event EventHandler<DataGridNavigationChangingEventArgs> NavigationChanging;
+
+        /// <inheritdoc />
+        public event EventHandler<DataGridNavigationChangedEventArgs> NavigationChanged;
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets or sets the Left/Right boundary policy.</summary>
+        public DataGridNavigationBoundaryMode HorizontalBoundaryMode
+        {
+            get => _horizontalBoundaryMode;
+            set => SetProperty(ref _horizontalBoundaryMode, value, nameof(HorizontalBoundaryMode));
+        }
+
+        /// <summary>Gets or sets the Up/Down boundary policy.</summary>
+        public DataGridNavigationBoundaryMode VerticalBoundaryMode
+        {
+            get => _verticalBoundaryMode;
+            set => SetProperty(ref _verticalBoundaryMode, value, nameof(VerticalBoundaryMode));
+        }
+
+        /// <summary>Gets or sets the Tab/Shift+Tab boundary policy.</summary>
+        public DataGridNavigationBoundaryMode TabBoundaryMode
+        {
+            get => _tabBoundaryMode;
+            set => SetProperty(ref _tabBoundaryMode, value, nameof(TabBoundaryMode));
+        }
+
+        /// <summary>Gets or sets when the grid manages Tab traversal.</summary>
+        public DataGridTabNavigationMode TabNavigationMode
+        {
+            get => _tabNavigationMode;
+            set => SetProperty(ref _tabNavigationMode, value, nameof(TabNavigationMode));
+        }
+
+        /// <summary>Gets or sets whether Left/Right are physical or flow-relative.</summary>
+        public DataGridHorizontalNavigationMode HorizontalNavigationMode
+        {
+            get => _horizontalNavigationMode;
+            set => SetProperty(ref _horizontalNavigationMode, value, nameof(HorizontalNavigationMode));
+        }
+
+        /// <inheritdoc />
+        public DataGridNavigationResult Resolve(DataGridNavigationRequest request)
+        {
+            DataGridNavigationResult result = ResolveCore(request);
+            EventHandler<DataGridNavigationChangingEventArgs> handler = NavigationChanging;
+            if (handler == null)
+            {
+                return result;
+            }
+
+            var args = new DataGridNavigationChangingEventArgs(request, result);
+            handler(this, args);
+            return args.Cancel ? DataGridNavigationResult.Cancel() : args.Result;
+        }
+
+        /// <inheritdoc />
+        public DataGridNavigationResult Query(DataGridNavigationRequest request) => ResolveCore(request);
+
+        /// <inheritdoc />
+        public void NotifyCompleted(DataGridNavigationCompleted completed)
+        {
+            EventHandler<DataGridNavigationChangedEventArgs> handler = NavigationChanged;
+            if (handler != null)
+            {
+                handler(this, new DataGridNavigationChangedEventArgs(completed));
+            }
+        }
+
+        /// <summary>Resolves the reusable built-in policy before preview observers run.</summary>
+        /// <param name="request">The semantic navigation request.</param>
+        /// <returns>The default policy decision.</returns>
+        protected virtual DataGridNavigationResult ResolveCore(DataGridNavigationRequest request)
+        {
+            if (HorizontalNavigationMode == DataGridHorizontalNavigationMode.Logical &&
+                request.FlowDirection == FlowDirection.RightToLeft)
+            {
+                if (request.Command == DataGridNavigationCommand.Left)
+                {
+                    return DataGridNavigationResult.RedirectTo(DataGridNavigationCommand.Right);
+                }
+
+                if (request.Command == DataGridNavigationCommand.Right)
+                {
+                    return DataGridNavigationResult.RedirectTo(DataGridNavigationCommand.Left);
+                }
+            }
+
+            if (!request.CurrentPosition.IsValid)
+            {
+                return DataGridNavigationResult.UseDefault();
+            }
+
+            if (request.Command is DataGridNavigationCommand.Next or DataGridNavigationCommand.Previous)
+            {
+                if (!request.IsEditing && TabNavigationMode == DataGridTabNavigationMode.EditingOnly)
+                {
+                    return DataGridNavigationResult.UseDefault();
+                }
+
+                if (request.ProposedPosition is { } proposed)
+                {
+                    return TabNavigationMode == DataGridTabNavigationMode.Always && !request.IsEditing
+                        ? DataGridNavigationResult.MoveTo(proposed)
+                        : DataGridNavigationResult.UseDefault();
+                }
+
+                return ResolveTabBoundary(request);
+            }
+
+            if (request.ProposedPosition.HasValue)
+            {
+                return DataGridNavigationResult.UseDefault();
+            }
+
+            return request.Command switch
+            {
+                DataGridNavigationCommand.Left => ResolveHorizontalBoundary(request, moveToEnd: true),
+                DataGridNavigationCommand.Right => ResolveHorizontalBoundary(request, moveToEnd: false),
+                DataGridNavigationCommand.Up => ResolveVerticalBoundary(request, moveToEnd: true),
+                DataGridNavigationCommand.Down => ResolveVerticalBoundary(request, moveToEnd: false),
+                _ => DataGridNavigationResult.UseDefault()
+            };
+        }
+
+        private DataGridNavigationResult ResolveHorizontalBoundary(
+            DataGridNavigationRequest request,
+            bool moveToEnd)
+        {
+            return HorizontalBoundaryMode switch
+            {
+                DataGridNavigationBoundaryMode.Wrap when request.HasColumns =>
+                    DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
+                        request.CurrentPosition.RowIndex,
+                        moveToEnd ? request.LastColumnDisplayIndex : request.FirstColumnDisplayIndex)),
+                DataGridNavigationBoundaryMode.Exit => DataGridNavigationResult.LeaveGrid(),
+                _ => DataGridNavigationResult.Stay()
+            };
+        }
+
+        private DataGridNavigationResult ResolveVerticalBoundary(
+            DataGridNavigationRequest request,
+            bool moveToEnd)
+        {
+            return VerticalBoundaryMode switch
+            {
+                DataGridNavigationBoundaryMode.Wrap when request.HasRows =>
+                    DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
+                        moveToEnd ? request.LastRowIndex : request.FirstRowIndex,
+                        request.CurrentPosition.ColumnDisplayIndex)),
+                DataGridNavigationBoundaryMode.Exit => DataGridNavigationResult.LeaveGrid(),
+                _ => DataGridNavigationResult.Stay()
+            };
+        }
+
+        private DataGridNavigationResult ResolveTabBoundary(DataGridNavigationRequest request)
+        {
+            if (TabBoundaryMode == DataGridNavigationBoundaryMode.Exit)
+            {
+                return DataGridNavigationResult.LeaveGrid();
+            }
+
+            if (TabBoundaryMode == DataGridNavigationBoundaryMode.Wrap && request.HasRows && request.HasColumns)
+            {
+                bool previous = request.Command == DataGridNavigationCommand.Previous;
+                return DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
+                    previous ? request.LastRowIndex : request.FirstRowIndex,
+                    previous ? request.LastColumnDisplayIndex : request.FirstColumnDisplayIndex));
+            }
+
+            return DataGridNavigationResult.Stay();
+        }
+
+        private void SetProperty<T>(ref T field, T value, string propertyName)
+        {
+            if (Equals(field, value))
+            {
+                return;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -50,6 +50,8 @@ namespace Avalonia.Controls.DataGridNavigation
         Next,
         /// <summary>Moves to the previous cell in row-major order.</summary>
         Previous,
+        /// <summary>Moves to an explicit data-cell position supplied by an input or programmatic request.</summary>
+        GoTo,
         /// <summary>Commits editing and applies the configured Enter behavior.</summary>
         Enter,
         /// <summary>Begins editing the current cell.</summary>
@@ -76,6 +78,8 @@ namespace Avalonia.Controls.DataGridNavigation
     {
         /// <summary>A keyboard gesture initiated the request.</summary>
         Keyboard,
+        /// <summary>A pointer gesture initiated the request.</summary>
+        Pointer,
         /// <summary>The DataGrid programmatic API initiated the request.</summary>
         Programmatic,
         /// <summary>An MVVM command initiated the request.</summary>
@@ -879,6 +883,13 @@ namespace Avalonia.Controls.DataGridNavigation
                 {
                     return DataGridNavigationResult.RedirectTo(DataGridNavigationCommand.Left);
                 }
+            }
+
+            if (request.Command == DataGridNavigationCommand.GoTo)
+            {
+                return request.ProposedPosition is { } target && target.IsValid
+                    ? DataGridNavigationResult.MoveTo(target)
+                    : DataGridNavigationResult.Stay();
             }
 
             if (!request.CurrentPosition.IsValid)

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -56,7 +56,11 @@ namespace Avalonia.Controls.DataGridNavigation
         BeginEdit,
         /// <summary>Cancels the current cell or row edit.</summary>
         CancelEdit,
-        /// <summary>Expands all expandable hierarchy nodes.</summary>
+        /// <summary>Expands the current hierarchy node or row group.</summary>
+        Expand,
+        /// <summary>Collapses the current hierarchy node or row group.</summary>
+        Collapse,
+        /// <summary>Expands the current hierarchy subtree.</summary>
         ExpandAll
     }
 
@@ -612,6 +616,55 @@ namespace Avalonia.Controls.DataGridNavigation
     }
 
     /// <summary>
+    /// Captures and restores serializable navigation policy without retaining a DataGrid or item.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationStateModel
+    {
+        /// <summary>Captures the current policy settings.</summary>
+        /// <returns>A detached policy snapshot.</returns>
+        DataGridNavigationPolicyState CaptureState();
+
+        /// <summary>Restores policy settings from a detached snapshot.</summary>
+        /// <param name="state">The policy snapshot.</param>
+        void RestoreState(DataGridNavigationPolicyState state);
+    }
+
+    /// <summary>
+    /// Stores the serializable policy portion of a navigation model.
+    /// Current-cell identity remains part of <see cref="global::Avalonia.Controls.DataGridSelectionState"/> so it can use stable item and column keys.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridNavigationPolicyState
+    {
+        /// <summary>Gets or sets the state contract version.</summary>
+        public int Version { get; set; } = 1;
+
+        /// <summary>Gets or sets the Left/Right boundary policy.</summary>
+        public DataGridNavigationBoundaryMode HorizontalBoundaryMode { get; set; } = DataGridNavigationBoundaryMode.Contained;
+
+        /// <summary>Gets or sets the Up/Down boundary policy.</summary>
+        public DataGridNavigationBoundaryMode VerticalBoundaryMode { get; set; } = DataGridNavigationBoundaryMode.Contained;
+
+        /// <summary>Gets or sets the Tab/Shift+Tab boundary policy.</summary>
+        public DataGridNavigationBoundaryMode TabBoundaryMode { get; set; } = DataGridNavigationBoundaryMode.Exit;
+
+        /// <summary>Gets or sets when the grid manages Tab traversal.</summary>
+        public DataGridTabNavigationMode TabNavigationMode { get; set; } = DataGridTabNavigationMode.EditingOnly;
+
+        /// <summary>Gets or sets whether Left/Right are physical or flow-relative.</summary>
+        public DataGridHorizontalNavigationMode HorizontalNavigationMode { get; set; } = DataGridHorizontalNavigationMode.Physical;
+    }
+
+    /// <summary>
     /// Carries a ViewModel-issued semantic navigation request to a bound DataGrid.
     /// </summary>
 #if !DATAGRID_INTERNAL
@@ -675,6 +728,7 @@ namespace Avalonia.Controls.DataGridNavigation
         IDataGridNavigationModel,
         IDataGridNavigationQueryModel,
         IDataGridNavigationController,
+        IDataGridNavigationStateModel,
         INotifyPropertyChanged
     {
         private DataGridNavigationBoundaryMode _horizontalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
@@ -778,6 +832,34 @@ namespace Avalonia.Controls.DataGridNavigation
             {
                 handler(this, new DataGridNavigationChangedEventArgs(completed));
             }
+        }
+
+        /// <inheritdoc />
+        public DataGridNavigationPolicyState CaptureState()
+        {
+            return new DataGridNavigationPolicyState
+            {
+                HorizontalBoundaryMode = HorizontalBoundaryMode,
+                VerticalBoundaryMode = VerticalBoundaryMode,
+                TabBoundaryMode = TabBoundaryMode,
+                TabNavigationMode = TabNavigationMode,
+                HorizontalNavigationMode = HorizontalNavigationMode
+            };
+        }
+
+        /// <inheritdoc />
+        public void RestoreState(DataGridNavigationPolicyState state)
+        {
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            HorizontalBoundaryMode = state.HorizontalBoundaryMode;
+            VerticalBoundaryMode = state.VerticalBoundaryMode;
+            TabBoundaryMode = state.TabBoundaryMode;
+            TabNavigationMode = state.TabNavigationMode;
+            HorizontalNavigationMode = state.HorizontalNavigationMode;
         }
 
         /// <summary>Resolves the reusable built-in policy before preview observers run.</summary>

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -588,6 +588,67 @@ namespace Avalonia.Controls.DataGridNavigation
     }
 
     /// <summary>
+    /// Issues semantic navigation requests from ViewModel commands without exposing a DataGrid instance.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridNavigationController
+    {
+        /// <summary>Raised when application code requests grid navigation.</summary>
+        event EventHandler<DataGridNavigationRequestedEventArgs> NavigationRequested;
+
+        /// <summary>Requests a semantic operation from the DataGrid bound to this model.</summary>
+        /// <param name="command">The semantic navigation command.</param>
+        /// <param name="modifiers">Modifiers used for selection extension and edge movement.</param>
+        /// <param name="origin">The source of the request.</param>
+        /// <returns><see langword="true"/> when a bound DataGrid handled the request.</returns>
+        bool RequestNavigate(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers = KeyModifiers.None,
+            DataGridNavigationOrigin origin = DataGridNavigationOrigin.Command);
+    }
+
+    /// <summary>
+    /// Carries a ViewModel-issued semantic navigation request to a bound DataGrid.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridNavigationRequestedEventArgs : EventArgs
+    {
+        /// <summary>Initializes a ViewModel-issued navigation request.</summary>
+        /// <param name="command">The semantic navigation command.</param>
+        /// <param name="modifiers">Modifiers used for selection extension and edge movement.</param>
+        /// <param name="origin">The source of the request.</param>
+        public DataGridNavigationRequestedEventArgs(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers,
+            DataGridNavigationOrigin origin)
+        {
+            Command = command;
+            Modifiers = modifiers;
+            Origin = origin;
+        }
+
+        /// <summary>Gets the semantic navigation command.</summary>
+        public DataGridNavigationCommand Command { get; }
+
+        /// <summary>Gets modifiers used for selection extension and edge movement.</summary>
+        public KeyModifiers Modifiers { get; }
+
+        /// <summary>Gets the source of the request.</summary>
+        public DataGridNavigationOrigin Origin { get; }
+
+        /// <summary>Gets or sets whether a bound DataGrid handled the request.</summary>
+        public bool Handled { get; set; }
+    }
+
+    /// <summary>
     /// Creates a navigation model for a DataGrid instance.
     /// </summary>
 #if !DATAGRID_INTERNAL
@@ -610,7 +671,11 @@ namespace Avalonia.Controls.DataGridNavigation
 #else
     internal
 #endif
-    class DataGridNavigationModel : IDataGridNavigationModel, IDataGridNavigationQueryModel, INotifyPropertyChanged
+    class DataGridNavigationModel :
+        IDataGridNavigationModel,
+        IDataGridNavigationQueryModel,
+        IDataGridNavigationController,
+        INotifyPropertyChanged
     {
         private DataGridNavigationBoundaryMode _horizontalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
         private DataGridNavigationBoundaryMode _verticalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
@@ -626,6 +691,9 @@ namespace Avalonia.Controls.DataGridNavigation
 
         /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc />
+        public event EventHandler<DataGridNavigationRequestedEventArgs> NavigationRequested;
 
         /// <summary>Gets or sets the Left/Right boundary policy.</summary>
         public DataGridNavigationBoundaryMode HorizontalBoundaryMode
@@ -679,6 +747,28 @@ namespace Avalonia.Controls.DataGridNavigation
 
         /// <inheritdoc />
         public DataGridNavigationResult Query(DataGridNavigationRequest request) => ResolveCore(request);
+
+        /// <inheritdoc />
+        public bool RequestNavigate(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers = KeyModifiers.None,
+            DataGridNavigationOrigin origin = DataGridNavigationOrigin.Command)
+        {
+            if (command == DataGridNavigationCommand.None)
+            {
+                return false;
+            }
+
+            EventHandler<DataGridNavigationRequestedEventArgs> handler = NavigationRequested;
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var args = new DataGridNavigationRequestedEventArgs(command, modifiers, origin);
+            handler(this, args);
+            return args.Handled;
+        }
 
         /// <inheritdoc />
         public void NotifyCompleted(DataGridNavigationCompleted completed)

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
@@ -1,0 +1,714 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+#nullable disable
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalonia.Controls.DataGridNavigation
+{
+    /// <summary>
+    /// Identifies an application-route operation requested from a DataGrid workflow.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridRouteNavigationKind
+    {
+        /// <summary>Pushes or otherwise navigates to a route.</summary>
+        Navigate,
+
+        /// <summary>Replaces the active history entry with a route.</summary>
+        Replace,
+
+        /// <summary>Clears the active history and navigates to a route.</summary>
+        Reset,
+
+        /// <summary>Navigates to the previous history entry.</summary>
+        Back,
+
+        /// <summary>Navigates to the next history entry when supported.</summary>
+        Forward
+    }
+
+    /// <summary>
+    /// Identifies how a grid-associated application route was activated.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridRouteNavigationOrigin
+    {
+        /// <summary>The route was activated by a ViewModel command.</summary>
+        Command,
+
+        /// <summary>The route was activated by keyboard input.</summary>
+        Keyboard,
+
+        /// <summary>The route was activated by pointer input.</summary>
+        Pointer,
+
+        /// <summary>The route was requested through an application API.</summary>
+        Programmatic,
+
+        /// <summary>The route was applied while restoring application state or a deep link.</summary>
+        RestoredState
+    }
+
+    /// <summary>
+    /// Describes the route operations supported by an <see cref="IDataGridRouteNavigator"/>.
+    /// </summary>
+    [Flags]
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridRouteNavigationCapabilities
+    {
+        /// <summary>No route operation is supported.</summary>
+        None = 0,
+
+        /// <summary>Navigation to a route is supported.</summary>
+        Navigate = 1 << 0,
+
+        /// <summary>Replacing the active history entry is supported.</summary>
+        Replace = 1 << 1,
+
+        /// <summary>Resetting history and navigating to a route is supported.</summary>
+        Reset = 1 << 2,
+
+        /// <summary>Backward history navigation is supported.</summary>
+        Back = 1 << 3,
+
+        /// <summary>Forward history navigation is supported.</summary>
+        Forward = 1 << 4,
+
+        /// <summary>All route operations are supported.</summary>
+        All = Navigate | Replace | Reset | Back | Forward
+    }
+
+    /// <summary>
+    /// Identifies the non-throwing outcome of an application-route request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    enum DataGridRouteNavigationStatus
+    {
+        /// <summary>The navigator completed the request successfully.</summary>
+        Succeeded,
+
+        /// <summary>The request was canceled before completion.</summary>
+        Canceled,
+
+        /// <summary>No route could be resolved from the supplied grid context.</summary>
+        RouteNotFound,
+
+        /// <summary>The navigator does not support the requested operation.</summary>
+        NotSupported,
+
+        /// <summary>The request or route was invalid.</summary>
+        InvalidRequest,
+
+        /// <summary>The navigator reported a failure.</summary>
+        Failed
+    }
+
+    /// <summary>
+    /// Represents a framework-neutral application route.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridRoute : IEquatable<DataGridRoute>
+    {
+        /// <summary>
+        /// Initializes a route.
+        /// </summary>
+        /// <param name="path">The stable route path or route segment.</param>
+        /// <param name="parameter">An optional immutable parameter or navigation state object.</param>
+        /// <param name="target">An optional region, outlet, screen, or host identifier.</param>
+        public DataGridRoute(string path, object parameter = null, string target = null)
+        {
+            Path = path ?? string.Empty;
+            Parameter = parameter;
+            Target = target ?? string.Empty;
+        }
+
+        /// <summary>Gets the stable route path or route segment.</summary>
+        public string Path { get; }
+
+        /// <summary>Gets an optional immutable parameter or navigation state object.</summary>
+        public object Parameter { get; }
+
+        /// <summary>Gets an optional region, outlet, screen, or host identifier.</summary>
+        public string Target { get; }
+
+        /// <summary>Gets whether the route contains a non-empty path.</summary>
+        public bool IsValid => !string.IsNullOrWhiteSpace(Path);
+
+        /// <summary>Gets an unset route.</summary>
+        public static DataGridRoute Unset => default;
+
+        /// <inheritdoc />
+        public bool Equals(DataGridRoute other) =>
+            string.Equals(Path, other.Path, StringComparison.Ordinal) &&
+            ReferenceEquals(Parameter, other.Parameter) &&
+            string.Equals(Target, other.Target, StringComparison.Ordinal);
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is DataGridRoute other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = StringComparer.Ordinal.GetHashCode(Path ?? string.Empty);
+                hash = (hash * 397) ^ (Parameter?.GetHashCode() ?? 0);
+                hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(Target ?? string.Empty);
+                return hash;
+            }
+        }
+
+        /// <summary>Compares two routes for equality.</summary>
+        public static bool operator ==(DataGridRoute left, DataGridRoute right) => left.Equals(right);
+
+        /// <summary>Compares two routes for inequality.</summary>
+        public static bool operator !=(DataGridRoute left, DataGridRoute right) => !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Carries stable row and column identity from a grid workflow to a route resolver.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridRouteContext
+    {
+        /// <summary>
+        /// Initializes a route context.
+        /// </summary>
+        /// <param name="item">The source item. It may be <see langword="null"/> when <paramref name="hasItem"/> is true.</param>
+        /// <param name="itemKey">An optional stable key for restoring the item after filtering or reload.</param>
+        /// <param name="columnKey">An optional stable column key.</param>
+        /// <param name="position">The current row and display-column position.</param>
+        /// <param name="origin">The activation source.</param>
+        /// <param name="hasItem">Whether the context carries an item, including a null item.</param>
+        public DataGridRouteContext(
+            object item,
+            object itemKey,
+            object columnKey,
+            DataGridNavigationPosition position,
+            DataGridRouteNavigationOrigin origin,
+            bool hasItem = true)
+        {
+            Item = item;
+            ItemKey = itemKey;
+            ColumnKey = columnKey;
+            Position = position;
+            Origin = origin;
+            HasItem = hasItem;
+        }
+
+        /// <summary>Gets whether the context carries an item.</summary>
+        public bool HasItem { get; }
+
+        /// <summary>Gets the source item.</summary>
+        public object Item { get; }
+
+        /// <summary>Gets the optional stable row key.</summary>
+        public object ItemKey { get; }
+
+        /// <summary>Gets the optional stable column key.</summary>
+        public object ColumnKey { get; }
+
+        /// <summary>Gets the current row and display-column position.</summary>
+        public DataGridNavigationPosition Position { get; }
+
+        /// <summary>Gets the activation source.</summary>
+        public DataGridRouteNavigationOrigin Origin { get; }
+
+        /// <summary>Gets an empty route context for history-only operations.</summary>
+        public static DataGridRouteContext Empty =>
+            new(null, null, null, DataGridNavigationPosition.Unset, DataGridRouteNavigationOrigin.Programmatic, false);
+    }
+
+    /// <summary>
+    /// Describes an application-route operation after grid context has been resolved.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridRouteNavigationRequest
+    {
+        /// <summary>
+        /// Initializes an application-route request.
+        /// </summary>
+        /// <param name="kind">The history or navigation operation.</param>
+        /// <param name="route">The destination route, or an unset route for Back and Forward.</param>
+        /// <param name="context">The grid context that produced the request.</param>
+        public DataGridRouteNavigationRequest(
+            DataGridRouteNavigationKind kind,
+            DataGridRoute route,
+            DataGridRouteContext context)
+        {
+            Kind = kind;
+            Route = route;
+            Context = context;
+        }
+
+        /// <summary>Gets the requested history or navigation operation.</summary>
+        public DataGridRouteNavigationKind Kind { get; }
+
+        /// <summary>Gets the destination route.</summary>
+        public DataGridRoute Route { get; }
+
+        /// <summary>Gets the grid context that produced the request.</summary>
+        public DataGridRouteContext Context { get; }
+
+        /// <summary>Gets whether this request contains all values required for its operation.</summary>
+        public bool IsValid =>
+            Kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward || Route.IsValid;
+    }
+
+    /// <summary>
+    /// Describes the completed outcome of an application-route request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    readonly struct DataGridRouteNavigationResult
+    {
+        /// <summary>
+        /// Initializes a route result.
+        /// </summary>
+        /// <param name="status">The non-throwing result status.</param>
+        /// <param name="currentRoute">The route active after completion when known.</param>
+        /// <param name="error">The exception reported by the host when navigation failed.</param>
+        public DataGridRouteNavigationResult(
+            DataGridRouteNavigationStatus status,
+            DataGridRoute currentRoute = default,
+            Exception error = null)
+        {
+            Status = status;
+            CurrentRoute = currentRoute;
+            Error = error;
+        }
+
+        /// <summary>Gets the non-throwing result status.</summary>
+        public DataGridRouteNavigationStatus Status { get; }
+
+        /// <summary>Gets whether the operation completed successfully.</summary>
+        public bool Succeeded => Status == DataGridRouteNavigationStatus.Succeeded;
+
+        /// <summary>Gets the route active after completion when known.</summary>
+        public DataGridRoute CurrentRoute { get; }
+
+        /// <summary>Gets the exception reported by the host when navigation failed.</summary>
+        public Exception Error { get; }
+
+        /// <summary>Creates a successful result.</summary>
+        /// <param name="currentRoute">The route active after completion when known.</param>
+        /// <returns>A successful result.</returns>
+        public static DataGridRouteNavigationResult Success(DataGridRoute currentRoute = default) =>
+            new(DataGridRouteNavigationStatus.Succeeded, currentRoute);
+
+        /// <summary>Creates a result with the supplied status.</summary>
+        /// <param name="status">A non-success result status.</param>
+        /// <returns>A result containing the supplied status.</returns>
+        public static DataGridRouteNavigationResult FromStatus(DataGridRouteNavigationStatus status) => new(status);
+
+        /// <summary>Creates a failed result without throwing through the input pipeline.</summary>
+        /// <param name="error">The exception reported by the route host.</param>
+        /// <returns>A failed result containing <paramref name="error"/>.</returns>
+        public static DataGridRouteNavigationResult Failure(Exception error) =>
+            new(DataGridRouteNavigationStatus.Failed, default, error);
+    }
+
+    /// <summary>
+    /// Resolves stable grid context into a framework-neutral application route.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridRouteResolver
+    {
+        /// <summary>Attempts to resolve a route for the supplied row and column context.</summary>
+        /// <param name="context">The stable grid context.</param>
+        /// <param name="route">The resolved route.</param>
+        /// <returns><see langword="true"/> when a valid route was resolved.</returns>
+        bool TryResolve(DataGridRouteContext context, out DataGridRoute route);
+    }
+
+    /// <summary>
+    /// Executes framework-neutral route requests using an application navigation host.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridRouteNavigator
+    {
+        /// <summary>Gets the route operations supported by this navigator.</summary>
+        DataGridRouteNavigationCapabilities Capabilities { get; }
+
+        /// <summary>Executes a route request.</summary>
+        /// <param name="request">The resolved route request.</param>
+        /// <param name="cancellationToken">Cancels navigation or an activation guard.</param>
+        /// <returns>A non-throwing navigation outcome.</returns>
+        ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationRequest request,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Coordinates route resolution, cancelable preview, host execution, and completion telemetry.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridRouteNavigationModel : INotifyPropertyChanged
+    {
+        /// <summary>Raised before a resolved request is sent to the route host.</summary>
+        event EventHandler<DataGridRouteNavigationChangingEventArgs> NavigationChanging;
+
+        /// <summary>Raised after a route operation completes.</summary>
+        event EventHandler<DataGridRouteNavigationChangedEventArgs> NavigationChanged;
+
+        /// <summary>Gets whether a route operation is currently in progress.</summary>
+        bool IsNavigating { get; }
+
+        /// <summary>Gets the last route reported as active by the host.</summary>
+        DataGridRoute CurrentRoute { get; }
+
+        /// <summary>Gets the result of the last completed operation.</summary>
+        DataGridRouteNavigationResult LastResult { get; }
+
+        /// <summary>Determines whether the model can issue an operation for the supplied context.</summary>
+        bool CanNavigate(DataGridRouteNavigationKind kind, DataGridRouteContext context);
+
+        /// <summary>Resolves and executes an application-route operation.</summary>
+        ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteContext context,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Provides cancelable preview data for a resolved application-route request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridRouteNavigationChangingEventArgs : CancelEventArgs
+    {
+        /// <summary>Initializes cancelable route preview data.</summary>
+        /// <param name="request">The resolved route request.</param>
+        public DataGridRouteNavigationChangingEventArgs(DataGridRouteNavigationRequest request)
+        {
+            Request = request;
+        }
+
+        /// <summary>Gets or sets the request sent to the route host when not canceled.</summary>
+        public DataGridRouteNavigationRequest Request { get; set; }
+    }
+
+    /// <summary>
+    /// Provides completion data for an application-route request.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridRouteNavigationChangedEventArgs : EventArgs
+    {
+        /// <summary>Initializes route completion data.</summary>
+        /// <param name="request">The request sent to the route host.</param>
+        /// <param name="result">The non-throwing host result.</param>
+        public DataGridRouteNavigationChangedEventArgs(
+            DataGridRouteNavigationRequest request,
+            DataGridRouteNavigationResult result)
+        {
+            Request = request;
+            Result = result;
+        }
+
+        /// <summary>Gets the request sent to the route host.</summary>
+        public DataGridRouteNavigationRequest Request { get; }
+
+        /// <summary>Gets the non-throwing host result.</summary>
+        public DataGridRouteNavigationResult Result { get; }
+    }
+
+    /// <summary>
+    /// Default framework-neutral route model used by ReactiveUI, Prism, Toolkit-style, and custom adapters.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridRouteNavigationModel : IDataGridRouteNavigationModel
+    {
+        private readonly IDataGridRouteResolver _resolver;
+        private readonly IDataGridRouteNavigator _navigator;
+        private bool _isNavigating;
+        private DataGridRoute _currentRoute;
+        private DataGridRouteNavigationResult _lastResult;
+
+        /// <summary>Initializes a route model from a resolver and application navigator.</summary>
+        /// <param name="resolver">Maps grid row and column context to routes.</param>
+        /// <param name="navigator">Executes routes using the application navigation host.</param>
+        public DataGridRouteNavigationModel(
+            IDataGridRouteResolver resolver,
+            IDataGridRouteNavigator navigator)
+        {
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+            _navigator = navigator ?? throw new ArgumentNullException(nameof(navigator));
+            _lastResult = DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.InvalidRequest);
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<DataGridRouteNavigationChangingEventArgs> NavigationChanging;
+
+        /// <inheritdoc />
+        public event EventHandler<DataGridRouteNavigationChangedEventArgs> NavigationChanged;
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc />
+        public bool IsNavigating => _isNavigating;
+
+        /// <inheritdoc />
+        public DataGridRoute CurrentRoute => _currentRoute;
+
+        /// <inheritdoc />
+        public DataGridRouteNavigationResult LastResult => _lastResult;
+
+        /// <inheritdoc />
+        public bool CanNavigate(DataGridRouteNavigationKind kind, DataGridRouteContext context)
+        {
+            if (!Supports(kind))
+            {
+                return false;
+            }
+
+            if (kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward)
+            {
+                return true;
+            }
+
+            return _resolver.TryResolve(context, out DataGridRoute route) && route.IsValid;
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteContext context,
+            CancellationToken cancellationToken = default)
+        {
+            DataGridRoute route = DataGridRoute.Unset;
+            if (!Supports(kind))
+            {
+                return Complete(
+                    new DataGridRouteNavigationRequest(kind, route, context),
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.NotSupported));
+            }
+
+            if (kind is not DataGridRouteNavigationKind.Back and not DataGridRouteNavigationKind.Forward &&
+                (!_resolver.TryResolve(context, out route) || !route.IsValid))
+            {
+                return Complete(
+                    new DataGridRouteNavigationRequest(kind, route, context),
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.RouteNotFound));
+            }
+
+            var request = new DataGridRouteNavigationRequest(kind, route, context);
+            var changing = new DataGridRouteNavigationChangingEventArgs(request);
+            NavigationChanging?.Invoke(this, changing);
+            request = changing.Request;
+            if (changing.Cancel)
+            {
+                return Complete(
+                    request,
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.Canceled));
+            }
+
+            if (!request.IsValid)
+            {
+                return Complete(
+                    request,
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.InvalidRequest));
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Complete(
+                    request,
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.Canceled));
+            }
+
+            SetIsNavigating(true);
+            DataGridRouteNavigationResult result;
+            try
+            {
+                result = await _navigator.NavigateAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                result = DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.Canceled);
+            }
+            catch (Exception error)
+            {
+                result = DataGridRouteNavigationResult.Failure(error);
+            }
+            finally
+            {
+                SetIsNavigating(false);
+            }
+
+            return Complete(request, result);
+        }
+
+        private bool Supports(DataGridRouteNavigationKind kind)
+        {
+            DataGridRouteNavigationCapabilities required = kind switch
+            {
+                DataGridRouteNavigationKind.Navigate => DataGridRouteNavigationCapabilities.Navigate,
+                DataGridRouteNavigationKind.Replace => DataGridRouteNavigationCapabilities.Replace,
+                DataGridRouteNavigationKind.Reset => DataGridRouteNavigationCapabilities.Reset,
+                DataGridRouteNavigationKind.Back => DataGridRouteNavigationCapabilities.Back,
+                DataGridRouteNavigationKind.Forward => DataGridRouteNavigationCapabilities.Forward,
+                _ => DataGridRouteNavigationCapabilities.None
+            };
+            return required != DataGridRouteNavigationCapabilities.None &&
+                (_navigator.Capabilities & required) == required;
+        }
+
+        private DataGridRouteNavigationResult Complete(
+            DataGridRouteNavigationRequest request,
+            DataGridRouteNavigationResult result)
+        {
+            DataGridRoute activeRoute = result.CurrentRoute;
+            if (result.Succeeded && !activeRoute.IsValid &&
+                request.Kind is DataGridRouteNavigationKind.Navigate or
+                    DataGridRouteNavigationKind.Replace or
+                    DataGridRouteNavigationKind.Reset)
+            {
+                activeRoute = request.Route;
+                result = DataGridRouteNavigationResult.Success(activeRoute);
+            }
+
+            if (result.Succeeded && activeRoute.IsValid && activeRoute != _currentRoute)
+            {
+                _currentRoute = activeRoute;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentRoute)));
+            }
+
+            _lastResult = result;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LastResult)));
+            NavigationChanged?.Invoke(this, new DataGridRouteNavigationChangedEventArgs(request, result));
+            return result;
+        }
+
+        private void SetIsNavigating(bool value)
+        {
+            if (_isNavigating == value)
+            {
+                return;
+            }
+
+            _isNavigating = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsNavigating)));
+        }
+    }
+
+    /// <summary>
+    /// Resolves routes through an AOT-safe delegate supplied by application composition.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DelegateDataGridRouteResolver : IDataGridRouteResolver
+    {
+        private readonly Func<DataGridRouteContext, DataGridRoute?> _resolver;
+
+        /// <summary>Initializes a delegate route resolver.</summary>
+        /// <param name="resolver">Returns a route or null when the context is not routable.</param>
+        public DelegateDataGridRouteResolver(Func<DataGridRouteContext, DataGridRoute?> resolver)
+        {
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        }
+
+        /// <inheritdoc />
+        public bool TryResolve(DataGridRouteContext context, out DataGridRoute route)
+        {
+            DataGridRoute? resolved = _resolver(context);
+            route = resolved.GetValueOrDefault();
+            return resolved.HasValue && route.IsValid;
+        }
+    }
+
+    /// <summary>
+    /// Executes route operations through an AOT-safe delegate supplied by a framework adapter.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DelegateDataGridRouteNavigator : IDataGridRouteNavigator
+    {
+        private readonly Func<DataGridRouteNavigationRequest, CancellationToken, ValueTask<DataGridRouteNavigationResult>> _navigate;
+
+        /// <summary>Initializes a delegate route navigator.</summary>
+        /// <param name="capabilities">The operations implemented by the delegate.</param>
+        /// <param name="navigate">The async route operation.</param>
+        public DelegateDataGridRouteNavigator(
+            DataGridRouteNavigationCapabilities capabilities,
+            Func<DataGridRouteNavigationRequest, CancellationToken, ValueTask<DataGridRouteNavigationResult>> navigate)
+        {
+            Capabilities = capabilities;
+            _navigate = navigate ?? throw new ArgumentNullException(nameof(navigate));
+        }
+
+        /// <inheritdoc />
+        public DataGridRouteNavigationCapabilities Capabilities { get; }
+
+        /// <inheritdoc />
+        public ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationRequest request,
+            CancellationToken cancellationToken = default) =>
+            _navigate(request, cancellationToken);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
@@ -117,6 +117,9 @@ namespace Avalonia.Controls.DataGridNavigation
         /// <summary>The navigator does not support the requested operation.</summary>
         NotSupported,
 
+        /// <summary>Another route operation is already mutating this navigation scope.</summary>
+        Busy,
+
         /// <summary>The request or route was invalid.</summary>
         InvalidRequest,
 
@@ -479,6 +482,7 @@ namespace Avalonia.Controls.DataGridNavigation
     {
         private readonly IDataGridRouteResolver _resolver;
         private readonly IDataGridRouteNavigator _navigator;
+        private int _navigationInProgress;
         private bool _isNavigating;
         private DataGridRoute _currentRoute;
         private DataGridRouteNavigationResult _lastResult;
@@ -516,7 +520,7 @@ namespace Avalonia.Controls.DataGridNavigation
         /// <inheritdoc />
         public bool CanNavigate(DataGridRouteNavigationKind kind, DataGridRouteContext context)
         {
-            if (!Supports(kind))
+            if (IsNavigating || !Supports(kind))
             {
                 return false;
             }
@@ -576,6 +580,13 @@ namespace Avalonia.Controls.DataGridNavigation
                     DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.Canceled));
             }
 
+            if (Interlocked.CompareExchange(ref _navigationInProgress, 1, 0) != 0)
+            {
+                return Complete(
+                    request,
+                    DataGridRouteNavigationResult.FromStatus(DataGridRouteNavigationStatus.Busy));
+            }
+
             SetIsNavigating(true);
             DataGridRouteNavigationResult result;
             try
@@ -592,6 +603,7 @@ namespace Avalonia.Controls.DataGridNavigation
             }
             finally
             {
+                Interlocked.Exchange(ref _navigationInProgress, 0);
                 SetIsNavigating(false);
             }
 

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridRouteNavigation.cs
@@ -252,6 +252,62 @@ namespace Avalonia.Controls.DataGridNavigation
     }
 
     /// <summary>
+    /// Creates route contexts for a DataGrid without coupling ViewModels to the control instance.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridRouteContextFactory
+    {
+        /// <summary>Creates a context for a data item and cell position.</summary>
+        DataGridRouteContext Create(
+            object item,
+            object columnKey,
+            DataGridNavigationPosition position,
+            DataGridRouteNavigationOrigin origin,
+            bool hasItem = true);
+    }
+
+    /// <summary>
+    /// Creates route contexts through an optional AOT-safe item-key selector.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridRouteContextFactory : IDataGridRouteContextFactory
+    {
+        private readonly Func<object, object> _itemKeySelector;
+
+        /// <summary>Initializes a context factory that preserves item references without a stable key.</summary>
+        public DataGridRouteContextFactory()
+        {
+        }
+
+        /// <summary>Initializes a context factory with a stable item-key selector.</summary>
+        /// <param name="itemKeySelector">Returns the stable key for a data item.</param>
+        public DataGridRouteContextFactory(Func<object, object> itemKeySelector)
+        {
+            _itemKeySelector = itemKeySelector ?? throw new ArgumentNullException(nameof(itemKeySelector));
+        }
+
+        /// <inheritdoc />
+        public DataGridRouteContext Create(
+            object item,
+            object columnKey,
+            DataGridNavigationPosition position,
+            DataGridRouteNavigationOrigin origin,
+            bool hasItem = true)
+        {
+            object itemKey = hasItem && item != null && _itemKeySelector != null ? _itemKeySelector(item) : null;
+            return new DataGridRouteContext(item, itemKey, columnKey, position, origin, hasItem);
+        }
+    }
+
+    /// <summary>
     /// Describes an application-route operation after grid context has been resolved.
     /// </summary>
 #if !DATAGRID_INTERNAL
@@ -422,6 +478,56 @@ namespace Avalonia.Controls.DataGridNavigation
     }
 
     /// <summary>
+    /// Lets a ViewModel request route navigation from the DataGrid bound to the model so the grid
+    /// supplies the authoritative current item, stable keys, and cell position.
+    /// </summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    interface IDataGridRouteNavigationController
+    {
+        /// <summary>Raised when application code requests a grid-contextual route operation.</summary>
+        event EventHandler<DataGridRouteNavigationRequestedEventArgs> NavigationRequested;
+
+        /// <summary>Requests a route operation from the DataGrid bound to this model.</summary>
+        /// <param name="kind">The route or history operation.</param>
+        /// <param name="origin">The source of the request.</param>
+        /// <returns><see langword="true"/> when a bound DataGrid accepted the request.</returns>
+        bool RequestNavigate(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteNavigationOrigin origin = DataGridRouteNavigationOrigin.Command);
+    }
+
+    /// <summary>Carries a ViewModel-issued route request to a bound DataGrid.</summary>
+#if !DATAGRID_INTERNAL
+    public
+#else
+    internal
+#endif
+    sealed class DataGridRouteNavigationRequestedEventArgs : EventArgs
+    {
+        /// <summary>Initializes a grid-contextual route request.</summary>
+        public DataGridRouteNavigationRequestedEventArgs(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteNavigationOrigin origin)
+        {
+            Kind = kind;
+            Origin = origin;
+        }
+
+        /// <summary>Gets the requested operation.</summary>
+        public DataGridRouteNavigationKind Kind { get; }
+
+        /// <summary>Gets the request origin.</summary>
+        public DataGridRouteNavigationOrigin Origin { get; }
+
+        /// <summary>Gets or sets whether a bound DataGrid accepted the request.</summary>
+        public bool Handled { get; set; }
+    }
+
+    /// <summary>
     /// Provides cancelable preview data for a resolved application-route request.
     /// </summary>
 #if !DATAGRID_INTERNAL
@@ -478,7 +584,7 @@ namespace Avalonia.Controls.DataGridNavigation
 #else
     internal
 #endif
-    sealed class DataGridRouteNavigationModel : IDataGridRouteNavigationModel
+    sealed class DataGridRouteNavigationModel : IDataGridRouteNavigationModel, IDataGridRouteNavigationController
     {
         private readonly IDataGridRouteResolver _resolver;
         private readonly IDataGridRouteNavigator _navigator;
@@ -506,6 +612,9 @@ namespace Avalonia.Controls.DataGridNavigation
         public event EventHandler<DataGridRouteNavigationChangedEventArgs> NavigationChanged;
 
         /// <inheritdoc />
+        public event EventHandler<DataGridRouteNavigationRequestedEventArgs> NavigationRequested;
+
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <inheritdoc />
@@ -516,6 +625,22 @@ namespace Avalonia.Controls.DataGridNavigation
 
         /// <inheritdoc />
         public DataGridRouteNavigationResult LastResult => _lastResult;
+
+        /// <inheritdoc />
+        public bool RequestNavigate(
+            DataGridRouteNavigationKind kind,
+            DataGridRouteNavigationOrigin origin = DataGridRouteNavigationOrigin.Command)
+        {
+            EventHandler<DataGridRouteNavigationRequestedEventArgs> handler = NavigationRequested;
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var args = new DataGridRouteNavigationRequestedEventArgs(kind, origin);
+            handler(this, args);
+            return args.Handled;
+        }
 
         /// <inheritdoc />
         public bool CanNavigate(DataGridRouteNavigationKind kind, DataGridRouteContext context)

--- a/src/DataGridSample.UnitTests/NavigationSampleTests.cs
+++ b/src/DataGridSample.UnitTests/NavigationSampleTests.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Linq;
 using System.Reactive.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using DataGridSample.Pages;
 using DataGridSample.ViewModels;
 using Xunit;
@@ -28,6 +32,8 @@ public sealed class NavigationSampleTests
         {
             DataGrid grid = view.GetLogicalDescendants().OfType<DataGrid>().Single();
             Assert.Same(viewModel.RouteNavigationModel, grid.RouteNavigationModel);
+            Assert.Same(viewModel.RouteContextFactory, grid.RouteContextFactory);
+            Assert.Same(viewModel.NavigationInputModel, grid.NavigationInputModel);
 
             viewModel.NavigateCommand.Execute().Subscribe();
             Assert.Contains("RoutingState.Navigate", viewModel.Status, StringComparison.Ordinal);
@@ -59,16 +65,86 @@ public sealed class NavigationSampleTests
             Assert.Same(viewModel.NavigationModel, grid.NavigationModel);
             Assert.Same(viewModel.RouteNavigationModel, grid.RouteNavigationModel);
             Assert.Same(viewModel.NavigationInputModel, grid.NavigationInputModel);
+            Assert.Same(viewModel.RouteContextFactory, grid.RouteContextFactory);
             DataGridNavigationInputResult jResult = viewModel.NavigationInputModel.Resolve(
                 CreateKeyRequest(DataGridNavigationInputKey.J));
             Assert.Equal(DataGridNavigationInputDecision.Navigate, jResult.Decision);
             Assert.Equal(DataGridNavigationCommand.Down, jResult.Command);
             Assert.True(viewModel.NavigationModel.RequestNavigate(DataGridNavigationCommand.Down));
+
+            DataGridCell target = grid.GetVisualDescendants()
+                .OfType<DataGridCell>()
+                .Single(cell => ReferenceEquals(cell.DataContext, viewModel.Items[2]) && cell.OwningColumn?.DisplayIndex == 1);
+            RaisePrimaryClick(target, window);
+
+            Assert.Contains("generated/303", viewModel.Status, StringComparison.Ordinal);
+            Assert.Contains("key 303", viewModel.Status, StringComparison.Ordinal);
+            Assert.Contains("cell 2:1", viewModel.Status, StringComparison.Ordinal);
         }
         finally
         {
             window.Close();
         }
+    }
+
+    [AvaloniaFact]
+    public void Route_page_click_routes_the_exact_cell_context_inside_the_grid()
+    {
+        var viewModel = new RouteNavigationSampleViewModel();
+        var view = new RouteNavigationPage { DataContext = viewModel };
+        var window = new Window { Width = 900, Height = 560, Content = view };
+        window.ApplySampleTheme();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            DataGrid grid = view.GetLogicalDescendants().OfType<DataGrid>().Single();
+            DataGridCell target = grid.GetVisualDescendants()
+                .OfType<DataGridCell>()
+                .Single(cell => ReferenceEquals(cell.DataContext, viewModel.Items[2]) && cell.OwningColumn?.DisplayIndex == 2);
+
+            RaisePrimaryClick(target, window);
+
+            Assert.Contains("work-items/108", viewModel.Status, StringComparison.Ordinal);
+            Assert.Contains("key 108", viewModel.Status, StringComparison.Ordinal);
+            Assert.Contains("cell 2:2", viewModel.Status, StringComparison.Ordinal);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void RaisePrimaryClick(Control source, Visual root)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var position = new Point(source.Bounds.Width / 2, source.Bounds.Height / 2);
+        var pressedProperties = new PointerPointProperties(
+            RawInputModifiers.LeftMouseButton,
+            PointerUpdateKind.LeftButtonPressed);
+        source.RaiseEvent(new PointerPressedEventArgs(
+            source,
+            pointer,
+            root,
+            position,
+            0,
+            pressedProperties,
+            KeyModifiers.None,
+            clickCount: 1));
+        var releasedProperties = new PointerPointProperties(
+            RawInputModifiers.None,
+            PointerUpdateKind.LeftButtonReleased);
+        source.RaiseEvent(new PointerReleasedEventArgs(
+            source,
+            pointer,
+            root,
+            position,
+            0,
+            releasedProperties,
+            KeyModifiers.None,
+            MouseButton.Left));
+        Dispatcher.UIThread.RunJobs();
     }
 
     private static DataGridNavigationInputRequest CreateKeyRequest(DataGridNavigationInputKey key) =>

--- a/src/DataGridSample.UnitTests/NavigationSampleTests.cs
+++ b/src/DataGridSample.UnitTests/NavigationSampleTests.cs
@@ -43,7 +43,7 @@ public sealed class NavigationSampleTests
     }
 
     [AvaloniaFact]
-    public void Generated_view_binds_generated_cell_and_application_route_models()
+    public void Generated_view_binds_generated_cell_input_and_application_route_models()
     {
         var viewModel = new GeneratedNavigationViewModel();
         var view = new GeneratedNavigationGridView(viewModel);
@@ -58,6 +58,11 @@ public sealed class NavigationSampleTests
 
             Assert.Same(viewModel.NavigationModel, grid.NavigationModel);
             Assert.Same(viewModel.RouteNavigationModel, grid.RouteNavigationModel);
+            Assert.Same(viewModel.NavigationInputModel, grid.NavigationInputModel);
+            DataGridNavigationInputResult jResult = viewModel.NavigationInputModel.Resolve(
+                CreateKeyRequest(DataGridNavigationInputKey.J));
+            Assert.Equal(DataGridNavigationInputDecision.Navigate, jResult.Decision);
+            Assert.Equal(DataGridNavigationCommand.Down, jResult.Command);
             Assert.True(viewModel.NavigationModel.RequestNavigate(DataGridNavigationCommand.Down));
         }
         finally
@@ -65,6 +70,26 @@ public sealed class NavigationSampleTests
             window.Close();
         }
     }
+
+    private static DataGridNavigationInputRequest CreateKeyRequest(DataGridNavigationInputKey key) =>
+        new(
+            DataGridNavigationInputKind.KeyDown,
+            key,
+            key,
+            DataGridNavigationKeyDeviceKind.Keyboard,
+            DataGridNavigationInputModifiers.None,
+            DataGridNavigationPointerDeviceKind.Unknown,
+            DataGridNavigationPointerButton.None,
+            DataGridNavigationWheelDirection.None,
+            0,
+            double.NaN,
+            double.NaN,
+            0,
+            0,
+            DataGridNavigationInputTargetKind.Cell,
+            DataGridNavigationPosition.Unset,
+            DataGridNavigationPosition.Unset,
+            false);
 
     [AvaloniaFact]
     public void Extended_navigation_pages_bind_models_without_view_event_handlers()

--- a/src/DataGridSample.UnitTests/NavigationSampleTests.cs
+++ b/src/DataGridSample.UnitTests/NavigationSampleTests.cs
@@ -15,6 +15,34 @@ namespace DataGridSample.Tests;
 public sealed class NavigationSampleTests
 {
     [AvaloniaFact]
+    public void Mvvm_framework_page_runs_framework_neutral_route_recipes()
+    {
+        var viewModel = new MvvmRouteFrameworksViewModel();
+        var view = new MvvmRouteFrameworksPage { DataContext = viewModel };
+        var window = new Window { Width = 1000, Height = 620, Content = view };
+        window.ApplySampleTheme();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            DataGrid grid = view.GetLogicalDescendants().OfType<DataGrid>().Single();
+            Assert.Same(viewModel.RouteNavigationModel, grid.RouteNavigationModel);
+
+            viewModel.NavigateCommand.Execute().Subscribe();
+            Assert.Contains("RoutingState.Navigate", viewModel.Status, StringComparison.Ordinal);
+
+            viewModel.SelectedRecipe = viewModel.Recipes[1];
+            viewModel.ResetCommand.Execute().Subscribe();
+            Assert.Contains("NavigateAsync(absoluteUri", viewModel.Status, StringComparison.Ordinal);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void Generated_view_binds_generated_cell_and_application_route_models()
     {
         var viewModel = new GeneratedNavigationViewModel();

--- a/src/DataGridSample.UnitTests/NavigationSampleTests.cs
+++ b/src/DataGridSample.UnitTests/NavigationSampleTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class NavigationSampleTests
+{
+    [AvaloniaFact]
+    public void Generated_view_binds_generated_cell_and_application_route_models()
+    {
+        var viewModel = new GeneratedNavigationViewModel();
+        var view = new GeneratedNavigationGridView(viewModel);
+        var window = new Window { Width = 900, Height = 560, Content = view };
+        window.ApplySampleTheme();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            DataGrid grid = view.GetLogicalDescendants().OfType<DataGrid>().Single();
+
+            Assert.Same(viewModel.NavigationModel, grid.NavigationModel);
+            Assert.Same(viewModel.RouteNavigationModel, grid.RouteNavigationModel);
+            Assert.True(viewModel.NavigationModel.RequestNavigate(DataGridNavigationCommand.Down));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Extended_navigation_pages_bind_models_without_view_event_handlers()
+    {
+        var customViewModel = new CustomNavigationModelViewModel();
+        var hierarchyViewModel = new HierarchicalNavigationViewModel();
+        var stateViewModel = new NavigationStateViewModel();
+        var tabs = new TabControl
+        {
+            ItemsSource = new object[]
+            {
+                new CustomNavigationModelPage { DataContext = customViewModel },
+                new HierarchicalNavigationPage { DataContext = hierarchyViewModel },
+                new NavigationStatePage { DataContext = stateViewModel }
+            }
+        };
+        var window = new Window { Width = 1000, Height = 680, Content = tabs };
+        window.ApplySampleTheme();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            DataGrid customGrid = tabs.GetLogicalDescendants().OfType<DataGrid>().First();
+            Assert.Same(customViewModel.NavigationModel, customGrid.NavigationModel);
+
+            stateViewModel.UseSpreadsheetPolicyCommand.Execute().Subscribe();
+            stateViewModel.CaptureCommand.Execute().Subscribe();
+            stateViewModel.UseContainedPolicyCommand.Execute().Subscribe();
+            stateViewModel.RestoreCommand.Execute().Subscribe();
+
+            Assert.Equal(DataGridNavigationBoundaryMode.Wrap, stateViewModel.NavigationModel.HorizontalBoundaryMode);
+            Assert.Equal(DataGridTabNavigationMode.Always, stateViewModel.NavigationModel.TabNavigationMode);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [Fact]
+    public void Custom_policy_redirects_protected_row_and_cancels_final_column()
+    {
+        var model = new CustomNavigationModelViewModel.GuardedNavigationModel();
+        var down = new DataGridNavigationRequest(
+            DataGridNavigationCommand.Down,
+            DataGridNavigationOrigin.Command,
+            new DataGridNavigationPosition(0, 1),
+            new DataGridNavigationPosition(1, 1),
+            Avalonia.Input.KeyModifiers.None,
+            isEditing: false,
+            DataGridSelectionMode.Single,
+            DataGridSelectionUnit.Cell,
+            Avalonia.Media.FlowDirection.LeftToRight,
+            firstRowIndex: 0,
+            lastRowIndex: 3,
+            firstColumnDisplayIndex: 0,
+            lastColumnDisplayIndex: 2);
+
+        DataGridNavigationResult redirected = model.Resolve(down);
+        DataGridNavigationResult canceled = model.Resolve(new DataGridNavigationRequest(
+            DataGridNavigationCommand.Right,
+            DataGridNavigationOrigin.Command,
+            new DataGridNavigationPosition(0, 2),
+            proposedPosition: null,
+            Avalonia.Input.KeyModifiers.None,
+            isEditing: false,
+            DataGridSelectionMode.Single,
+            DataGridSelectionUnit.Cell,
+            Avalonia.Media.FlowDirection.LeftToRight,
+            firstRowIndex: 0,
+            lastRowIndex: 3,
+            firstColumnDisplayIndex: 0,
+            lastColumnDisplayIndex: 2));
+
+        Assert.Equal(new DataGridNavigationPosition(2, 1), redirected.Target);
+        Assert.Equal(DataGridNavigationDecision.Stay, canceled.Decision);
+        Assert.Equal(DataGridNavigationFailureReason.Canceled, canceled.FailureReason);
+    }
+}

--- a/src/DataGridSample/Adapters/ReactiveUiDataGridRouteNavigator.cs
+++ b/src/DataGridSample/Adapters/ReactiveUiDataGridRouteNavigator.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.Adapters;
+
+/// <summary>
+/// Adapts the framework-neutral DataGrid route contract to a ReactiveUI routing stack.
+/// </summary>
+public sealed class ReactiveUiDataGridRouteNavigator : IDataGridRouteNavigator
+{
+    private readonly IScreen _screen;
+    private readonly Func<DataGridRoute, IRoutableViewModel?> _viewModelFactory;
+
+    public ReactiveUiDataGridRouteNavigator(
+        IScreen screen,
+        Func<DataGridRoute, IRoutableViewModel?> viewModelFactory)
+    {
+        _screen = screen ?? throw new ArgumentNullException(nameof(screen));
+        _viewModelFactory = viewModelFactory ?? throw new ArgumentNullException(nameof(viewModelFactory));
+    }
+
+    public DataGridRouteNavigationCapabilities Capabilities =>
+        DataGridRouteNavigationCapabilities.Navigate |
+        DataGridRouteNavigationCapabilities.Reset |
+        DataGridRouteNavigationCapabilities.Back;
+
+    public async ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+        DataGridRouteNavigationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        switch (request.Kind)
+        {
+            case DataGridRouteNavigationKind.Navigate:
+            case DataGridRouteNavigationKind.Reset:
+                IRoutableViewModel? viewModel = _viewModelFactory(request.Route);
+                if (viewModel == null)
+                {
+                    return DataGridRouteNavigationResult.FromStatus(
+                        DataGridRouteNavigationStatus.RouteNotFound);
+                }
+
+                if (request.Kind == DataGridRouteNavigationKind.Reset)
+                {
+                    await _screen.Router.NavigateAndReset.Execute(viewModel).ToTask(cancellationToken);
+                }
+                else
+                {
+                    await _screen.Router.Navigate.Execute(viewModel).ToTask(cancellationToken);
+                }
+
+                return DataGridRouteNavigationResult.Success(request.Route);
+
+            case DataGridRouteNavigationKind.Back:
+                if (_screen.Router.NavigationStack.Count <= 1)
+                {
+                    return DataGridRouteNavigationResult.FromStatus(
+                        DataGridRouteNavigationStatus.NotSupported);
+                }
+
+                IRoutableViewModel current = await _screen.Router.NavigateBack
+                    .Execute(RxVoid.Default)
+                    .ToTask(cancellationToken);
+                return DataGridRouteNavigationResult.Success(
+                    new DataGridRoute(current.UrlPathSegment));
+
+            default:
+                return DataGridRouteNavigationResult.FromStatus(
+                    DataGridRouteNavigationStatus.NotSupported);
+        }
+    }
+}

--- a/src/DataGridSample/Adapters/ReactiveUiRouteViewLocator.cs
+++ b/src/DataGridSample/Adapters/ReactiveUiRouteViewLocator.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using ReactiveUI;
+
+namespace DataGridSample.Adapters;
+
+/// <summary>
+/// A reflection-free ReactiveUI view locator for the route navigation sample.
+/// </summary>
+public sealed class ReactiveUiRouteViewLocator : IViewLocator
+{
+    public IViewFor<TViewModel>? ResolveView<TViewModel>() where TViewModel : class =>
+        ResolveView<TViewModel>(null);
+
+    public IViewFor<TViewModel>? ResolveView<TViewModel>(string? contract) where TViewModel : class
+    {
+        IViewFor? view = typeof(TViewModel) == typeof(OrderListRouteViewModel)
+            ? new OrderListRouteView()
+            : typeof(TViewModel) == typeof(OrderDetailRouteViewModel)
+                ? new OrderDetailRouteView()
+                : null;
+        return view as IViewFor<TViewModel>;
+    }
+
+    public IViewFor? ResolveView(object? instance) => ResolveView(instance, null);
+
+    public IViewFor? ResolveView(object? instance, string? contract) => instance switch
+    {
+        OrderListRouteViewModel => new OrderListRouteView(),
+        OrderDetailRouteViewModel => new OrderDetailRouteView(),
+        _ => null
+    };
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -490,6 +490,13 @@
         </pages:ReactiveUiRouteNavigationPage.DataContext>
       </pages:ReactiveUiRouteNavigationPage>
     </TabItem>
+    <TabItem Header="Navigation MVVM Frameworks">
+      <pages:MvvmRouteFrameworksPage>
+        <pages:MvvmRouteFrameworksPage.DataContext>
+          <viewModels:MvvmRouteFrameworksViewModel />
+        </pages:MvvmRouteFrameworksPage.DataContext>
+      </pages:MvvmRouteFrameworksPage>
+    </TabItem>
     <TabItem Header="Navigation Source Generator">
       <pages:GeneratedNavigationPage>
         <pages:GeneratedNavigationPage.DataContext>

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -455,6 +455,27 @@
         </pages:NavigationAdvancedLayoutPage.DataContext>
       </pages:NavigationAdvancedLayoutPage>
     </TabItem>
+    <TabItem Header="Navigation Custom Policy">
+      <pages:CustomNavigationModelPage>
+        <pages:CustomNavigationModelPage.DataContext>
+          <viewModels:CustomNavigationModelViewModel />
+        </pages:CustomNavigationModelPage.DataContext>
+      </pages:CustomNavigationModelPage>
+    </TabItem>
+    <TabItem Header="Navigation Hierarchy">
+      <pages:HierarchicalNavigationPage>
+        <pages:HierarchicalNavigationPage.DataContext>
+          <viewModels:HierarchicalNavigationViewModel />
+        </pages:HierarchicalNavigationPage.DataContext>
+      </pages:HierarchicalNavigationPage>
+    </TabItem>
+    <TabItem Header="Navigation State">
+      <pages:NavigationStatePage>
+        <pages:NavigationStatePage.DataContext>
+          <viewModels:NavigationStateViewModel />
+        </pages:NavigationStatePage.DataContext>
+      </pages:NavigationStatePage>
+    </TabItem>
     <TabItem Header="Navigation Application Routes">
       <pages:RouteNavigationPage>
         <pages:RouteNavigationPage.DataContext>

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -427,6 +427,55 @@
     <TabItem Header="Routed events">
       <pages:RoutedEventsPage />
     </TabItem>
+    <TabItem Header="Navigation Model Basics">
+      <pages:NavigationModelBasicsPage>
+        <pages:NavigationModelBasicsPage.DataContext>
+          <viewModels:NavigationModelSampleViewModel />
+        </pages:NavigationModelBasicsPage.DataContext>
+      </pages:NavigationModelBasicsPage>
+    </TabItem>
+    <TabItem Header="Navigation Policies &amp; RTL">
+      <pages:NavigationPoliciesPage>
+        <pages:NavigationPoliciesPage.DataContext>
+          <viewModels:NavigationModelSampleViewModel />
+        </pages:NavigationPoliciesPage.DataContext>
+      </pages:NavigationPoliciesPage>
+    </TabItem>
+    <TabItem Header="Navigation Editing &amp; Selection">
+      <pages:NavigationEditingSelectionPage>
+        <pages:NavigationEditingSelectionPage.DataContext>
+          <viewModels:NavigationModelSampleViewModel />
+        </pages:NavigationEditingSelectionPage.DataContext>
+      </pages:NavigationEditingSelectionPage>
+    </TabItem>
+    <TabItem Header="Navigation Advanced Layout">
+      <pages:NavigationAdvancedLayoutPage>
+        <pages:NavigationAdvancedLayoutPage.DataContext>
+          <viewModels:NavigationModelSampleViewModel />
+        </pages:NavigationAdvancedLayoutPage.DataContext>
+      </pages:NavigationAdvancedLayoutPage>
+    </TabItem>
+    <TabItem Header="Navigation Application Routes">
+      <pages:RouteNavigationPage>
+        <pages:RouteNavigationPage.DataContext>
+          <viewModels:RouteNavigationSampleViewModel />
+        </pages:RouteNavigationPage.DataContext>
+      </pages:RouteNavigationPage>
+    </TabItem>
+    <TabItem Header="Navigation ReactiveUI Routes">
+      <pages:ReactiveUiRouteNavigationPage>
+        <pages:ReactiveUiRouteNavigationPage.DataContext>
+          <viewModels:ReactiveUiRouteNavigationViewModel />
+        </pages:ReactiveUiRouteNavigationPage.DataContext>
+      </pages:ReactiveUiRouteNavigationPage>
+    </TabItem>
+    <TabItem Header="Navigation Source Generator">
+      <pages:GeneratedNavigationPage>
+        <pages:GeneratedNavigationPage.DataContext>
+          <viewModels:GeneratedNavigationViewModel />
+        </pages:GeneratedNavigationPage.DataContext>
+      </pages:GeneratedNavigationPage>
+    </TabItem>
     <TabItem Header="Keyboard Overrides">
       <pages:KeyboardGestureHandlingPage />
     </TabItem>

--- a/src/DataGridSample/Pages/CustomNavigationModelPage.axaml
+++ b/src/DataGridSample/Pages/CustomNavigationModelPage.axaml
@@ -1,0 +1,36 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.CustomNavigationModelPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:CustomNavigationModelViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Custom navigation policy" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="A ViewModel-owned subclass redirects a semantic request and vetoes another. The view only binds commands and the model." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1">
+      <Button Margin="0,0,6,0" Content="Down (skip protected)" Command="{CompiledBinding DownCommand}" />
+      <Button Content="Right (guard final column)" Command="{CompiledBinding RightCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="90" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:CustomNavigationModelViewModel+CustomNavigationRow" />
+        <DataGridTextColumn Header="Name" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:CustomNavigationModelViewModel+CustomNavigationRow" />
+        <DataGridTextColumn Header="Access" Width="*" ColumnKey="access"
+                            Binding="{CompiledBinding Access}" x:DataType="vm:CustomNavigationModelViewModel+CustomNavigationRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Padding="10" CornerRadius="6" Background="#100078D4">
+      <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/CustomNavigationModelPage.axaml.cs
+++ b/src/DataGridSample/Pages/CustomNavigationModelPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class CustomNavigationModelPage : UserControl
+{
+    public CustomNavigationModelPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
+++ b/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
@@ -5,11 +5,11 @@
              xmlns:pages="clr-namespace:DataGridSample.Pages"
              xmlns:vm="clr-namespace:DataGridSample.ViewModels"
              x:DataType="vm:GeneratedNavigationViewModel">
-  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="10">
     <StackPanel Spacing="4">
       <TextBlock FontSize="20" FontWeight="SemiBold" Text="Source-generated navigation" />
       <TextBlock TextWrapping="Wrap"
-                 Text="The schema provider creates both model types, the partial ViewModel owns a generated cell controller, and the generated view uses reflection-free compiled bindings for both models." />
+                 Text="The provider generates cell and input models; the partial ViewModel owns the key, pointer, wheel, and route policy; and the generated view binds all models without reflection or event handlers." />
     </StackPanel>
 
     <WrapPanel Grid.Row="1">
@@ -19,9 +19,14 @@
       <Button Content="Back" Command="{CompiledBinding BackCommand}" />
     </WrapPanel>
 
-    <pages:GeneratedNavigationGridView Grid.Row="2" />
+    <Border Grid.Row="2" Padding="10" CornerRadius="6" Background="#0C605E5C">
+      <TextBlock TextWrapping="Wrap"
+                 Text="Input model: J/K move vertically, the physical H key moves left on every keyboard layout, G/Shift+G jump to grid start/end through ViewModel resolution, a primary cell press targets that cell, and Ctrl+wheel navigates route history." />
+    </Border>
 
-    <Border Grid.Row="3" Padding="10" CornerRadius="6" Background="#100078D4">
+    <pages:GeneratedNavigationGridView Grid.Row="3" />
+
+    <Border Grid.Row="4" Padding="10" CornerRadius="6" Background="#100078D4">
       <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
     </Border>
   </Grid>

--- a/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
+++ b/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
@@ -9,7 +9,7 @@
     <StackPanel Spacing="4">
       <TextBlock FontSize="20" FontWeight="SemiBold" Text="Source-generated navigation" />
       <TextBlock TextWrapping="Wrap"
-                 Text="The provider generates cell and input models; the partial ViewModel owns the key, pointer, wheel, and route policy; and the generated view binds all models without reflection or event handlers." />
+                 Text="The provider generates cell, input, and stable-key route-context models. The generated view binds them without reflection or event handlers, so click and Enter routes originate inside the grid with the exact cell context." />
     </StackPanel>
 
     <WrapPanel Grid.Row="1">
@@ -21,7 +21,7 @@
 
     <Border Grid.Row="2" Padding="10" CornerRadius="6" Background="#0C605E5C">
       <TextBlock TextWrapping="Wrap"
-                 Text="Input model: J/K move vertically, the physical H key moves left on every keyboard layout, G/Shift+G jump to grid start/end through ViewModel resolution, a primary cell press targets that cell, and Ctrl+wheel navigates route history." />
+                 Text="Input model: J/K move vertically, physical H moves left, G/Shift+G jump to grid edges, primary press targets a cell, release or Enter opens its route with generated stable identity, and Ctrl+wheel navigates history." />
     </Border>
 
     <pages:GeneratedNavigationGridView Grid.Row="3" />

--- a/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
+++ b/src/DataGridSample/Pages/GeneratedNavigationPage.axaml
@@ -1,0 +1,28 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.GeneratedNavigationPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:pages="clr-namespace:DataGridSample.Pages"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:GeneratedNavigationViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Source-generated navigation" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="The schema provider creates both model types, the partial ViewModel owns a generated cell controller, and the generated view uses reflection-free compiled bindings for both models." />
+    </StackPanel>
+
+    <WrapPanel Grid.Row="1">
+      <Button Margin="0,0,6,0" Content="Previous cell" Command="{CompiledBinding PreviousCellCommand}" />
+      <Button Margin="0,0,14,0" Content="Next cell" Command="{CompiledBinding NextCellCommand}" />
+      <Button Margin="0,0,6,0" Content="Open selected route" Command="{CompiledBinding OpenRouteCommand}" />
+      <Button Content="Back" Command="{CompiledBinding BackCommand}" />
+    </WrapPanel>
+
+    <pages:GeneratedNavigationGridView Grid.Row="2" />
+
+    <Border Grid.Row="3" Padding="10" CornerRadius="6" Background="#100078D4">
+      <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/GeneratedNavigationPage.axaml.cs
+++ b/src/DataGridSample/Pages/GeneratedNavigationPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class GeneratedNavigationPage : UserControl
+{
+    public GeneratedNavigationPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/HierarchicalNavigationPage.axaml
+++ b/src/DataGridSample/Pages/HierarchicalNavigationPage.axaml
@@ -1,0 +1,44 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.HierarchicalNavigationPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:hier="clr-namespace:Avalonia.Controls.DataGridHierarchical;assembly=Avalonia.Controls.DataGrid"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:HierarchicalNavigationViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Hierarchical navigation" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Expand, collapse, subtree expansion, and vertical movement use the same semantic controller as flat-grid navigation." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1">
+      <Button Margin="0,0,6,0" Content="Expand" Command="{CompiledBinding ExpandCommand}" />
+      <Button Margin="0,0,14,0" Content="Collapse" Command="{CompiledBinding CollapseCommand}" />
+      <Button Margin="0,0,14,0" Content="Expand subtree" Command="{CompiledBinding ExpandSubtreeCommand}" />
+      <Button Margin="0,0,6,0" Content="Up" Command="{CompiledBinding UpCommand}" />
+      <Button Content="Down" Command="{CompiledBinding DownCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              HierarchicalModel="{CompiledBinding Model}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              HierarchicalRowsEnabled="True"
+              Classes="hierarchical"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridHierarchicalColumn Header="Node" Width="2*"
+                                    Binding="{CompiledBinding Item}" x:DataType="hier:HierarchicalNode">
+          <DataGridHierarchicalColumn.CellTemplate>
+            <DataTemplate x:DataType="vm:HierarchicalNavigationViewModel+NavigationTreeNode">
+              <TextBlock Text="{CompiledBinding Name}" />
+            </DataTemplate>
+          </DataGridHierarchicalColumn.CellTemplate>
+        </DataGridHierarchicalColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Padding="10" CornerRadius="6" Background="#100078D4">
+      <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/HierarchicalNavigationPage.axaml.cs
+++ b/src/DataGridSample/Pages/HierarchicalNavigationPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class HierarchicalNavigationPage : UserControl
+{
+    public HierarchicalNavigationPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml
+++ b/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml
@@ -1,0 +1,40 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.MvvmRouteFrameworksPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:MvvmRouteFrameworksViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="MVVM framework route wiring" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Every framework keeps its native router behind IDataGridRouteNavigator. Select a recipe to see how the same stable DataGrid route maps to ReactiveUI, Prism, CommunityToolkit.Mvvm, or plain DI." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10">
+      <Button Margin="0,0,6,6" Content="Navigate" Command="{CompiledBinding NavigateCommand}" />
+      <Button Margin="0,0,6,6" Content="Reset" Command="{CompiledBinding ResetCommand}" />
+      <Button Margin="0,0,6,6" Content="Back" Command="{CompiledBinding BackCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Recipes}"
+              SelectedItem="{CompiledBinding SelectedRecipe, Mode=TwoWay}"
+              RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionMode="Single">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Framework" Width="150" ColumnKey="framework"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:MvvmRouteFrameworksViewModel+FrameworkRouteRecipe" />
+        <DataGridTextColumn Header="Native host" Width="220" ColumnKey="host"
+                            Binding="{CompiledBinding NativeHost}" x:DataType="vm:MvvmRouteFrameworksViewModel+FrameworkRouteRecipe" />
+        <DataGridTextColumn Header="Native operations" Width="260" ColumnKey="operations"
+                            Binding="{CompiledBinding NativeOperations}" x:DataType="vm:MvvmRouteFrameworksViewModel+FrameworkRouteRecipe" />
+        <DataGridTextColumn Header="Integration boundary" Width="2*" ColumnKey="notes"
+                            Binding="{CompiledBinding IntegrationNotes}" x:DataType="vm:MvvmRouteFrameworksViewModel+FrameworkRouteRecipe" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Margin="0,10,0,0" Padding="10" Background="#100078D4" CornerRadius="6">
+      <TextBlock TextWrapping="Wrap" Text="{CompiledBinding Status}" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml
+++ b/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml
@@ -8,7 +8,7 @@
     <StackPanel Spacing="4">
       <TextBlock FontSize="20" FontWeight="SemiBold" Text="MVVM framework route wiring" />
       <TextBlock TextWrapping="Wrap"
-                 Text="Every framework keeps its native router behind IDataGridRouteNavigator. Select a recipe to see how the same stable DataGrid route maps to ReactiveUI, Prism, CommunityToolkit.Mvvm, or plain DI." />
+                 Text="Every framework keeps its native router behind IDataGridRouteNavigator. Click a recipe cell or press Enter to route with the DataGrid-owned item, key, column, and position context; toolbar commands use that same path." />
     </StackPanel>
     <WrapPanel Grid.Row="1" Margin="0,10">
       <Button Margin="0,0,6,6" Content="Navigate" Command="{CompiledBinding NavigateCommand}" />
@@ -19,6 +19,8 @@
               ItemsSource="{CompiledBinding Recipes}"
               SelectedItem="{CompiledBinding SelectedRecipe, Mode=TwoWay}"
               RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              RouteContextFactory="{CompiledBinding RouteContextFactory}"
+              NavigationInputModel="{CompiledBinding NavigationInputModel}"
               AutoGenerateColumns="False"
               CanUserAddRows="False"
               SelectionMode="Single">

--- a/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml.cs
+++ b/src/DataGridSample/Pages/MvvmRouteFrameworksPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class MvvmRouteFrameworksPage : UserControl
+{
+    public MvvmRouteFrameworksPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/NavigationAdvancedLayoutPage.axaml
+++ b/src/DataGridSample/Pages/NavigationAdvancedLayoutPage.axaml
@@ -1,0 +1,42 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.NavigationAdvancedLayoutPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:NavigationModelSampleViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Hidden, reordered, and frozen columns" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Navigation uses visible display order and skips filler columns. Frozen-left, frozen-right, hidden, and read-only columns keep the existing virtualization mechanics." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10">
+      <Button Margin="0,0,6,6" Content="←" Command="{CompiledBinding LeftCommand}" />
+      <Button Margin="0,0,6,6" Content="→" Command="{CompiledBinding RightCommand}" />
+      <Button Margin="0,0,6,6" Content="Row start" Command="{CompiledBinding RowStartCommand}" />
+      <Button Margin="0,0,6,6" Content="Row end" Command="{CompiledBinding RowEndCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              FrozenColumnCount="1"
+              FrozenColumnCountRight="1"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Frozen ID" Width="100" ColumnKey="id" DisplayIndex="0"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Hidden" Width="100" ColumnKey="hidden" IsVisible="False" DisplayIndex="2"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Status (reordered)" Width="*" ColumnKey="status" DisplayIndex="1"
+                            Binding="{CompiledBinding Status}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Name" Width="2*" ColumnKey="name" DisplayIndex="3"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridCheckBoxColumn Header="Frozen right" Width="120" ColumnKey="enabled" DisplayIndex="4"
+                                Binding="{CompiledBinding Enabled}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <TextBlock Grid.Row="3" Margin="0,10,0,0" Text="{CompiledBinding Status}" />
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/NavigationAdvancedLayoutPage.axaml.cs
+++ b/src/DataGridSample/Pages/NavigationAdvancedLayoutPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class NavigationAdvancedLayoutPage : UserControl
+{
+    public NavigationAdvancedLayoutPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/NavigationEditingSelectionPage.axaml
+++ b/src/DataGridSample/Pages/NavigationEditingSelectionPage.axaml
@@ -1,0 +1,50 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.NavigationEditingSelectionPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             xmlns:nav="clr-namespace:Avalonia.Controls.DataGridNavigation;assembly=Avalonia.Controls.DataGrid"
+             x:DataType="vm:NavigationModelSampleViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Editing, Tab, Enter, and selection" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="F2/editor ownership, validation-aware movement, row-major Tab, Enter continuation, and Shift selection all pass through one semantic pipeline." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10">
+      <Button Margin="0,0,6,6" Content="Begin edit (F2)" Command="{CompiledBinding BeginEditCommand}" />
+      <Button Margin="0,0,6,6" Content="Cancel edit (Esc)" Command="{CompiledBinding CancelEditCommand}" />
+      <Button Margin="0,0,6,6" Content="Previous (Shift+Tab)" Command="{CompiledBinding PreviousCommand}" />
+      <Button Margin="0,0,6,6" Content="Next (Tab)" Command="{CompiledBinding NextCommand}" />
+      <Button Margin="0,0,6,6" Content="Extend down (Shift+↓)" Command="{CompiledBinding ExtendDownCommand}" />
+      <ComboBox Width="130"
+                SelectedItem="{CompiledBinding NavigationModel.TabNavigationMode, Mode=TwoWay}">
+        <nav:DataGridTabNavigationMode>EditingOnly</nav:DataGridTabNavigationMode>
+        <nav:DataGridTabNavigationMode>Always</nav:DataGridTabNavigationMode>
+      </ComboBox>
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionMode="Extended"
+              SelectionUnit="Cell"
+              EnterKeyNavigationMode="NextCell"
+              ContinueEditingOnEnter="True">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Read-only ID" Width="110" IsReadOnly="True" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Editable name" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Editable status" Width="*" ColumnKey="status"
+                            Binding="{CompiledBinding Status}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridCheckBoxColumn Header="Enabled" Width="100" ColumnKey="enabled"
+                                Binding="{CompiledBinding Enabled}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Margin="0,10,0,0" Padding="10" Background="#100078D4" CornerRadius="6">
+      <TextBlock Text="{CompiledBinding Status}" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/NavigationEditingSelectionPage.axaml.cs
+++ b/src/DataGridSample/Pages/NavigationEditingSelectionPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class NavigationEditingSelectionPage : UserControl
+{
+    public NavigationEditingSelectionPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/NavigationModelBasicsPage.axaml
+++ b/src/DataGridSample/Pages/NavigationModelBasicsPage.axaml
@@ -1,0 +1,48 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.NavigationModelBasicsPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:NavigationModelSampleViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Navigation model basics" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Semantic movement is independent of gestures. These ReactiveCommands request navigation through the model bound to the grid." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10" VerticalAlignment="Center">
+      <Button Margin="0,0,6,6" Content="↑" Command="{CompiledBinding UpCommand}" />
+      <Button Margin="0,0,6,6" Content="↓" Command="{CompiledBinding DownCommand}" />
+      <Button Margin="0,0,6,6" Content="←" Command="{CompiledBinding LeftCommand}" />
+      <Button Margin="0,0,14,6" Content="→" Command="{CompiledBinding RightCommand}" />
+      <Button Margin="0,0,6,6" Content="Row start" Command="{CompiledBinding RowStartCommand}" />
+      <Button Margin="0,0,6,6" Content="Row end" Command="{CompiledBinding RowEndCommand}" />
+      <Button Margin="0,0,6,6" Content="Grid start" Command="{CompiledBinding GridStartCommand}" />
+      <Button Margin="0,0,6,6" Content="Grid end" Command="{CompiledBinding GridEndCommand}" />
+      <Button Margin="0,0,6,6" Content="Page up" Command="{CompiledBinding PageUpCommand}" />
+      <Button Margin="0,0,6,6" Content="Page down" Command="{CompiledBinding PageDownCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="90" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Name" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Status" Width="*" ColumnKey="status"
+                            Binding="{CompiledBinding Status}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Progress" Width="*" ColumnKey="progress"
+                            Binding="{CompiledBinding Progress, StringFormat={}{0:P0}}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridCheckBoxColumn Header="Enabled" Width="100" ColumnKey="enabled"
+                                Binding="{CompiledBinding Enabled}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Margin="0,10,0,0" Padding="10" CornerRadius="6" Background="#100078D4">
+      <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/NavigationModelBasicsPage.axaml.cs
+++ b/src/DataGridSample/Pages/NavigationModelBasicsPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class NavigationModelBasicsPage : UserControl
+{
+    public NavigationModelBasicsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/NavigationPoliciesPage.axaml
+++ b/src/DataGridSample/Pages/NavigationPoliciesPage.axaml
@@ -1,0 +1,78 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.NavigationPoliciesPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             xmlns:nav="clr-namespace:Avalonia.Controls.DataGridNavigation;assembly=Avalonia.Controls.DataGrid"
+             xmlns:media="clr-namespace:Avalonia.Media;assembly=Avalonia.Base"
+             x:DataType="vm:NavigationModelSampleViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Navigation policies and direction" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Configure contained, wrapping, or focus-exit boundaries; opt into Tab traversal and logical RTL movement without replacing the grid engine." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10" VerticalAlignment="Center">
+      <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Horizontal" />
+      <ComboBox Width="120" Margin="0,0,14,6"
+                SelectedItem="{CompiledBinding NavigationModel.HorizontalBoundaryMode, Mode=TwoWay}">
+        <nav:DataGridNavigationBoundaryMode>Contained</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Wrap</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Exit</nav:DataGridNavigationBoundaryMode>
+      </ComboBox>
+      <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Vertical" />
+      <ComboBox Width="120" Margin="0,0,14,6"
+                SelectedItem="{CompiledBinding NavigationModel.VerticalBoundaryMode, Mode=TwoWay}">
+        <nav:DataGridNavigationBoundaryMode>Contained</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Wrap</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Exit</nav:DataGridNavigationBoundaryMode>
+      </ComboBox>
+      <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Tab" />
+      <ComboBox Width="120" Margin="0,0,14,6"
+                SelectedItem="{CompiledBinding NavigationModel.TabBoundaryMode, Mode=TwoWay}">
+        <nav:DataGridNavigationBoundaryMode>Contained</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Wrap</nav:DataGridNavigationBoundaryMode>
+        <nav:DataGridNavigationBoundaryMode>Exit</nav:DataGridNavigationBoundaryMode>
+      </ComboBox>
+      <ComboBox Width="130" Margin="0,0,14,6"
+                SelectedItem="{CompiledBinding NavigationModel.TabNavigationMode, Mode=TwoWay}">
+        <nav:DataGridTabNavigationMode>EditingOnly</nav:DataGridTabNavigationMode>
+        <nav:DataGridTabNavigationMode>Always</nav:DataGridTabNavigationMode>
+      </ComboBox>
+      <ComboBox Width="110" Margin="0,0,14,6"
+                SelectedItem="{CompiledBinding NavigationModel.HorizontalNavigationMode, Mode=TwoWay}">
+        <nav:DataGridHorizontalNavigationMode>Physical</nav:DataGridHorizontalNavigationMode>
+        <nav:DataGridHorizontalNavigationMode>Logical</nav:DataGridHorizontalNavigationMode>
+      </ComboBox>
+      <ComboBox Width="120" Margin="0,0,6,6" SelectedItem="{CompiledBinding FlowDirection, Mode=TwoWay}">
+        <media:FlowDirection>LeftToRight</media:FlowDirection>
+        <media:FlowDirection>RightToLeft</media:FlowDirection>
+      </ComboBox>
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              FlowDirection="{CompiledBinding FlowDirection}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="90" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Name" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Status" Width="*" ColumnKey="status"
+                            Binding="{CompiledBinding Status}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+        <DataGridTextColumn Header="Progress" Width="*" ColumnKey="progress"
+                            Binding="{CompiledBinding Progress, StringFormat={}{0:P0}}" x:DataType="vm:NavigationModelSampleViewModel+NavigationRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <WrapPanel Grid.Row="3" Margin="0,10,0,0">
+      <Button Margin="0,0,6,6" Content="Previous cell" Command="{CompiledBinding PreviousCommand}" />
+      <Button Margin="0,0,6,6" Content="Next cell" Command="{CompiledBinding NextCommand}" />
+      <Button Margin="0,0,6,6" Content="←" Command="{CompiledBinding LeftCommand}" />
+      <Button Margin="0,0,12,6" Content="→" Command="{CompiledBinding RightCommand}" />
+      <TextBlock VerticalAlignment="Center" Text="{CompiledBinding Status}" />
+    </WrapPanel>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/NavigationPoliciesPage.axaml.cs
+++ b/src/DataGridSample/Pages/NavigationPoliciesPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class NavigationPoliciesPage : UserControl
+{
+    public NavigationPoliciesPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/NavigationStatePage.axaml
+++ b/src/DataGridSample/Pages/NavigationStatePage.axaml
@@ -1,0 +1,38 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.NavigationStatePage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:NavigationStateViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Navigation state" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Policy snapshots are detached and serializable. Current-cell identity is captured by the existing keyed selection-state contract, so filtering and column reorder remain safe." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1">
+      <Button Margin="0,0,6,0" Content="Spreadsheet policy" Command="{CompiledBinding UseSpreadsheetPolicyCommand}" />
+      <Button Margin="0,0,14,0" Content="Contained policy" Command="{CompiledBinding UseContainedPolicyCommand}" />
+      <Button Margin="0,0,6,0" Content="Capture policy" Command="{CompiledBinding CaptureCommand}" />
+      <Button Content="Restore policy" Command="{CompiledBinding RestoreCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              NavigationModel="{CompiledBinding NavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionUnit="Cell">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="90" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:NavigationStateViewModel+NavigationStateRow" />
+        <DataGridTextColumn Header="Name" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:NavigationStateViewModel+NavigationStateRow" />
+        <DataGridTextColumn Header="Stable key" Width="*" ColumnKey="stable-key"
+                            Binding="{CompiledBinding StableKey}" x:DataType="vm:NavigationStateViewModel+NavigationStateRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="3" Padding="10" CornerRadius="6" Background="#100078D4">
+      <TextBlock Text="{CompiledBinding Status}" TextWrapping="Wrap" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/NavigationStatePage.axaml.cs
+++ b/src/DataGridSample/Pages/NavigationStatePage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class NavigationStatePage : UserControl
+{
+    public NavigationStatePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/OrderDetailRouteView.axaml
+++ b/src/DataGridSample/Pages/OrderDetailRouteView.axaml
@@ -1,0 +1,17 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<rxui:ReactiveUserControl x:Class="DataGridSample.Pages.OrderDetailRouteView"
+                          x:TypeArguments="vm:OrderDetailRouteViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
+                          xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+                          x:DataType="vm:OrderDetailRouteViewModel">
+  <StackPanel Spacing="8">
+    <TextBlock FontSize="18" FontWeight="SemiBold" Text="Order details" />
+    <TextBlock FontSize="16" Text="{CompiledBinding Order.Customer}" />
+    <TextBlock Text="{CompiledBinding Order.Id, StringFormat=Order #{0}}" />
+    <TextBlock Text="{CompiledBinding Order.Total, StringFormat=Total: {0:C0}}" />
+    <TextBlock Text="{CompiledBinding Order.State, StringFormat=State: {0}}" />
+    <TextBlock Opacity="0.7" Text="{CompiledBinding UrlPathSegment, StringFormat=UrlPathSegment: {0}}" />
+  </StackPanel>
+</rxui:ReactiveUserControl>

--- a/src/DataGridSample/Pages/OrderDetailRouteView.axaml.cs
+++ b/src/DataGridSample/Pages/OrderDetailRouteView.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using DataGridSample.ViewModels;
+using ReactiveUI.Avalonia;
+
+namespace DataGridSample.Pages;
+
+public partial class OrderDetailRouteView : ReactiveUserControl<OrderDetailRouteViewModel>
+{
+    public OrderDetailRouteView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/OrderListRouteView.axaml
+++ b/src/DataGridSample/Pages/OrderListRouteView.axaml
@@ -1,0 +1,15 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<rxui:ReactiveUserControl x:Class="DataGridSample.Pages.OrderListRouteView"
+                          x:TypeArguments="vm:OrderListRouteViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
+                          xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+                          x:DataType="vm:OrderListRouteViewModel">
+  <StackPanel Spacing="8">
+    <TextBlock FontSize="18" FontWeight="SemiBold" Text="Orders route" />
+    <TextBlock TextWrapping="Wrap"
+               Text="Choose an order in the grid and push its details onto the ReactiveUI navigation stack." />
+    <TextBlock Opacity="0.7" Text="UrlPathSegment: orders" />
+  </StackPanel>
+</rxui:ReactiveUserControl>

--- a/src/DataGridSample/Pages/OrderListRouteView.axaml.cs
+++ b/src/DataGridSample/Pages/OrderListRouteView.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using DataGridSample.ViewModels;
+using ReactiveUI.Avalonia;
+
+namespace DataGridSample.Pages;
+
+public partial class OrderListRouteView : ReactiveUserControl<OrderListRouteViewModel>
+{
+    public OrderListRouteView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml
+++ b/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml
@@ -10,7 +10,7 @@
     <StackPanel Grid.ColumnSpan="2" Spacing="4">
       <TextBlock FontSize="20" FontWeight="SemiBold" Text="ReactiveUI route adapter" />
       <TextBlock TextWrapping="Wrap"
-                 Text="The grid resolves an opaque route; the adapter creates IRoutableViewModel instances and executes RoutingState.Navigate, NavigateAndReset, or NavigateBack. RoutedViewHost uses an explicit AOT-safe view locator." />
+                 Text="Click a cell or press Enter: the DataGrid captures that exact item key, column, and position before the adapter executes RoutingState.Navigate. Toolbar commands use the same grid-owned context path; RoutedViewHost uses an explicit AOT-safe view locator." />
     </StackPanel>
     <WrapPanel Grid.Row="1" Grid.ColumnSpan="2" Margin="0,10">
       <Button Margin="0,0,6,6" Content="Open selected order" Command="{CompiledBinding OpenOrderCommand}" />
@@ -21,6 +21,8 @@
               ItemsSource="{CompiledBinding Orders}"
               SelectedItem="{CompiledBinding SelectedOrder, Mode=TwoWay}"
               RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              RouteContextFactory="{CompiledBinding RouteContextFactory}"
+              NavigationInputModel="{CompiledBinding NavigationInputModel}"
               AutoGenerateColumns="False"
               CanUserAddRows="False">
       <DataGrid.Columns>

--- a/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml
+++ b/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml
@@ -1,0 +1,47 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.ReactiveUiRouteNavigationPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             xmlns:adapters="clr-namespace:DataGridSample.Adapters"
+             xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
+             x:DataType="vm:ReactiveUiRouteNavigationViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" ColumnDefinitions="3*,2*">
+    <StackPanel Grid.ColumnSpan="2" Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="ReactiveUI route adapter" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="The grid resolves an opaque route; the adapter creates IRoutableViewModel instances and executes RoutingState.Navigate, NavigateAndReset, or NavigateBack. RoutedViewHost uses an explicit AOT-safe view locator." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Grid.ColumnSpan="2" Margin="0,10">
+      <Button Margin="0,0,6,6" Content="Open selected order" Command="{CompiledBinding OpenOrderCommand}" />
+      <Button Margin="0,0,6,6" Content="Back" Command="{CompiledBinding BackCommand}" />
+      <Button Margin="0,0,6,6" Content="Reset to selected" Command="{CompiledBinding ResetCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Orders}"
+              SelectedItem="{CompiledBinding SelectedOrder, Mode=TwoWay}"
+              RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="80" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:ReactiveUiRouteNavigationViewModel+OrderRouteRow" />
+        <DataGridTextColumn Header="Customer" Width="2*" ColumnKey="customer"
+                            Binding="{CompiledBinding Customer}" x:DataType="vm:ReactiveUiRouteNavigationViewModel+OrderRouteRow" />
+        <DataGridTextColumn Header="Total" Width="*" ColumnKey="total"
+                            Binding="{CompiledBinding Total, StringFormat={}{0:C0}}" x:DataType="vm:ReactiveUiRouteNavigationViewModel+OrderRouteRow" />
+        <DataGridTextColumn Header="State" Width="*" ColumnKey="state"
+                            Binding="{CompiledBinding State}" x:DataType="vm:ReactiveUiRouteNavigationViewModel+OrderRouteRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <Border Grid.Row="2" Grid.Column="1" Margin="10,0,0,0" Padding="12"
+            BorderBrush="#330078D4" BorderThickness="1" CornerRadius="8">
+      <rxui:RoutedViewHost Router="{CompiledBinding Router}">
+        <rxui:RoutedViewHost.ViewLocator>
+          <adapters:ReactiveUiRouteViewLocator />
+        </rxui:RoutedViewHost.ViewLocator>
+      </rxui:RoutedViewHost>
+    </Border>
+    <TextBlock Grid.Row="3" Grid.ColumnSpan="2" Margin="0,10,0,0" Text="{CompiledBinding Status}" />
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml.cs
+++ b/src/DataGridSample/Pages/ReactiveUiRouteNavigationPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class ReactiveUiRouteNavigationPage : UserControl
+{
+    public ReactiveUiRouteNavigationPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/Pages/RouteNavigationPage.axaml
+++ b/src/DataGridSample/Pages/RouteNavigationPage.axaml
@@ -1,0 +1,44 @@
+<!-- Copyright (c) Wieslaw Soltes. Licensed under the MIT license. -->
+<UserControl x:Class="DataGridSample.Pages.RouteNavigationPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:DataGridSample.ViewModels"
+             x:DataType="vm:RouteNavigationSampleViewModel">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto,Auto">
+    <StackPanel Spacing="4">
+      <TextBlock FontSize="20" FontWeight="SemiBold" Text="Framework-neutral route navigation" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="A stable row/column context resolves to an application route. The host advertises Navigate, Replace, Reset, Back, and Forward capabilities and returns typed cancellation or failure results." />
+    </StackPanel>
+    <WrapPanel Grid.Row="1" Margin="0,10">
+      <Button Margin="0,0,6,6" Content="Navigate" Command="{CompiledBinding NavigateCommand}" />
+      <Button Margin="0,0,6,6" Content="Replace" Command="{CompiledBinding ReplaceCommand}" />
+      <Button Margin="0,0,14,6" Content="Reset" Command="{CompiledBinding ResetCommand}" />
+      <Button Margin="0,0,6,6" Content="Back" Command="{CompiledBinding BackCommand}" />
+      <Button Margin="0,0,6,6" Content="Forward" Command="{CompiledBinding ForwardCommand}" />
+    </WrapPanel>
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Items}"
+              SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}"
+              RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              SelectionMode="Single">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="ID" Width="80" ColumnKey="id"
+                            Binding="{CompiledBinding Id}" x:DataType="vm:RouteNavigationSampleViewModel+RouteRow" />
+        <DataGridTextColumn Header="Work item" Width="2*" ColumnKey="name"
+                            Binding="{CompiledBinding Name}" x:DataType="vm:RouteNavigationSampleViewModel+RouteRow" />
+        <DataGridTextColumn Header="Area" Width="*" ColumnKey="area"
+                            Binding="{CompiledBinding Area}" x:DataType="vm:RouteNavigationSampleViewModel+RouteRow" />
+        <DataGridTextColumn Header="State" Width="*" ColumnKey="state"
+                            Binding="{CompiledBinding State}" x:DataType="vm:RouteNavigationSampleViewModel+RouteRow" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <TextBlock Grid.Row="3" Margin="0,10,0,0" FontWeight="SemiBold"
+               Text="{CompiledBinding RouteNavigator.HistorySummary}" />
+    <Border Grid.Row="4" Margin="0,8,0,0" Padding="10" Background="#100078D4" CornerRadius="6">
+      <TextBlock Text="{CompiledBinding Status}" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/RouteNavigationPage.axaml
+++ b/src/DataGridSample/Pages/RouteNavigationPage.axaml
@@ -8,7 +8,7 @@
     <StackPanel Spacing="4">
       <TextBlock FontSize="20" FontWeight="SemiBold" Text="Framework-neutral route navigation" />
       <TextBlock TextWrapping="Wrap"
-                 Text="A stable row/column context resolves to an application route. The host advertises Navigate, Replace, Reset, Back, and Forward capabilities and returns typed cancellation or failure results." />
+                 Text="Click any cell or press Enter to route from inside the DataGrid. The grid preserves the clicked item key, column key, position, and origin before the framework-neutral host executes Navigate, Replace, Reset, Back, or Forward." />
     </StackPanel>
     <WrapPanel Grid.Row="1" Margin="0,10">
       <Button Margin="0,0,6,6" Content="Navigate" Command="{CompiledBinding NavigateCommand}" />
@@ -21,6 +21,8 @@
               ItemsSource="{CompiledBinding Items}"
               SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}"
               RouteNavigationModel="{CompiledBinding RouteNavigationModel}"
+              RouteContextFactory="{CompiledBinding RouteContextFactory}"
+              NavigationInputModel="{CompiledBinding NavigationInputModel}"
               AutoGenerateColumns="False"
               CanUserAddRows="False"
               SelectionMode="Single">

--- a/src/DataGridSample/Pages/RouteNavigationPage.axaml.cs
+++ b/src/DataGridSample/Pages/RouteNavigationPage.axaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+
+namespace DataGridSample.Pages;
+
+public partial class RouteNavigationPage : UserControl
+{
+    public RouteNavigationPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DataGridSample/ViewModels/CustomNavigationModelViewModel.cs
+++ b/src/DataGridSample/ViewModels/CustomNavigationModelViewModel.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class CustomNavigationModelViewModel : ReactiveObject
+{
+    private string _status = "Down from row 1 skips the protected row; Right is blocked in the final column.";
+
+    public CustomNavigationModelViewModel()
+    {
+        Items = new ObservableCollection<CustomNavigationRow>
+        {
+            new(1, "Inbox", "Normal"),
+            new(2, "Protected approval", "Protected"),
+            new(3, "Archive", "Normal"),
+            new(4, "Audit", "Normal")
+        };
+        NavigationModel = new GuardedNavigationModel();
+        NavigationModel.NavigationChanged += (_, e) =>
+            Status = e.Completed.Moved
+                ? $"{e.Completed.Request.Command}: moved to {e.Completed.NewPosition.RowIndex}:{e.Completed.NewPosition.ColumnDisplayIndex}"
+                : $"{e.Completed.Request.Command}: {e.Completed.FailureReason}";
+        DownCommand = ReactiveCommand.Create(() =>
+            NavigationModel.RequestNavigate(DataGridNavigationCommand.Down));
+        RightCommand = ReactiveCommand.Create(() =>
+            NavigationModel.RequestNavigate(DataGridNavigationCommand.Right));
+    }
+
+    public ObservableCollection<CustomNavigationRow> Items { get; }
+
+    public GuardedNavigationModel NavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, bool> DownCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> RightCommand { get; }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    public sealed class GuardedNavigationModel : DataGridNavigationModel
+    {
+        protected override DataGridNavigationResult ResolveCore(DataGridNavigationRequest request)
+        {
+            if (request.Command == DataGridNavigationCommand.Down &&
+                request.CurrentPosition.RowIndex == 0 &&
+                request.LastRowIndex >= 2)
+            {
+                return DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
+                    rowIndex: 2,
+                    request.CurrentPosition.ColumnDisplayIndex));
+            }
+
+            if (request.Command == DataGridNavigationCommand.Right &&
+                request.CurrentPosition.ColumnDisplayIndex == request.LastColumnDisplayIndex)
+            {
+                return DataGridNavigationResult.Cancel();
+            }
+
+            return base.ResolveCore(request);
+        }
+    }
+
+    public sealed record CustomNavigationRow(int Id, string Name, string Access);
+}

--- a/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
@@ -13,7 +13,8 @@ namespace DataGridSample.ViewModels;
 [GenerateDataGridViewModel(
     typeof(GeneratedNavigationRow),
     ProviderName = "GeneratedNavigationRowSchema",
-    GenerateNavigationModel = true)]
+    GenerateNavigationModel = true,
+    GenerateNavigationInputModel = true)]
 [GenerateDataGridView(
     typeof(GeneratedNavigationRow),
     ViewName = "GeneratedNavigationGridView",
@@ -22,7 +23,8 @@ namespace DataGridSample.ViewModels;
     Title = "Generated navigation grid",
     AutomationId = "generated-navigation-grid",
     NavigationModelPropertyName = nameof(NavigationModel),
-    RouteNavigationModelPropertyName = nameof(RouteNavigationModel))]
+    RouteNavigationModelPropertyName = nameof(RouteNavigationModel),
+    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
 public sealed partial class GeneratedNavigationViewModel : ReactiveObject
 {
     private GeneratedNavigationRow? _selectedItem;
@@ -46,6 +48,41 @@ public sealed partial class GeneratedNavigationViewModel : ReactiveObject
         RouteNavigationModel = GeneratedNavigationRowSchema.CreateRouteNavigationModel(
             resolver,
             new RouteNavigationSampleViewModel.InMemoryRouteNavigator());
+
+        NavigationInputModel.SetBindings(
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.J,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down)),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.K,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Up)),
+            DataGridNavigationInputBinding.PhysicalKeyDown(
+                DataGridNavigationInputKey.H,
+                DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Left)),
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerPressed,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateToTarget(),
+                targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.Wheel(
+                DataGridNavigationWheelDirection.Up,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Back),
+                DataGridNavigationInputModifiers.Control),
+            DataGridNavigationInputBinding.Wheel(
+                DataGridNavigationWheelDirection.Down,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Forward),
+                DataGridNavigationInputModifiers.Control));
+        NavigationInputModel.InputResolving += (_, e) =>
+        {
+            if (e.Request.Kind == DataGridNavigationInputKind.KeyDown &&
+                e.Request.Key == DataGridNavigationInputKey.G)
+            {
+                e.Result = DataGridNavigationInputResult.Navigate(
+                    (e.Request.Modifiers & DataGridNavigationInputModifiers.Shift) != 0
+                        ? DataGridNavigationCommand.GridEnd
+                        : DataGridNavigationCommand.GridStart);
+            }
+        };
 
         NavigationModel.NavigationChanged += (_, e) =>
             Status = e.Completed.Moved

--- a/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
@@ -14,7 +14,8 @@ namespace DataGridSample.ViewModels;
     typeof(GeneratedNavigationRow),
     ProviderName = "GeneratedNavigationRowSchema",
     GenerateNavigationModel = true,
-    GenerateNavigationInputModel = true)]
+    GenerateNavigationInputModel = true,
+    GenerateRouteContextFactory = true)]
 [GenerateDataGridView(
     typeof(GeneratedNavigationRow),
     ViewName = "GeneratedNavigationGridView",
@@ -24,7 +25,8 @@ namespace DataGridSample.ViewModels;
     AutomationId = "generated-navigation-grid",
     NavigationModelPropertyName = nameof(NavigationModel),
     RouteNavigationModelPropertyName = nameof(RouteNavigationModel),
-    NavigationInputModelPropertyName = nameof(NavigationInputModel))]
+    NavigationInputModelPropertyName = nameof(NavigationInputModel),
+    RouteContextFactoryPropertyName = nameof(RouteContextFactory))]
 public sealed partial class GeneratedNavigationViewModel : ReactiveObject
 {
     private GeneratedNavigationRow? _selectedItem;
@@ -64,6 +66,14 @@ public sealed partial class GeneratedNavigationViewModel : ReactiveObject
                 DataGridNavigationPointerButton.Primary,
                 DataGridNavigationInputResult.NavigateToTarget(),
                 targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerReleased,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate),
+                targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.Enter,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate)),
             DataGridNavigationInputBinding.Wheel(
                 DataGridNavigationWheelDirection.Up,
                 DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Back),
@@ -89,30 +99,29 @@ public sealed partial class GeneratedNavigationViewModel : ReactiveObject
                 ? $"Generated cell model: {e.Completed.Request.Command} → {e.Completed.NewPosition.RowIndex}:{e.Completed.NewPosition.ColumnDisplayIndex}"
                 : $"Generated cell model: {e.Completed.FailureReason}";
         RouteNavigationModel.NavigationChanged += (_, e) =>
-            Status = $"Generated route model: {e.Result.Status} · {e.Result.CurrentRoute.Path}";
+            Status = $"Generated route model: {e.Result.Status} · {e.Result.CurrentRoute.Path} · key {e.Request.Context.ItemKey} · cell {e.Request.Context.Position.RowIndex}:{e.Request.Context.Position.ColumnDisplayIndex}";
 
         NextCellCommand = ReactiveCommand.Create(() =>
             NavigationModel.RequestNavigate(DataGridNavigationCommand.Next));
         PreviousCellCommand = ReactiveCommand.Create(() =>
             NavigationModel.RequestNavigate(DataGridNavigationCommand.Previous));
-        OpenRouteCommand = ReactiveCommand.CreateFromTask(OpenRouteAsync);
-        BackCommand = ReactiveCommand.CreateFromTask(() =>
-            RouteNavigationModel.NavigateAsync(
-                DataGridRouteNavigationKind.Back,
-                DataGridRouteContext.Empty).AsTask());
+        OpenRouteCommand = ReactiveCommand.Create(() =>
+            RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
+        BackCommand = ReactiveCommand.Create(() =>
+            RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Back));
     }
 
     public ObservableCollection<GeneratedNavigationRow> Items { get; }
 
-    public IDataGridRouteNavigationModel RouteNavigationModel { get; }
+    public DataGridRouteNavigationModel RouteNavigationModel { get; }
 
     public ReactiveCommand<RxVoid, bool> NextCellCommand { get; }
 
     public ReactiveCommand<RxVoid, bool> PreviousCellCommand { get; }
 
-    public ReactiveCommand<RxVoid, DataGridRouteNavigationResult> OpenRouteCommand { get; }
+    public ReactiveCommand<RxVoid, bool> OpenRouteCommand { get; }
 
-    public ReactiveCommand<RxVoid, DataGridRouteNavigationResult> BackCommand { get; }
+    public ReactiveCommand<RxVoid, bool> BackCommand { get; }
 
     public GeneratedNavigationRow? SelectedItem
     {
@@ -126,18 +135,6 @@ public sealed partial class GeneratedNavigationViewModel : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref _status, value);
     }
 
-    private Task<DataGridRouteNavigationResult> OpenRouteAsync()
-    {
-        GeneratedNavigationRow? selected = SelectedItem;
-        var context = new DataGridRouteContext(
-            selected,
-            selected?.Id,
-            "name",
-            DataGridNavigationPosition.Unset,
-            DataGridRouteNavigationOrigin.Command,
-            selected != null);
-        return RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Navigate, context).AsTask();
-    }
 }
 
 public sealed class GeneratedNavigationRow
@@ -150,6 +147,7 @@ public sealed class GeneratedNavigationRow
         State = state;
     }
 
+    [DataGridKey]
     [DataGridColumn(Order = 0, ColumnKey = "id", IsReadOnly = true)]
     public int Id { get; set; }
 

--- a/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/GeneratedNavigationViewModel.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+using ProDataGrid.SourceGeneration;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+[GenerateDataGridViewModel(
+    typeof(GeneratedNavigationRow),
+    ProviderName = "GeneratedNavigationRowSchema",
+    GenerateNavigationModel = true)]
+[GenerateDataGridView(
+    typeof(GeneratedNavigationRow),
+    ViewName = "GeneratedNavigationGridView",
+    ViewNamespace = "DataGridSample.Pages",
+    Recipe = DataGridViewRecipe.GridOnly,
+    Title = "Generated navigation grid",
+    AutomationId = "generated-navigation-grid",
+    NavigationModelPropertyName = nameof(NavigationModel),
+    RouteNavigationModelPropertyName = nameof(RouteNavigationModel))]
+public sealed partial class GeneratedNavigationViewModel : ReactiveObject
+{
+    private GeneratedNavigationRow? _selectedItem;
+    private string _status = "Both navigation models and their compiled bindings were source-generated.";
+
+    public GeneratedNavigationViewModel()
+    {
+        Items = new ObservableCollection<GeneratedNavigationRow>
+        {
+            new(301, "Accounts", "Finance", "Ready"),
+            new(302, "Incidents", "Operations", "Attention"),
+            new(303, "Identity", "Security", "Active"),
+            new(304, "Forecast", "Planning", "Draft")
+        };
+        SelectedItem = Items[0];
+
+        var resolver = new DelegateDataGridRouteResolver(context =>
+            context.Item is GeneratedNavigationRow row
+                ? new DataGridRoute($"generated/{row.Id}", row, "details")
+                : null);
+        RouteNavigationModel = GeneratedNavigationRowSchema.CreateRouteNavigationModel(
+            resolver,
+            new RouteNavigationSampleViewModel.InMemoryRouteNavigator());
+
+        NavigationModel.NavigationChanged += (_, e) =>
+            Status = e.Completed.Moved
+                ? $"Generated cell model: {e.Completed.Request.Command} → {e.Completed.NewPosition.RowIndex}:{e.Completed.NewPosition.ColumnDisplayIndex}"
+                : $"Generated cell model: {e.Completed.FailureReason}";
+        RouteNavigationModel.NavigationChanged += (_, e) =>
+            Status = $"Generated route model: {e.Result.Status} · {e.Result.CurrentRoute.Path}";
+
+        NextCellCommand = ReactiveCommand.Create(() =>
+            NavigationModel.RequestNavigate(DataGridNavigationCommand.Next));
+        PreviousCellCommand = ReactiveCommand.Create(() =>
+            NavigationModel.RequestNavigate(DataGridNavigationCommand.Previous));
+        OpenRouteCommand = ReactiveCommand.CreateFromTask(OpenRouteAsync);
+        BackCommand = ReactiveCommand.CreateFromTask(() =>
+            RouteNavigationModel.NavigateAsync(
+                DataGridRouteNavigationKind.Back,
+                DataGridRouteContext.Empty).AsTask());
+    }
+
+    public ObservableCollection<GeneratedNavigationRow> Items { get; }
+
+    public IDataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, bool> NextCellCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> PreviousCellCommand { get; }
+
+    public ReactiveCommand<RxVoid, DataGridRouteNavigationResult> OpenRouteCommand { get; }
+
+    public ReactiveCommand<RxVoid, DataGridRouteNavigationResult> BackCommand { get; }
+
+    public GeneratedNavigationRow? SelectedItem
+    {
+        get => _selectedItem;
+        set => this.RaiseAndSetIfChanged(ref _selectedItem, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private Task<DataGridRouteNavigationResult> OpenRouteAsync()
+    {
+        GeneratedNavigationRow? selected = SelectedItem;
+        var context = new DataGridRouteContext(
+            selected,
+            selected?.Id,
+            "name",
+            DataGridNavigationPosition.Unset,
+            DataGridRouteNavigationOrigin.Command,
+            selected != null);
+        return RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Navigate, context).AsTask();
+    }
+}
+
+public sealed class GeneratedNavigationRow
+{
+    public GeneratedNavigationRow(int id, string name, string area, string state)
+    {
+        Id = id;
+        Name = name;
+        Area = area;
+        State = state;
+    }
+
+    [DataGridColumn(Order = 0, ColumnKey = "id", IsReadOnly = true)]
+    public int Id { get; set; }
+
+    [DataGridColumn(Order = 1, ColumnKey = "name")]
+    public string Name { get; set; }
+
+    [DataGridColumn(Order = 2, ColumnKey = "area")]
+    public string Area { get; set; }
+
+    [DataGridColumn(Order = 3, ColumnKey = "state")]
+    public string State { get; set; }
+}

--- a/src/DataGridSample/ViewModels/HierarchicalNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/HierarchicalNavigationViewModel.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class HierarchicalNavigationViewModel : ReactiveObject
+{
+    private string _status = "Select a node, then use semantic expand/collapse commands.";
+
+    public HierarchicalNavigationViewModel()
+    {
+        NavigationTreeNode planning = new("Planning", "Portfolio");
+        planning.Children.Add(new NavigationTreeNode("Roadmap", "Document"));
+        planning.Children.Add(new NavigationTreeNode("Capacity", "Report"));
+        NavigationTreeNode delivery = new("Delivery", "Portfolio");
+        NavigationTreeNode release = new("Release 4.2", "Release");
+        release.Children.Add(new NavigationTreeNode("Desktop", "Workstream"));
+        release.Children.Add(new NavigationTreeNode("Mobile", "Workstream"));
+        delivery.Children.Add(release);
+
+        Model = new HierarchicalModel<NavigationTreeNode>(new HierarchicalOptions<NavigationTreeNode>
+        {
+            ItemsSelector = static node => node.Children,
+            IsLeafSelector = static node => node.Children.Count == 0
+        });
+        Model.SetRoots([planning, delivery]);
+        NavigationModel = new DataGridNavigationModel();
+        NavigationModel.NavigationChanged += (_, e) =>
+            Status = $"{e.Completed.Request.Command}: {(e.Completed.Handled ? "handled" : e.Completed.FailureReason.ToString())}";
+
+        ExpandCommand = CreateCommand(DataGridNavigationCommand.Expand);
+        CollapseCommand = CreateCommand(DataGridNavigationCommand.Collapse);
+        ExpandSubtreeCommand = CreateCommand(DataGridNavigationCommand.ExpandAll);
+        UpCommand = CreateCommand(DataGridNavigationCommand.Up);
+        DownCommand = CreateCommand(DataGridNavigationCommand.Down);
+    }
+
+    public HierarchicalModel<NavigationTreeNode> Model { get; }
+
+    public DataGridNavigationModel NavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, bool> ExpandCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> CollapseCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> ExpandSubtreeCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> UpCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> DownCommand { get; }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private ReactiveCommand<RxVoid, bool> CreateCommand(DataGridNavigationCommand command) =>
+        ReactiveCommand.Create(() => NavigationModel.RequestNavigate(command));
+
+    public sealed class NavigationTreeNode
+    {
+        public NavigationTreeNode(string name, string kind)
+        {
+            Name = name;
+            Kind = kind;
+        }
+
+        public string Name { get; }
+
+        public string Kind { get; }
+
+        public ObservableCollection<NavigationTreeNode> Children { get; } = [];
+
+        public override string ToString() => Name;
+    }
+}

--- a/src/DataGridSample/ViewModels/MvvmRouteFrameworksViewModel.cs
+++ b/src/DataGridSample/ViewModels/MvvmRouteFrameworksViewModel.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+/// <summary>
+/// Demonstrates how framework-native route operations remain behind the
+/// framework-neutral <see cref="IDataGridRouteNavigator"/> boundary.
+/// </summary>
+public sealed class MvvmRouteFrameworksViewModel : ReactiveObject
+{
+    private FrameworkRouteRecipe? _selectedRecipe;
+    private string _status = "Select a framework recipe and execute a route operation.";
+
+    public MvvmRouteFrameworksViewModel()
+    {
+        Recipes = new ObservableCollection<FrameworkRouteRecipe>
+        {
+            new(
+                "ReactiveUI",
+                "IScreen + RoutingState",
+                "Navigate / NavigateAndReset / NavigateBack",
+                "Working adapter and RoutedViewHost sample are on the adjacent ReactiveUI page."),
+            new(
+                "Prism",
+                "IRegionManager or INavigationService",
+                "RequestNavigate / NavigateAsync / GoBackAsync",
+                "Wrap the platform-specific journal and NavigationParameters in IDataGridRouteNavigator."),
+            new(
+                "CommunityToolkit.Mvvm",
+                "Application-owned navigation service",
+                "AsyncRelayCommand -> NavigateAsync",
+                "The Toolkit supplies commands and observable state; the application supplies the router."),
+            new(
+                "Plain MVVM + DI",
+                "Scoped IDataGridRouteNavigationModel",
+                "ICommand -> NavigateAsync",
+                "Register the resolver and native adapter with Microsoft.Extensions.DependencyInjection.")
+        };
+        SelectedRecipe = Recipes[0];
+
+        var resolver = new DelegateDataGridRouteResolver(context =>
+            context.Item is FrameworkRouteRecipe recipe
+                ? new DataGridRoute(
+                    $"frameworks/{recipe.Name.ToLowerInvariant().Replace(' ', '-')}",
+                    recipe,
+                    "details")
+                : null);
+        var navigator = new FrameworkRecipeNavigator(() => SelectedRecipe);
+        RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+        RouteNavigationModel.NavigationChanged += (_, e) =>
+            Status = e.Result.Succeeded
+                ? $"{e.Result.CurrentRoute.Path}: {navigator.LastNativeOperation}"
+                : $"{e.Request.Kind}: {e.Result.Status}";
+
+        NavigateCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Navigate));
+        ResetCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Reset));
+        BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Back));
+    }
+
+    public ObservableCollection<FrameworkRouteRecipe> Recipes { get; }
+
+    public DataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> NavigateCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+
+    public FrameworkRouteRecipe? SelectedRecipe
+    {
+        get => _selectedRecipe;
+        set => this.RaiseAndSetIfChanged(ref _selectedRecipe, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private async Task NavigateAsync(DataGridRouteNavigationKind kind)
+    {
+        FrameworkRouteRecipe? recipe = SelectedRecipe;
+        DataGridRouteContext context = kind == DataGridRouteNavigationKind.Back
+            ? DataGridRouteContext.Empty
+            : new DataGridRouteContext(
+                recipe,
+                recipe?.Name,
+                "framework",
+                DataGridNavigationPosition.Unset,
+                DataGridRouteNavigationOrigin.Command,
+                recipe != null);
+        await RouteNavigationModel.NavigateAsync(kind, context);
+    }
+
+    public sealed record FrameworkRouteRecipe(
+        string Name,
+        string NativeHost,
+        string NativeOperations,
+        string IntegrationNotes);
+
+    private sealed class FrameworkRecipeNavigator : IDataGridRouteNavigator
+    {
+        private readonly Func<FrameworkRouteRecipe?> _selectedRecipe;
+
+        public FrameworkRecipeNavigator(Func<FrameworkRouteRecipe?> selectedRecipe)
+        {
+            _selectedRecipe = selectedRecipe;
+        }
+
+        public DataGridRouteNavigationCapabilities Capabilities =>
+            DataGridRouteNavigationCapabilities.Navigate |
+            DataGridRouteNavigationCapabilities.Reset |
+            DataGridRouteNavigationCapabilities.Back;
+
+        public string LastNativeOperation { get; private set; } = "No native operation";
+
+        public ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromResult(DataGridRouteNavigationResult.FromStatus(
+                    DataGridRouteNavigationStatus.Canceled));
+            }
+
+            FrameworkRouteRecipe? recipe = request.Route.Parameter as FrameworkRouteRecipe ?? _selectedRecipe();
+            if (recipe == null)
+            {
+                return ValueTask.FromResult(DataGridRouteNavigationResult.FromStatus(
+                    DataGridRouteNavigationStatus.RouteNotFound));
+            }
+
+            LastNativeOperation = MapOperation(recipe.Name, request.Kind);
+            DataGridRoute currentRoute = !request.Route.IsValid
+                ? new DataGridRoute($"frameworks/{recipe.Name.ToLowerInvariant().Replace(' ', '-')}")
+                : request.Route;
+            return ValueTask.FromResult(DataGridRouteNavigationResult.Success(currentRoute));
+        }
+
+        private static string MapOperation(string framework, DataGridRouteNavigationKind kind) =>
+            (framework, kind) switch
+            {
+                ("ReactiveUI", DataGridRouteNavigationKind.Navigate) => "RoutingState.Navigate.Execute(viewModel)",
+                ("ReactiveUI", DataGridRouteNavigationKind.Reset) => "RoutingState.NavigateAndReset.Execute(viewModel)",
+                ("ReactiveUI", DataGridRouteNavigationKind.Back) => "RoutingState.NavigateBack.Execute()",
+                ("Prism", DataGridRouteNavigationKind.Navigate) => "INavigationService.NavigateAsync(uri, parameters)",
+                ("Prism", DataGridRouteNavigationKind.Reset) => "NavigateAsync(absoluteUri, parameters)",
+                ("Prism", DataGridRouteNavigationKind.Back) => "INavigationService.GoBackAsync(parameters)",
+                ("CommunityToolkit.Mvvm", DataGridRouteNavigationKind.Navigate) => "AsyncRelayCommand -> applicationNavigation.NavigateAsync(route)",
+                ("CommunityToolkit.Mvvm", DataGridRouteNavigationKind.Reset) => "AsyncRelayCommand -> applicationNavigation.ResetAsync(route)",
+                ("CommunityToolkit.Mvvm", DataGridRouteNavigationKind.Back) => "AsyncRelayCommand -> applicationNavigation.BackAsync()",
+                (_, DataGridRouteNavigationKind.Navigate) => "ICommand -> IDataGridRouteNavigationModel.NavigateAsync(route)",
+                (_, DataGridRouteNavigationKind.Reset) => "ICommand -> IDataGridRouteNavigationModel.NavigateAsync(reset)",
+                _ => "ICommand -> IDataGridRouteNavigationModel.NavigateAsync(back)"
+            };
+    }
+}

--- a/src/DataGridSample/ViewModels/MvvmRouteFrameworksViewModel.cs
+++ b/src/DataGridSample/ViewModels/MvvmRouteFrameworksViewModel.cs
@@ -56,25 +56,39 @@ public sealed class MvvmRouteFrameworksViewModel : ReactiveObject
                 : null);
         var navigator = new FrameworkRecipeNavigator(() => SelectedRecipe);
         RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+        RouteContextFactory = new DataGridRouteContextFactory(item => ((FrameworkRouteRecipe)item).Name);
+        NavigationInputModel = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerReleased,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate),
+                targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.Enter,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate)));
         RouteNavigationModel.NavigationChanged += (_, e) =>
             Status = e.Result.Succeeded
                 ? $"{e.Result.CurrentRoute.Path}: {navigator.LastNativeOperation}"
                 : $"{e.Request.Kind}: {e.Result.Status}";
 
-        NavigateCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Navigate));
-        ResetCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Reset));
-        BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Back));
+        NavigateCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
+        ResetCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Reset));
+        BackCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Back));
     }
 
     public ObservableCollection<FrameworkRouteRecipe> Recipes { get; }
 
     public DataGridRouteNavigationModel RouteNavigationModel { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> NavigateCommand { get; }
+    public DataGridRouteContextFactory RouteContextFactory { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+    public DataGridNavigationInputModel NavigationInputModel { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+    public ReactiveCommand<RxVoid, bool> NavigateCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> ResetCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> BackCommand { get; }
 
     public FrameworkRouteRecipe? SelectedRecipe
     {
@@ -86,21 +100,6 @@ public sealed class MvvmRouteFrameworksViewModel : ReactiveObject
     {
         get => _status;
         private set => this.RaiseAndSetIfChanged(ref _status, value);
-    }
-
-    private async Task NavigateAsync(DataGridRouteNavigationKind kind)
-    {
-        FrameworkRouteRecipe? recipe = SelectedRecipe;
-        DataGridRouteContext context = kind == DataGridRouteNavigationKind.Back
-            ? DataGridRouteContext.Empty
-            : new DataGridRouteContext(
-                recipe,
-                recipe?.Name,
-                "framework",
-                DataGridNavigationPosition.Unset,
-                DataGridRouteNavigationOrigin.Command,
-                recipe != null);
-        await RouteNavigationModel.NavigateAsync(kind, context);
     }
 
     public sealed record FrameworkRouteRecipe(

--- a/src/DataGridSample/ViewModels/NavigationModelSampleViewModel.cs
+++ b/src/DataGridSample/ViewModels/NavigationModelSampleViewModel.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Input;
+using Avalonia.Media;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class NavigationModelSampleViewModel : ReactiveObject
+{
+    private string _status = "Focus a cell or use a command to begin.";
+    private FlowDirection _flowDirection = FlowDirection.LeftToRight;
+
+    public NavigationModelSampleViewModel()
+    {
+        Items = new ObservableCollection<NavigationRow>
+        {
+            new(1001, "Atlas", "Planning", 0.82, true),
+            new(1002, "Borealis", "Active", 0.64, true),
+            new(1003, "Cirrus", "Review", 0.91, false),
+            new(1004, "Dorado", "Blocked", 0.35, true),
+            new(1005, "Equinox", "Active", 0.73, true),
+            new(1006, "Fjord", "Planning", 0.48, false),
+            new(1007, "Gemini", "Review", 0.57, true),
+            new(1008, "Helios", "Active", 0.88, true)
+        };
+
+        NavigationModel = new DataGridNavigationModel();
+        NavigationModel.NavigationChanging += (_, e) =>
+            Status = $"Resolving {e.Request.Command} from {e.Request.CurrentPosition.RowIndex}:{e.Request.CurrentPosition.ColumnDisplayIndex}";
+        NavigationModel.NavigationChanged += (_, e) =>
+        {
+            DataGridNavigationCompleted completed = e.Completed;
+            Status = completed.Moved
+                ? $"{completed.Request.Command}: {completed.OldPosition.RowIndex}:{completed.OldPosition.ColumnDisplayIndex} → {completed.NewPosition.RowIndex}:{completed.NewPosition.ColumnDisplayIndex}"
+                : $"{completed.Request.Command}: {completed.FailureReason}";
+        };
+
+        UpCommand = CreateNavigationCommand(DataGridNavigationCommand.Up);
+        DownCommand = CreateNavigationCommand(DataGridNavigationCommand.Down);
+        LeftCommand = CreateNavigationCommand(DataGridNavigationCommand.Left);
+        RightCommand = CreateNavigationCommand(DataGridNavigationCommand.Right);
+        PageUpCommand = CreateNavigationCommand(DataGridNavigationCommand.PageUp);
+        PageDownCommand = CreateNavigationCommand(DataGridNavigationCommand.PageDown);
+        RowStartCommand = CreateNavigationCommand(DataGridNavigationCommand.RowStart);
+        RowEndCommand = CreateNavigationCommand(DataGridNavigationCommand.RowEnd);
+        GridStartCommand = CreateNavigationCommand(DataGridNavigationCommand.GridStart);
+        GridEndCommand = CreateNavigationCommand(DataGridNavigationCommand.GridEnd);
+        NextCommand = CreateNavigationCommand(DataGridNavigationCommand.Next);
+        PreviousCommand = CreateNavigationCommand(DataGridNavigationCommand.Previous);
+        BeginEditCommand = CreateNavigationCommand(DataGridNavigationCommand.BeginEdit);
+        CancelEditCommand = CreateNavigationCommand(DataGridNavigationCommand.CancelEdit);
+        ExtendDownCommand = ReactiveCommand.Create(() =>
+            NavigationModel.RequestNavigate(DataGridNavigationCommand.Down, KeyModifiers.Shift));
+    }
+
+    public ObservableCollection<NavigationRow> Items { get; }
+
+    public DataGridNavigationModel NavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, bool> UpCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> DownCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> LeftCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> RightCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> PageUpCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> PageDownCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> RowStartCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> RowEndCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> GridStartCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> GridEndCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> NextCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> PreviousCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> BeginEditCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> CancelEditCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> ExtendDownCommand { get; }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    public FlowDirection FlowDirection
+    {
+        get => _flowDirection;
+        set => this.RaiseAndSetIfChanged(ref _flowDirection, value);
+    }
+
+    private ReactiveCommand<RxVoid, bool> CreateNavigationCommand(DataGridNavigationCommand command) =>
+        ReactiveCommand.Create(() => NavigationModel.RequestNavigate(command));
+
+    public sealed class NavigationRow
+    {
+        public NavigationRow(int id, string name, string status, double progress, bool enabled)
+        {
+            Id = id;
+            Name = name;
+            Status = status;
+            Progress = progress;
+            Enabled = enabled;
+        }
+
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Status { get; set; }
+
+        public double Progress { get; set; }
+
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/DataGridSample/ViewModels/NavigationStateViewModel.cs
+++ b/src/DataGridSample/ViewModels/NavigationStateViewModel.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class NavigationStateViewModel : ReactiveObject
+{
+    private DataGridNavigationPolicyState? _capturedState;
+    private string _status = "Configure policy, capture it, change it, and restore the detached snapshot.";
+
+    public NavigationStateViewModel()
+    {
+        Items = new ObservableCollection<NavigationStateRow>
+        {
+            new(501, "Stable row A", "alpha"),
+            new(502, "Stable row B", "beta"),
+            new(503, "Stable row C", "gamma")
+        };
+        NavigationModel = new DataGridNavigationModel();
+        UseSpreadsheetPolicyCommand = ReactiveCommand.Create(UseSpreadsheetPolicy);
+        UseContainedPolicyCommand = ReactiveCommand.Create(UseContainedPolicy);
+        CaptureCommand = ReactiveCommand.Create(Capture);
+        RestoreCommand = ReactiveCommand.Create(Restore);
+    }
+
+    public ObservableCollection<NavigationStateRow> Items { get; }
+
+    public DataGridNavigationModel NavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> UseSpreadsheetPolicyCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> UseContainedPolicyCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> CaptureCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> RestoreCommand { get; }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private void UseSpreadsheetPolicy()
+    {
+        NavigationModel.HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap;
+        NavigationModel.VerticalBoundaryMode = DataGridNavigationBoundaryMode.Wrap;
+        NavigationModel.TabNavigationMode = DataGridTabNavigationMode.Always;
+        NavigationModel.TabBoundaryMode = DataGridNavigationBoundaryMode.Wrap;
+        Publish("Spreadsheet policy applied");
+    }
+
+    private void UseContainedPolicy()
+    {
+        NavigationModel.HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
+        NavigationModel.VerticalBoundaryMode = DataGridNavigationBoundaryMode.Contained;
+        NavigationModel.TabNavigationMode = DataGridTabNavigationMode.EditingOnly;
+        NavigationModel.TabBoundaryMode = DataGridNavigationBoundaryMode.Exit;
+        Publish("Contained policy applied");
+    }
+
+    private void Capture()
+    {
+        _capturedState = NavigationModel.CaptureState();
+        Publish("Policy snapshot captured");
+    }
+
+    private void Restore()
+    {
+        if (_capturedState == null)
+        {
+            Status = "Capture a policy snapshot first.";
+            return;
+        }
+
+        NavigationModel.RestoreState(_capturedState);
+        Publish("Policy snapshot restored");
+    }
+
+    private void Publish(string action)
+    {
+        Status = $"{action}: horizontal={NavigationModel.HorizontalBoundaryMode}, vertical={NavigationModel.VerticalBoundaryMode}, tab={NavigationModel.TabNavigationMode}/{NavigationModel.TabBoundaryMode}";
+    }
+
+    public sealed record NavigationStateRow(int Id, string Name, string StableKey);
+}

--- a/src/DataGridSample/ViewModels/ReactiveUiRouteNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/ReactiveUiRouteNavigationViewModel.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.ObjectModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+using DataGridSample.Adapters;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class ReactiveUiRouteNavigationViewModel : ReactiveObject, IScreen
+{
+    private OrderRouteRow? _selectedOrder;
+    private string _status = "ReactiveUI RoutingState is ready.";
+
+    public ReactiveUiRouteNavigationViewModel()
+    {
+        Orders = new ObservableCollection<OrderRouteRow>
+        {
+            new(2401, "Alpine Ski House", 12840m, "Ready"),
+            new(2402, "Blue Yonder", 7640m, "Review"),
+            new(2403, "Contoso Retail", 19320m, "Attention"),
+            new(2404, "Fabrikam", 9450m, "Ready")
+        };
+        SelectedOrder = Orders[0];
+
+        Router = new RoutingState();
+        ViewLocator = new ReactiveUiRouteViewLocator();
+        var navigator = new ReactiveUiDataGridRouteNavigator(this, CreateRouteViewModel);
+        var resolver = new DelegateDataGridRouteResolver(context =>
+            context.Item is OrderRouteRow order
+                ? new DataGridRoute($"orders/{order.Id}", order, "order-details")
+                : null);
+        RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+        RouteNavigationModel.NavigationChanged += (_, e) =>
+            Status = $"{e.Request.Kind}: {e.Result.Status} · stack depth {Router.NavigationStack.Count}";
+
+        OpenOrderCommand = ReactiveCommand.CreateFromTask(OpenOrderAsync);
+        BackCommand = ReactiveCommand.CreateFromTask(BackAsync);
+        ResetCommand = ReactiveCommand.CreateFromTask(ResetAsync);
+
+        Router.NavigateAndReset.Execute(new OrderListRouteViewModel(this)).Subscribe();
+    }
+
+    public RoutingState Router { get; }
+
+    public IViewLocator ViewLocator { get; }
+
+    public ObservableCollection<OrderRouteRow> Orders { get; }
+
+    public DataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> OpenOrderCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+
+    public OrderRouteRow? SelectedOrder
+    {
+        get => _selectedOrder;
+        set => this.RaiseAndSetIfChanged(ref _selectedOrder, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private async Task OpenOrderAsync()
+    {
+        OrderRouteRow? order = SelectedOrder;
+        var context = new DataGridRouteContext(
+            order,
+            order?.Id,
+            "customer",
+            DataGridNavigationPosition.Unset,
+            DataGridRouteNavigationOrigin.Command,
+            order != null);
+        await RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Navigate, context);
+    }
+
+    private async Task BackAsync() =>
+        await RouteNavigationModel.NavigateAsync(
+            DataGridRouteNavigationKind.Back,
+            DataGridRouteContext.Empty);
+
+    private async Task ResetAsync()
+    {
+        OrderRouteRow? order = SelectedOrder;
+        var context = new DataGridRouteContext(
+            order,
+            order?.Id,
+            "customer",
+            DataGridNavigationPosition.Unset,
+            DataGridRouteNavigationOrigin.Command,
+            order != null);
+        await RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Reset, context);
+    }
+
+    private IRoutableViewModel? CreateRouteViewModel(DataGridRoute route) =>
+        route.Parameter is OrderRouteRow order
+            ? new OrderDetailRouteViewModel(this, order)
+            : null;
+
+    public sealed record OrderRouteRow(int Id, string Customer, decimal Total, string State);
+}
+
+public sealed class OrderListRouteViewModel : ReactiveObject, IRoutableViewModel
+{
+    public OrderListRouteViewModel(IScreen hostScreen)
+    {
+        HostScreen = hostScreen;
+    }
+
+    public string UrlPathSegment => "orders";
+
+    public IScreen HostScreen { get; }
+}
+
+public sealed class OrderDetailRouteViewModel : ReactiveObject, IRoutableViewModel
+{
+    public OrderDetailRouteViewModel(
+        IScreen hostScreen,
+        ReactiveUiRouteNavigationViewModel.OrderRouteRow order)
+    {
+        HostScreen = hostScreen;
+        Order = order;
+    }
+
+    public string UrlPathSegment => $"orders/{Order.Id}";
+
+    public IScreen HostScreen { get; }
+
+    public ReactiveUiRouteNavigationViewModel.OrderRouteRow Order { get; }
+}

--- a/src/DataGridSample/ViewModels/ReactiveUiRouteNavigationViewModel.cs
+++ b/src/DataGridSample/ViewModels/ReactiveUiRouteNavigationViewModel.cs
@@ -35,12 +35,22 @@ public sealed class ReactiveUiRouteNavigationViewModel : ReactiveObject, IScreen
                 ? new DataGridRoute($"orders/{order.Id}", order, "order-details")
                 : null);
         RouteNavigationModel = new DataGridRouteNavigationModel(resolver, navigator);
+        RouteContextFactory = new DataGridRouteContextFactory(item => ((OrderRouteRow)item).Id);
+        NavigationInputModel = new DataGridNavigationInputModel(
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerReleased,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate),
+                targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.Enter,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate)));
         RouteNavigationModel.NavigationChanged += (_, e) =>
-            Status = $"{e.Request.Kind}: {e.Result.Status} · stack depth {Router.NavigationStack.Count}";
+            Status = $"{e.Request.Kind}: {e.Result.Status} · key {e.Request.Context.ItemKey} · cell {e.Request.Context.Position.RowIndex}:{e.Request.Context.Position.ColumnDisplayIndex} · stack depth {Router.NavigationStack.Count}";
 
-        OpenOrderCommand = ReactiveCommand.CreateFromTask(OpenOrderAsync);
-        BackCommand = ReactiveCommand.CreateFromTask(BackAsync);
-        ResetCommand = ReactiveCommand.CreateFromTask(ResetAsync);
+        OpenOrderCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Navigate));
+        BackCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Back));
+        ResetCommand = ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(DataGridRouteNavigationKind.Reset));
 
         Router.NavigateAndReset.Execute(new OrderListRouteViewModel(this)).Subscribe();
     }
@@ -53,11 +63,15 @@ public sealed class ReactiveUiRouteNavigationViewModel : ReactiveObject, IScreen
 
     public DataGridRouteNavigationModel RouteNavigationModel { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> OpenOrderCommand { get; }
+    public DataGridRouteContextFactory RouteContextFactory { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+    public DataGridNavigationInputModel NavigationInputModel { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+    public ReactiveCommand<RxVoid, bool> OpenOrderCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> BackCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> ResetCommand { get; }
 
     public OrderRouteRow? SelectedOrder
     {
@@ -69,37 +83,6 @@ public sealed class ReactiveUiRouteNavigationViewModel : ReactiveObject, IScreen
     {
         get => _status;
         private set => this.RaiseAndSetIfChanged(ref _status, value);
-    }
-
-    private async Task OpenOrderAsync()
-    {
-        OrderRouteRow? order = SelectedOrder;
-        var context = new DataGridRouteContext(
-            order,
-            order?.Id,
-            "customer",
-            DataGridNavigationPosition.Unset,
-            DataGridRouteNavigationOrigin.Command,
-            order != null);
-        await RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Navigate, context);
-    }
-
-    private async Task BackAsync() =>
-        await RouteNavigationModel.NavigateAsync(
-            DataGridRouteNavigationKind.Back,
-            DataGridRouteContext.Empty);
-
-    private async Task ResetAsync()
-    {
-        OrderRouteRow? order = SelectedOrder;
-        var context = new DataGridRouteContext(
-            order,
-            order?.Id,
-            "customer",
-            DataGridNavigationPosition.Unset,
-            DataGridRouteNavigationOrigin.Command,
-            order != null);
-        await RouteNavigationModel.NavigateAsync(DataGridRouteNavigationKind.Reset, context);
     }
 
     private IRoutableViewModel? CreateRouteViewModel(DataGridRoute route) =>

--- a/src/DataGridSample/ViewModels/RouteNavigationSampleViewModel.cs
+++ b/src/DataGridSample/ViewModels/RouteNavigationSampleViewModel.cs
@@ -15,7 +15,7 @@ namespace DataGridSample.ViewModels;
 public sealed class RouteNavigationSampleViewModel : ReactiveObject
 {
     private RouteRow? _selectedItem;
-    private string _status = "Select a row, then navigate.";
+    private string _status = "Click a cell or press Enter to route with its full grid context.";
 
     public RouteNavigationSampleViewModel()
     {
@@ -34,31 +34,37 @@ public sealed class RouteNavigationSampleViewModel : ReactiveObject
                 : null);
         RouteNavigator = new InMemoryRouteNavigator();
         RouteNavigationModel = new DataGridRouteNavigationModel(resolver, RouteNavigator);
+        RouteContextFactory = new DataGridRouteContextFactory(item => ((RouteRow)item).Id);
+        NavigationInputModel = CreateRouteInputModel();
         RouteNavigationModel.NavigationChanged += (_, e) =>
-            Status = $"{e.Request.Kind}: {e.Result.Status} · {e.Result.CurrentRoute.Path}";
+            Status = $"{e.Request.Kind}: {e.Result.Status} · {e.Result.CurrentRoute.Path} · key {e.Request.Context.ItemKey} · cell {e.Request.Context.Position.RowIndex}:{e.Request.Context.Position.ColumnDisplayIndex}";
 
-        NavigateCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Navigate));
-        ReplaceCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Replace));
-        ResetCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Reset));
-        BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Back));
-        ForwardCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Forward));
+        NavigateCommand = CreateRouteCommand(DataGridRouteNavigationKind.Navigate);
+        ReplaceCommand = CreateRouteCommand(DataGridRouteNavigationKind.Replace);
+        ResetCommand = CreateRouteCommand(DataGridRouteNavigationKind.Reset);
+        BackCommand = CreateRouteCommand(DataGridRouteNavigationKind.Back);
+        ForwardCommand = CreateRouteCommand(DataGridRouteNavigationKind.Forward);
     }
 
     public ObservableCollection<RouteRow> Items { get; }
 
     public DataGridRouteNavigationModel RouteNavigationModel { get; }
 
+    public DataGridRouteContextFactory RouteContextFactory { get; }
+
+    public DataGridNavigationInputModel NavigationInputModel { get; }
+
     public InMemoryRouteNavigator RouteNavigator { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> NavigateCommand { get; }
+    public ReactiveCommand<RxVoid, bool> NavigateCommand { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> ReplaceCommand { get; }
+    public ReactiveCommand<RxVoid, bool> ReplaceCommand { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+    public ReactiveCommand<RxVoid, bool> ResetCommand { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+    public ReactiveCommand<RxVoid, bool> BackCommand { get; }
 
-    public ReactiveCommand<RxVoid, RxVoid> ForwardCommand { get; }
+    public ReactiveCommand<RxVoid, bool> ForwardCommand { get; }
 
     public RouteRow? SelectedItem
     {
@@ -72,19 +78,19 @@ public sealed class RouteNavigationSampleViewModel : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref _status, value);
     }
 
-    private async Task NavigateAsync(DataGridRouteNavigationKind kind)
-    {
-        DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward
-            ? DataGridRouteContext.Empty
-            : new DataGridRouteContext(
-                SelectedItem,
-                SelectedItem?.Id,
-                "name",
-                DataGridNavigationPosition.Unset,
-                DataGridRouteNavigationOrigin.Command,
-                SelectedItem != null);
-        await RouteNavigationModel.NavigateAsync(kind, context);
-    }
+    private ReactiveCommand<RxVoid, bool> CreateRouteCommand(DataGridRouteNavigationKind kind) =>
+        ReactiveCommand.Create(() => RouteNavigationModel.RequestNavigate(kind));
+
+    private static DataGridNavigationInputModel CreateRouteInputModel() =>
+        new(
+            DataGridNavigationInputBinding.Pointer(
+                DataGridNavigationInputKind.PointerReleased,
+                DataGridNavigationPointerButton.Primary,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate),
+                targetKind: DataGridNavigationInputTargetKind.Cell),
+            DataGridNavigationInputBinding.KeyDown(
+                DataGridNavigationInputKey.Enter,
+                DataGridNavigationInputResult.NavigateRoute(DataGridRouteNavigationKind.Navigate)));
 
     public sealed record RouteRow(int Id, string Name, string Area, string State);
 

--- a/src/DataGridSample/ViewModels/RouteNavigationSampleViewModel.cs
+++ b/src/DataGridSample/ViewModels/RouteNavigationSampleViewModel.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls.DataGridNavigation;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class RouteNavigationSampleViewModel : ReactiveObject
+{
+    private RouteRow? _selectedItem;
+    private string _status = "Select a row, then navigate.";
+
+    public RouteNavigationSampleViewModel()
+    {
+        Items = new ObservableCollection<RouteRow>
+        {
+            new(42, "Northwind renewal", "Customer", "Ready"),
+            new(73, "Warehouse exception", "Operations", "Attention"),
+            new(108, "Quarterly forecast", "Finance", "Draft"),
+            new(131, "Identity rollout", "Security", "Active")
+        };
+        SelectedItem = Items[0];
+
+        var resolver = new DelegateDataGridRouteResolver(context =>
+            context.Item is RouteRow row
+                ? new DataGridRoute($"work-items/{row.Id}", row, "details")
+                : null);
+        RouteNavigator = new InMemoryRouteNavigator();
+        RouteNavigationModel = new DataGridRouteNavigationModel(resolver, RouteNavigator);
+        RouteNavigationModel.NavigationChanged += (_, e) =>
+            Status = $"{e.Request.Kind}: {e.Result.Status} · {e.Result.CurrentRoute.Path}";
+
+        NavigateCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Navigate));
+        ReplaceCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Replace));
+        ResetCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Reset));
+        BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Back));
+        ForwardCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(DataGridRouteNavigationKind.Forward));
+    }
+
+    public ObservableCollection<RouteRow> Items { get; }
+
+    public DataGridRouteNavigationModel RouteNavigationModel { get; }
+
+    public InMemoryRouteNavigator RouteNavigator { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> NavigateCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ReplaceCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ForwardCommand { get; }
+
+    public RouteRow? SelectedItem
+    {
+        get => _selectedItem;
+        set => this.RaiseAndSetIfChanged(ref _selectedItem, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    private async Task NavigateAsync(DataGridRouteNavigationKind kind)
+    {
+        DataGridRouteContext context = kind is DataGridRouteNavigationKind.Back or DataGridRouteNavigationKind.Forward
+            ? DataGridRouteContext.Empty
+            : new DataGridRouteContext(
+                SelectedItem,
+                SelectedItem?.Id,
+                "name",
+                DataGridNavigationPosition.Unset,
+                DataGridRouteNavigationOrigin.Command,
+                SelectedItem != null);
+        await RouteNavigationModel.NavigateAsync(kind, context);
+    }
+
+    public sealed record RouteRow(int Id, string Name, string Area, string State);
+
+    public sealed class InMemoryRouteNavigator : ReactiveObject, IDataGridRouteNavigator
+    {
+        private readonly List<DataGridRoute> _history = [];
+        private int _index = -1;
+        private string _historySummary = "History is empty";
+
+        public DataGridRouteNavigationCapabilities Capabilities => DataGridRouteNavigationCapabilities.All;
+
+        public string HistorySummary
+        {
+            get => _historySummary;
+            private set => this.RaiseAndSetIfChanged(ref _historySummary, value);
+        }
+
+        public ValueTask<DataGridRouteNavigationResult> NavigateAsync(
+            DataGridRouteNavigationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromResult(DataGridRouteNavigationResult.FromStatus(
+                    DataGridRouteNavigationStatus.Canceled));
+            }
+
+            switch (request.Kind)
+            {
+                case DataGridRouteNavigationKind.Navigate:
+                    if (_index + 1 < _history.Count)
+                    {
+                        _history.RemoveRange(_index + 1, _history.Count - _index - 1);
+                    }
+                    _history.Add(request.Route);
+                    _index = _history.Count - 1;
+                    break;
+                case DataGridRouteNavigationKind.Replace:
+                    if (_index < 0)
+                    {
+                        _history.Add(request.Route);
+                        _index = 0;
+                    }
+                    else
+                    {
+                        _history[_index] = request.Route;
+                    }
+                    break;
+                case DataGridRouteNavigationKind.Reset:
+                    _history.Clear();
+                    _history.Add(request.Route);
+                    _index = 0;
+                    break;
+                case DataGridRouteNavigationKind.Back when _index > 0:
+                    _index--;
+                    break;
+                case DataGridRouteNavigationKind.Forward when _index + 1 < _history.Count:
+                    _index++;
+                    break;
+                default:
+                    return ValueTask.FromResult(DataGridRouteNavigationResult.FromStatus(
+                        DataGridRouteNavigationStatus.NotSupported));
+            }
+
+            DataGridRoute current = _history[_index];
+            HistorySummary = $"{_index + 1}/{_history.Count}: {current.Path} [{current.Target}]";
+            return ValueTask.FromResult(DataGridRouteNavigationResult.Success(current));
+        }
+    }
+}

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -1256,11 +1256,14 @@ public sealed class ProDataGridGeneratorTests
                 [GenerateDataGridViewModel(
                     typeof(Row),
                     GenerateNavigationModel = true,
-                    NavigationModelPropertyName = nameof(CellNavigation))]
+                    NavigationModelPropertyName = nameof(CellNavigation),
+                    GenerateNavigationInputModel = true,
+                    NavigationInputModelPropertyName = nameof(InputNavigation))]
                 [GenerateDataGridView(
                     typeof(Row),
                     NavigationModelPropertyName = nameof(CellNavigation),
-                    RouteNavigationModelPropertyName = nameof(RouteNavigation))]
+                    RouteNavigationModelPropertyName = nameof(RouteNavigation),
+                    NavigationInputModelPropertyName = nameof(InputNavigation))]
                 public sealed partial class RowsViewModel
                 {
                     public IReadOnlyList<Row> Items { get; } = new List<Row>();
@@ -1272,11 +1275,15 @@ public sealed class ProDataGridGeneratorTests
         AssertNoErrors(result);
         Assert.Contains("DataGridNavigationModel CellNavigation", result.CombinedSource);
         Assert.Contains("CreateNavigationModel()", result.CombinedSource);
+        Assert.Contains("DataGridNavigationInputModel InputNavigation", result.CombinedSource);
+        Assert.Contains("CreateNavigationInputModel()", result.CombinedSource);
         Assert.Contains("CreateRouteNavigationModel(", result.CombinedSource);
         Assert.Contains("DataGrid.NavigationModelProperty", result.CombinedSource);
         Assert.Contains("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
+        Assert.Contains("DataGrid.NavigationInputModelProperty", result.CombinedSource);
         Assert.Contains("viewModel.CellNavigation", result.CombinedSource);
         Assert.Contains("viewModel.RouteNavigation", result.CombinedSource);
+        Assert.Contains("viewModel.InputNavigation", result.CombinedSource);
     }
 
     [Fact]
@@ -1293,21 +1300,56 @@ public sealed class ProDataGridGeneratorTests
                 [GenerateDataGridView(
                     typeof(Row),
                     NavigationModelPropertyName = nameof(CellNavigation),
-                    RouteNavigationModelPropertyName = nameof(RouteNavigation))]
+                    RouteNavigationModelPropertyName = nameof(RouteNavigation),
+                    NavigationInputModelPropertyName = nameof(InputNavigation))]
                 public sealed partial class RowsViewModel
                 {
                     public IReadOnlyList<Row> Items { get; } = new List<Row>();
                     public object CellNavigation { get; } = new object();
                     public object RouteNavigation { get; } = new object();
+                    public object InputNavigation { get; } = new object();
                 }
             }
             """);
 
         Assert.Equal(
-            2,
+            3,
             result.GeneratorDiagnostics.Count(static diagnostic => diagnostic.Id == "PDGSG141"));
         Assert.DoesNotContain("DataGrid.NavigationModelProperty", result.CombinedSource);
         Assert.DoesNotContain("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
+        Assert.DoesNotContain("DataGrid.NavigationInputModelProperty", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Namespace_navigation_input_policy_generates_and_binds_input_model()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using ProDataGrid.SourceGeneration;
+            [assembly: GenerateDataGridViewModelsForNamespace(
+                "Demo.ViewModels",
+                GenerateNavigationInputModel = true,
+                NavigationInputModelPropertyName = "GridInput")]
+            [assembly: GenerateDataGridViewsForNamespace(
+                "Demo.ViewModels",
+                NavigationInputModelPropertyName = "GridInput")]
+            namespace Demo.Models
+            {
+                public sealed class Row { public int Id { get; set; } }
+            }
+            namespace Demo.ViewModels
+            {
+                public sealed partial class RowsViewModel
+                {
+                    public IReadOnlyList<Demo.Models.Row> Items { get; } = new List<Demo.Models.Row>();
+                }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGridNavigationInputModel GridInput", result.CombinedSource);
+        Assert.Contains("DataGrid.NavigationInputModelProperty", result.CombinedSource);
+        Assert.Contains("viewModel.GridInput", result.CombinedSource);
     }
 
     [Fact]

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -1242,6 +1242,75 @@ public sealed class ProDataGridGeneratorTests
     }
 
     [Fact]
+    public void Navigation_models_generate_factories_view_model_member_and_typed_view_bindings()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using Avalonia.Controls.DataGridNavigation;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo
+            {
+                public sealed class Row { public int Id { get; set; } }
+
+                [GenerateDataGridViewModel(
+                    typeof(Row),
+                    GenerateNavigationModel = true,
+                    NavigationModelPropertyName = nameof(CellNavigation))]
+                [GenerateDataGridView(
+                    typeof(Row),
+                    NavigationModelPropertyName = nameof(CellNavigation),
+                    RouteNavigationModelPropertyName = nameof(RouteNavigation))]
+                public sealed partial class RowsViewModel
+                {
+                    public IReadOnlyList<Row> Items { get; } = new List<Row>();
+                    public IDataGridRouteNavigationModel RouteNavigation { get; } = null!;
+                }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGridNavigationModel CellNavigation", result.CombinedSource);
+        Assert.Contains("CreateNavigationModel()", result.CombinedSource);
+        Assert.Contains("CreateRouteNavigationModel(", result.CombinedSource);
+        Assert.Contains("DataGrid.NavigationModelProperty", result.CombinedSource);
+        Assert.Contains("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
+        Assert.Contains("viewModel.CellNavigation", result.CombinedSource);
+        Assert.Contains("viewModel.RouteNavigation", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Invalid_navigation_model_bindings_report_PDGSG141()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo
+            {
+                public sealed class Row { public int Id { get; set; } }
+
+                [GenerateDataGridViewModel(typeof(Row))]
+                [GenerateDataGridView(
+                    typeof(Row),
+                    NavigationModelPropertyName = nameof(CellNavigation),
+                    RouteNavigationModelPropertyName = nameof(RouteNavigation))]
+                public sealed partial class RowsViewModel
+                {
+                    public IReadOnlyList<Row> Items { get; } = new List<Row>();
+                    public object CellNavigation { get; } = new object();
+                    public object RouteNavigation { get; } = new object();
+                }
+            }
+            """);
+
+        Assert.Equal(
+            2,
+            result.GeneratorDiagnostics.Count(static diagnostic => diagnostic.Id == "PDGSG141"));
+        Assert.DoesNotContain("DataGrid.NavigationModelProperty", result.CombinedSource);
+        Assert.DoesNotContain("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
+    }
+
+    [Fact]
     public void Invalid_navigation_contracts_and_unbounded_high_frequency_details_are_rejected()
     {
         GeneratorTestResult result = GeneratorTestHelper.Run("""

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -1258,12 +1258,15 @@ public sealed class ProDataGridGeneratorTests
                     GenerateNavigationModel = true,
                     NavigationModelPropertyName = nameof(CellNavigation),
                     GenerateNavigationInputModel = true,
-                    NavigationInputModelPropertyName = nameof(InputNavigation))]
+                    NavigationInputModelPropertyName = nameof(InputNavigation),
+                    GenerateRouteContextFactory = true,
+                    RouteContextFactoryPropertyName = nameof(RouteContext))]
                 [GenerateDataGridView(
                     typeof(Row),
                     NavigationModelPropertyName = nameof(CellNavigation),
                     RouteNavigationModelPropertyName = nameof(RouteNavigation),
-                    NavigationInputModelPropertyName = nameof(InputNavigation))]
+                    NavigationInputModelPropertyName = nameof(InputNavigation),
+                    RouteContextFactoryPropertyName = nameof(RouteContext))]
                 public sealed partial class RowsViewModel
                 {
                     public IReadOnlyList<Row> Items { get; } = new List<Row>();
@@ -1277,13 +1280,17 @@ public sealed class ProDataGridGeneratorTests
         Assert.Contains("CreateNavigationModel()", result.CombinedSource);
         Assert.Contains("DataGridNavigationInputModel InputNavigation", result.CombinedSource);
         Assert.Contains("CreateNavigationInputModel()", result.CombinedSource);
+        Assert.Contains("DataGridRouteContextFactory RouteContext", result.CombinedSource);
+        Assert.Contains("CreateRouteContextFactory()", result.CombinedSource);
         Assert.Contains("CreateRouteNavigationModel(", result.CombinedSource);
         Assert.Contains("DataGrid.NavigationModelProperty", result.CombinedSource);
         Assert.Contains("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
         Assert.Contains("DataGrid.NavigationInputModelProperty", result.CombinedSource);
+        Assert.Contains("DataGrid.RouteContextFactoryProperty", result.CombinedSource);
         Assert.Contains("viewModel.CellNavigation", result.CombinedSource);
         Assert.Contains("viewModel.RouteNavigation", result.CombinedSource);
         Assert.Contains("viewModel.InputNavigation", result.CombinedSource);
+        Assert.Contains("viewModel.RouteContext", result.CombinedSource);
     }
 
     [Fact]
@@ -1301,23 +1308,26 @@ public sealed class ProDataGridGeneratorTests
                     typeof(Row),
                     NavigationModelPropertyName = nameof(CellNavigation),
                     RouteNavigationModelPropertyName = nameof(RouteNavigation),
-                    NavigationInputModelPropertyName = nameof(InputNavigation))]
+                    NavigationInputModelPropertyName = nameof(InputNavigation),
+                    RouteContextFactoryPropertyName = nameof(RouteContext))]
                 public sealed partial class RowsViewModel
                 {
                     public IReadOnlyList<Row> Items { get; } = new List<Row>();
                     public object CellNavigation { get; } = new object();
                     public object RouteNavigation { get; } = new object();
                     public object InputNavigation { get; } = new object();
+                    public object RouteContext { get; } = new object();
                 }
             }
             """);
 
         Assert.Equal(
-            3,
+            4,
             result.GeneratorDiagnostics.Count(static diagnostic => diagnostic.Id == "PDGSG141"));
         Assert.DoesNotContain("DataGrid.NavigationModelProperty", result.CombinedSource);
         Assert.DoesNotContain("DataGrid.RouteNavigationModelProperty", result.CombinedSource);
         Assert.DoesNotContain("DataGrid.NavigationInputModelProperty", result.CombinedSource);
+        Assert.DoesNotContain("DataGrid.RouteContextFactoryProperty", result.CombinedSource);
     }
 
     [Fact]
@@ -1329,10 +1339,13 @@ public sealed class ProDataGridGeneratorTests
             [assembly: GenerateDataGridViewModelsForNamespace(
                 "Demo.ViewModels",
                 GenerateNavigationInputModel = true,
-                NavigationInputModelPropertyName = "GridInput")]
+                NavigationInputModelPropertyName = "GridInput",
+                GenerateRouteContextFactory = true,
+                RouteContextFactoryPropertyName = "GridRouteContext")]
             [assembly: GenerateDataGridViewsForNamespace(
                 "Demo.ViewModels",
-                NavigationInputModelPropertyName = "GridInput")]
+                NavigationInputModelPropertyName = "GridInput",
+                RouteContextFactoryPropertyName = "GridRouteContext")]
             namespace Demo.Models
             {
                 public sealed class Row { public int Id { get; set; } }
@@ -1348,8 +1361,34 @@ public sealed class ProDataGridGeneratorTests
 
         AssertNoErrors(result);
         Assert.Contains("DataGridNavigationInputModel GridInput", result.CombinedSource);
+        Assert.Contains("DataGridRouteContextFactory GridRouteContext", result.CombinedSource);
         Assert.Contains("DataGrid.NavigationInputModelProperty", result.CombinedSource);
         Assert.Contains("viewModel.GridInput", result.CombinedSource);
+        Assert.Contains("DataGrid.RouteContextFactoryProperty", result.CombinedSource);
+        Assert.Contains("viewModel.GridRouteContext", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Generated_route_context_factory_uses_schema_key_without_reflection()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using ProDataGrid.SourceGeneration;
+            namespace Demo
+            {
+                public sealed class Row
+                {
+                    [DataGridKey]
+                    public int Id { get; set; }
+                }
+
+                [GenerateDataGridColumns(typeof(Row))]
+                public sealed partial class RowsSchemaMarker { }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("CreateRouteContextFactory()", result.CombinedSource);
+        Assert.Contains("Instance.GetKey((global::Demo.Row)item)", result.CombinedSource);
     }
 
     [Fact]

--- a/src/ProDataGrid.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/ProDataGrid.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -43,3 +43,4 @@ PDGSG137 | ProDataGrid.SourceGeneration | Error | Invalid formula fill translato
 PDGSG138 | ProDataGrid.SourceGeneration | Error | Invalid generated formula syntax
 PDGSG139 | ProDataGrid.SourceGeneration | Error | Invalid generated view presentation
 PDGSG140 | ProDataGrid.SourceGeneration | Error | Invalid generated collection-view defaults
+PDGSG141 | ProDataGrid.SourceGeneration | Error | Invalid generated view navigation integration

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
@@ -233,6 +233,8 @@ public sealed partial class ProDataGridGenerator
                 public string ColumnDefinitionsPropertyName { get; set; } = "ColumnDefinitions";
                 public string SchemaPropertyName { get; set; } = "DataGridSchema";
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+                public bool GenerateNavigationModel { get; set; }
+                public string NavigationModelPropertyName { get; set; } = "NavigationModel";
                 public string? ProviderName { get; set; }
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
@@ -277,6 +279,8 @@ public sealed partial class ProDataGridGenerator
                 public string ColumnDefinitionsPropertyName { get; set; } = "ColumnDefinitions";
                 public string SchemaPropertyName { get; set; } = "DataGridSchema";
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+                public bool GenerateNavigationModel { get; set; }
+                public string NavigationModelPropertyName { get; set; } = "NavigationModel";
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
             }
@@ -308,6 +312,8 @@ public sealed partial class ProDataGridGenerator
                 public string? SearchModelPropertyName { get; set; }
                 public string? SearchTextPropertyName { get; set; }
                 public string? SelectionModelPropertyName { get; set; }
+                public string? NavigationModelPropertyName { get; set; }
+                public string? RouteNavigationModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =
@@ -395,6 +401,8 @@ public sealed partial class ProDataGridGenerator
                 public string? SearchModelPropertyName { get; set; }
                 public string? SearchTextPropertyName { get; set; }
                 public string? SelectionModelPropertyName { get; set; }
+                public string? NavigationModelPropertyName { get; set; }
+                public string? RouteNavigationModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
@@ -237,6 +237,8 @@ public sealed partial class ProDataGridGenerator
                 public string NavigationModelPropertyName { get; set; } = "NavigationModel";
                 public bool GenerateNavigationInputModel { get; set; }
                 public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
+                public bool GenerateRouteContextFactory { get; set; }
+                public string RouteContextFactoryPropertyName { get; set; } = "RouteContextFactory";
                 public string? ProviderName { get; set; }
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
@@ -285,6 +287,8 @@ public sealed partial class ProDataGridGenerator
                 public string NavigationModelPropertyName { get; set; } = "NavigationModel";
                 public bool GenerateNavigationInputModel { get; set; }
                 public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
+                public bool GenerateRouteContextFactory { get; set; }
+                public string RouteContextFactoryPropertyName { get; set; } = "RouteContextFactory";
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
             }
@@ -319,6 +323,7 @@ public sealed partial class ProDataGridGenerator
                 public string? NavigationModelPropertyName { get; set; }
                 public string? RouteNavigationModelPropertyName { get; set; }
                 public string? NavigationInputModelPropertyName { get; set; }
+                public string? RouteContextFactoryPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =
@@ -409,6 +414,7 @@ public sealed partial class ProDataGridGenerator
                 public string? NavigationModelPropertyName { get; set; }
                 public string? RouteNavigationModelPropertyName { get; set; }
                 public string? NavigationInputModelPropertyName { get; set; }
+                public string? RouteContextFactoryPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
@@ -235,6 +235,8 @@ public sealed partial class ProDataGridGenerator
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
                 public bool GenerateNavigationModel { get; set; }
                 public string NavigationModelPropertyName { get; set; } = "NavigationModel";
+                public bool GenerateNavigationInputModel { get; set; }
+                public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
                 public string? ProviderName { get; set; }
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
@@ -281,6 +283,8 @@ public sealed partial class ProDataGridGenerator
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
                 public bool GenerateNavigationModel { get; set; }
                 public string NavigationModelPropertyName { get; set; } = "NavigationModel";
+                public bool GenerateNavigationInputModel { get; set; }
+                public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
                 public bool Strict { get; set; } = true;
                 public bool Streaming { get; set; }
             }
@@ -314,6 +318,7 @@ public sealed partial class ProDataGridGenerator
                 public string? SelectionModelPropertyName { get; set; }
                 public string? NavigationModelPropertyName { get; set; }
                 public string? RouteNavigationModelPropertyName { get; set; }
+                public string? NavigationInputModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =
@@ -403,6 +408,7 @@ public sealed partial class ProDataGridGenerator
                 public string? SelectionModelPropertyName { get; set; }
                 public string? NavigationModelPropertyName { get; set; }
                 public string? RouteNavigationModelPropertyName { get; set; }
+                public string? NavigationInputModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridSelectionMode SelectionMode { get; set; } =
                     global::Avalonia.Controls.DataGridSelectionMode.Single;
                 public global::Avalonia.Controls.DataGridSelectionUnit SelectionUnit { get; set; } =

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Diagnostics.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Diagnostics.cs
@@ -215,6 +215,11 @@ internal static class GeneratorDiagnostics
         "Invalid generated collection-view defaults",
         "Generated collection-view defaults for item type '{0}' are invalid: {1}");
 
+    public static readonly DiagnosticDescriptor InvalidViewNavigationIntegration = Create(
+        "PDGSG141",
+        "Invalid generated view navigation integration",
+        "Generated navigation integration for view '{0}' is invalid: {1}");
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
@@ -933,7 +933,8 @@ internal static partial class Discovery
             .Where(static model => model.GenerateColumnDefinitionsProperty ||
                                    model.GenerateSchemaProperty ||
                                    model.GenerateFastPathOptionsProperty ||
-                                   model.GenerateNavigationModelProperty)
+                                   model.GenerateNavigationModelProperty ||
+                                   model.GenerateNavigationInputModelProperty)
             .Select(Emitter.EmitViewModelSource)
             .ToImmutableArray();
 
@@ -985,6 +986,7 @@ internal static partial class Discovery
                 SchemaPropertyName = pending.SchemaPropertyName,
                 FastPathOptionsPropertyName = pending.FastPathOptionsPropertyName,
                 NavigationModelPropertyName = pending.NavigationModelPropertyName,
+                NavigationInputModelPropertyName = pending.NavigationInputModelPropertyName,
                 Location = pending.Location,
                 IsDirectIncremental = pending.IsDirectIncremental
             };
@@ -1009,6 +1011,12 @@ internal static partial class Discovery
             model.GenerateNavigationModelProperty = pending.GenerateNavigationModel && ValidateGeneratedViewModelMember(
                 pending.ViewModelType,
                 model.NavigationModelPropertyName,
+                generatedMembers,
+                viewModelDiagnostics,
+                pending.Location);
+            model.GenerateNavigationInputModelProperty = pending.GenerateNavigationInputModel && ValidateGeneratedViewModelMember(
+                pending.ViewModelType,
+                model.NavigationInputModelPropertyName,
                 generatedMembers,
                 viewModelDiagnostics,
                 pending.Location);
@@ -4082,6 +4090,8 @@ internal static partial class Discovery
             FastPathOptionsPropertyName = GeneratorUtilities.GetString(arguments, "FastPathOptionsPropertyName") ?? "FastPathOptions",
             GenerateNavigationModel = GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationModel", false),
             NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName") ?? "NavigationModel",
+            GenerateNavigationInputModel = GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationInputModel", false),
+            NavigationInputModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationInputModelPropertyName") ?? "NavigationInputModel",
             Location = GetLocation(attribute)
         };
     }
@@ -4096,7 +4106,9 @@ internal static partial class Discovery
             pending.SchemaPropertyName + "|" +
             pending.FastPathOptionsPropertyName + "|" +
             pending.GenerateNavigationModel + "|" +
-            pending.NavigationModelPropertyName;
+            pending.NavigationModelPropertyName + "|" +
+            pending.GenerateNavigationInputModel + "|" +
+            pending.NavigationInputModelPropertyName;
         viewModels[key] = pending;
     }
 
@@ -4231,6 +4243,10 @@ internal static partial class Discovery
         public bool GenerateNavigationModel { get; set; }
 
         public string NavigationModelPropertyName { get; set; } = "NavigationModel";
+
+        public bool GenerateNavigationInputModel { get; set; }
+
+        public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
 
         public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
@@ -932,7 +932,8 @@ internal static partial class Discovery
                 suppressDirectDiagnostics: false)
             .Where(static model => model.GenerateColumnDefinitionsProperty ||
                                    model.GenerateSchemaProperty ||
-                                   model.GenerateFastPathOptionsProperty)
+                                   model.GenerateFastPathOptionsProperty ||
+                                   model.GenerateNavigationModelProperty)
             .Select(Emitter.EmitViewModelSource)
             .ToImmutableArray();
 
@@ -983,6 +984,7 @@ internal static partial class Discovery
                 ColumnDefinitionsPropertyName = pending.ColumnDefinitionsPropertyName,
                 SchemaPropertyName = pending.SchemaPropertyName,
                 FastPathOptionsPropertyName = pending.FastPathOptionsPropertyName,
+                NavigationModelPropertyName = pending.NavigationModelPropertyName,
                 Location = pending.Location,
                 IsDirectIncremental = pending.IsDirectIncremental
             };
@@ -1001,6 +1003,12 @@ internal static partial class Discovery
             model.GenerateFastPathOptionsProperty = ValidateGeneratedViewModelMember(
                 pending.ViewModelType,
                 model.FastPathOptionsPropertyName,
+                generatedMembers,
+                viewModelDiagnostics,
+                pending.Location);
+            model.GenerateNavigationModelProperty = pending.GenerateNavigationModel && ValidateGeneratedViewModelMember(
+                pending.ViewModelType,
+                model.NavigationModelPropertyName,
                 generatedMembers,
                 viewModelDiagnostics,
                 pending.Location);
@@ -4072,6 +4080,8 @@ internal static partial class Discovery
             ColumnDefinitionsPropertyName = GeneratorUtilities.GetString(arguments, "ColumnDefinitionsPropertyName") ?? "ColumnDefinitions",
             SchemaPropertyName = GeneratorUtilities.GetString(arguments, "SchemaPropertyName") ?? "DataGridSchema",
             FastPathOptionsPropertyName = GeneratorUtilities.GetString(arguments, "FastPathOptionsPropertyName") ?? "FastPathOptions",
+            GenerateNavigationModel = GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationModel", false),
+            NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName") ?? "NavigationModel",
             Location = GetLocation(attribute)
         };
     }
@@ -4084,7 +4094,9 @@ internal static partial class Discovery
             GeneratorUtilities.GetMetadataName(pending.ItemType) + "|" +
             pending.ColumnDefinitionsPropertyName + "|" +
             pending.SchemaPropertyName + "|" +
-            pending.FastPathOptionsPropertyName;
+            pending.FastPathOptionsPropertyName + "|" +
+            pending.GenerateNavigationModel + "|" +
+            pending.NavigationModelPropertyName;
         viewModels[key] = pending;
     }
 
@@ -4215,6 +4227,10 @@ internal static partial class Discovery
         public string SchemaPropertyName { get; set; } = "DataGridSchema";
 
         public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+
+        public bool GenerateNavigationModel { get; set; }
+
+        public string NavigationModelPropertyName { get; set; } = "NavigationModel";
 
         public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Discovery.cs
@@ -934,7 +934,8 @@ internal static partial class Discovery
                                    model.GenerateSchemaProperty ||
                                    model.GenerateFastPathOptionsProperty ||
                                    model.GenerateNavigationModelProperty ||
-                                   model.GenerateNavigationInputModelProperty)
+                                   model.GenerateNavigationInputModelProperty ||
+                                   model.GenerateRouteContextFactoryProperty)
             .Select(Emitter.EmitViewModelSource)
             .ToImmutableArray();
 
@@ -987,6 +988,7 @@ internal static partial class Discovery
                 FastPathOptionsPropertyName = pending.FastPathOptionsPropertyName,
                 NavigationModelPropertyName = pending.NavigationModelPropertyName,
                 NavigationInputModelPropertyName = pending.NavigationInputModelPropertyName,
+                RouteContextFactoryPropertyName = pending.RouteContextFactoryPropertyName,
                 Location = pending.Location,
                 IsDirectIncremental = pending.IsDirectIncremental
             };
@@ -1017,6 +1019,12 @@ internal static partial class Discovery
             model.GenerateNavigationInputModelProperty = pending.GenerateNavigationInputModel && ValidateGeneratedViewModelMember(
                 pending.ViewModelType,
                 model.NavigationInputModelPropertyName,
+                generatedMembers,
+                viewModelDiagnostics,
+                pending.Location);
+            model.GenerateRouteContextFactoryProperty = pending.GenerateRouteContextFactory && ValidateGeneratedViewModelMember(
+                pending.ViewModelType,
+                model.RouteContextFactoryPropertyName,
                 generatedMembers,
                 viewModelDiagnostics,
                 pending.Location);
@@ -4092,6 +4100,8 @@ internal static partial class Discovery
             NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName") ?? "NavigationModel",
             GenerateNavigationInputModel = GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationInputModel", false),
             NavigationInputModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationInputModelPropertyName") ?? "NavigationInputModel",
+            GenerateRouteContextFactory = GeneratorUtilities.GetBoolean(arguments, "GenerateRouteContextFactory", false),
+            RouteContextFactoryPropertyName = GeneratorUtilities.GetString(arguments, "RouteContextFactoryPropertyName") ?? "RouteContextFactory",
             Location = GetLocation(attribute)
         };
     }
@@ -4108,7 +4118,9 @@ internal static partial class Discovery
             pending.GenerateNavigationModel + "|" +
             pending.NavigationModelPropertyName + "|" +
             pending.GenerateNavigationInputModel + "|" +
-            pending.NavigationInputModelPropertyName;
+            pending.NavigationInputModelPropertyName + "|" +
+            pending.GenerateRouteContextFactory + "|" +
+            pending.RouteContextFactoryPropertyName;
         viewModels[key] = pending;
     }
 
@@ -4247,6 +4259,10 @@ internal static partial class Discovery
         public bool GenerateNavigationInputModel { get; set; }
 
         public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
+
+        public bool GenerateRouteContextFactory { get; set; }
+
+        public string RouteContextFactoryPropertyName { get; set; } = "RouteContextFactory";
 
         public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
@@ -34,7 +34,8 @@ internal static class Emitter
             if (viewModel.IsDirectIncremental ||
                 (!viewModel.GenerateColumnDefinitionsProperty &&
                  !viewModel.GenerateSchemaProperty &&
-                 !viewModel.GenerateFastPathOptionsProperty))
+                 !viewModel.GenerateFastPathOptionsProperty &&
+                 !viewModel.GenerateNavigationModelProperty))
             {
                 continue;
             }
@@ -696,7 +697,15 @@ internal static class Emitter
                 .Append("            => ").Append(GetKeyAccessExpression(schema, "item")).AppendLine(";");
         }
 
-        builder.AppendLine();
+        builder.AppendLine()
+            .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel CreateNavigationModel()")
+            .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel();")
+            .AppendLine()
+            .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridRouteNavigationModel CreateRouteNavigationModel(")
+            .AppendLine("            global::Avalonia.Controls.DataGridNavigation.IDataGridRouteResolver resolver,")
+            .AppendLine("            global::Avalonia.Controls.DataGridNavigation.IDataGridRouteNavigator navigator)")
+            .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridRouteNavigationModel(resolver, navigator);")
+            .AppendLine();
     }
 
     private static void EmitColumnAliasMap(StringBuilder builder, SchemaModel schema)
@@ -2602,6 +2611,18 @@ internal static class Emitter
                 .Append(" { get; } = ").Append(providerType).AppendLine(".Instance.CreateFastPathOptions();");
         }
 
+        if (model.GenerateNavigationModelProperty)
+        {
+            if (model.GenerateFastPathOptionsProperty)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(prefix).Append("public global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel ")
+                .Append(GeneratorUtilities.EscapeIdentifier(model.NavigationModelPropertyName))
+                .Append(" { get; } = ").Append(providerType).AppendLine(".CreateNavigationModel();");
+        }
+
         for (int i = chain.Length - 1; i >= 0; i--)
         {
             indent--;
@@ -3191,6 +3212,14 @@ internal static class Emitter
         {
             EmitViewPropertyInfo(builder, model.SelectionModel, viewModelType, "SelectionModel");
         }
+        if (model.NavigationModel != null)
+        {
+            EmitViewPropertyInfo(builder, model.NavigationModel, viewModelType, "NavigationModel");
+        }
+        if (model.RouteNavigationModel != null)
+        {
+            EmitViewPropertyInfo(builder, model.RouteNavigationModel, viewModelType, "RouteNavigationModel");
+        }
         if (model.ClipboardImportModel != null)
         {
             EmitViewPropertyInfo(builder, model.ClipboardImportModel, viewModelType, "ClipboardImportModel");
@@ -3449,6 +3478,8 @@ internal static class Emitter
                 .Append(model.SelectionUnit.ToString(CultureInfo.InvariantCulture)).AppendLine(";");
         }
         EmitOptionalGridBinding(builder, model.SelectionModel, "Selection", "s_selectionModelProperty");
+        EmitOptionalGridBinding(builder, model.NavigationModel, "NavigationModel", "s_navigationModelProperty");
+        EmitOptionalGridBinding(builder, model.RouteNavigationModel, "RouteNavigationModel", "s_routeNavigationModelProperty");
         EmitOptionalGridBinding(builder, model.ClipboardImportModel, "ClipboardImportModel", "s_clipboardImportModelProperty");
         EmitOptionalGridBinding(builder, model.FillModel, "FillModel", "s_fillModelProperty");
         EmitOptionalGridBinding(builder, model.FormulaModel, "FormulaModel", "s_formulaModelProperty");

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
@@ -35,7 +35,8 @@ internal static class Emitter
                 (!viewModel.GenerateColumnDefinitionsProperty &&
                  !viewModel.GenerateSchemaProperty &&
                  !viewModel.GenerateFastPathOptionsProperty &&
-                 !viewModel.GenerateNavigationModelProperty))
+                 !viewModel.GenerateNavigationModelProperty &&
+                 !viewModel.GenerateNavigationInputModelProperty))
             {
                 continue;
             }
@@ -700,6 +701,9 @@ internal static class Emitter
         builder.AppendLine()
             .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel CreateNavigationModel()")
             .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel();")
+            .AppendLine()
+            .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel CreateNavigationInputModel()")
+            .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel();")
             .AppendLine()
             .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridRouteNavigationModel CreateRouteNavigationModel(")
             .AppendLine("            global::Avalonia.Controls.DataGridNavigation.IDataGridRouteResolver resolver,")
@@ -2623,6 +2627,18 @@ internal static class Emitter
                 .Append(" { get; } = ").Append(providerType).AppendLine(".CreateNavigationModel();");
         }
 
+        if (model.GenerateNavigationInputModelProperty)
+        {
+            if (model.GenerateFastPathOptionsProperty || model.GenerateNavigationModelProperty)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(prefix).Append("public global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel ")
+                .Append(GeneratorUtilities.EscapeIdentifier(model.NavigationInputModelPropertyName))
+                .Append(" { get; } = ").Append(providerType).AppendLine(".CreateNavigationInputModel();");
+        }
+
         for (int i = chain.Length - 1; i >= 0; i--)
         {
             indent--;
@@ -3220,6 +3236,10 @@ internal static class Emitter
         {
             EmitViewPropertyInfo(builder, model.RouteNavigationModel, viewModelType, "RouteNavigationModel");
         }
+        if (model.NavigationInputModel != null)
+        {
+            EmitViewPropertyInfo(builder, model.NavigationInputModel, viewModelType, "NavigationInputModel");
+        }
         if (model.ClipboardImportModel != null)
         {
             EmitViewPropertyInfo(builder, model.ClipboardImportModel, viewModelType, "ClipboardImportModel");
@@ -3480,6 +3500,7 @@ internal static class Emitter
         EmitOptionalGridBinding(builder, model.SelectionModel, "Selection", "s_selectionModelProperty");
         EmitOptionalGridBinding(builder, model.NavigationModel, "NavigationModel", "s_navigationModelProperty");
         EmitOptionalGridBinding(builder, model.RouteNavigationModel, "RouteNavigationModel", "s_routeNavigationModelProperty");
+        EmitOptionalGridBinding(builder, model.NavigationInputModel, "NavigationInputModel", "s_navigationInputModelProperty");
         EmitOptionalGridBinding(builder, model.ClipboardImportModel, "ClipboardImportModel", "s_clipboardImportModelProperty");
         EmitOptionalGridBinding(builder, model.FillModel, "FillModel", "s_fillModelProperty");
         EmitOptionalGridBinding(builder, model.FormulaModel, "FormulaModel", "s_formulaModelProperty");

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
@@ -36,7 +36,8 @@ internal static class Emitter
                  !viewModel.GenerateSchemaProperty &&
                  !viewModel.GenerateFastPathOptionsProperty &&
                  !viewModel.GenerateNavigationModelProperty &&
-                 !viewModel.GenerateNavigationInputModelProperty))
+                 !viewModel.GenerateNavigationInputModelProperty &&
+                 !viewModel.GenerateRouteContextFactoryProperty))
             {
                 continue;
             }
@@ -704,6 +705,21 @@ internal static class Emitter
             .AppendLine()
             .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel CreateNavigationInputModel()")
             .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel();")
+            .AppendLine();
+
+        if (schema.KeyMember != null)
+        {
+            builder.AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory CreateRouteContextFactory()")
+                .Append("            => new global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory(static item => Instance.GetKey((")
+                .Append(itemType).AppendLine(")item)!);");
+        }
+        else
+        {
+            builder.AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory CreateRouteContextFactory()")
+                .AppendLine("            => new global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory();");
+        }
+
+        builder
             .AppendLine()
             .AppendLine("        public static global::Avalonia.Controls.DataGridNavigation.DataGridRouteNavigationModel CreateRouteNavigationModel(")
             .AppendLine("            global::Avalonia.Controls.DataGridNavigation.IDataGridRouteResolver resolver,")
@@ -2639,6 +2655,20 @@ internal static class Emitter
                 .Append(" { get; } = ").Append(providerType).AppendLine(".CreateNavigationInputModel();");
         }
 
+        if (model.GenerateRouteContextFactoryProperty)
+        {
+            if (model.GenerateFastPathOptionsProperty ||
+                model.GenerateNavigationModelProperty ||
+                model.GenerateNavigationInputModelProperty)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(prefix).Append("public global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory ")
+                .Append(GeneratorUtilities.EscapeIdentifier(model.RouteContextFactoryPropertyName))
+                .Append(" { get; } = ").Append(providerType).AppendLine(".CreateRouteContextFactory();");
+        }
+
         for (int i = chain.Length - 1; i >= 0; i--)
         {
             indent--;
@@ -3240,6 +3270,10 @@ internal static class Emitter
         {
             EmitViewPropertyInfo(builder, model.NavigationInputModel, viewModelType, "NavigationInputModel");
         }
+        if (model.RouteContextFactory != null)
+        {
+            EmitViewPropertyInfo(builder, model.RouteContextFactory, viewModelType, "RouteContextFactory");
+        }
         if (model.ClipboardImportModel != null)
         {
             EmitViewPropertyInfo(builder, model.ClipboardImportModel, viewModelType, "ClipboardImportModel");
@@ -3501,6 +3535,7 @@ internal static class Emitter
         EmitOptionalGridBinding(builder, model.NavigationModel, "NavigationModel", "s_navigationModelProperty");
         EmitOptionalGridBinding(builder, model.RouteNavigationModel, "RouteNavigationModel", "s_routeNavigationModelProperty");
         EmitOptionalGridBinding(builder, model.NavigationInputModel, "NavigationInputModel", "s_navigationInputModelProperty");
+        EmitOptionalGridBinding(builder, model.RouteContextFactory, "RouteContextFactory", "s_routeContextFactoryProperty");
         EmitOptionalGridBinding(builder, model.ClipboardImportModel, "ClipboardImportModel", "s_clipboardImportModelProperty");
         EmitOptionalGridBinding(builder, model.FillModel, "FillModel", "s_fillModelProperty");
         EmitOptionalGridBinding(builder, model.FormulaModel, "FormulaModel", "s_formulaModelProperty");

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
@@ -121,6 +121,8 @@ internal sealed class ViewModelViewModel
 
     public ViewBindingModel? RouteNavigationModel { get; set; }
 
+    public ViewBindingModel? NavigationInputModel { get; set; }
+
     public int SelectionMode { get; set; }
 
     public int SelectionUnit { get; set; }
@@ -701,6 +703,8 @@ internal sealed class ViewModelModel
 
     public string NavigationModelPropertyName { get; set; } = "NavigationModel";
 
+    public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
+
     public bool GenerateColumnDefinitionsProperty { get; set; } = true;
 
     public bool GenerateSchemaProperty { get; set; } = true;
@@ -708,6 +712,8 @@ internal sealed class ViewModelModel
     public bool GenerateFastPathOptionsProperty { get; set; } = true;
 
     public bool GenerateNavigationModelProperty { get; set; }
+
+    public bool GenerateNavigationInputModelProperty { get; set; }
 
     public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
@@ -123,6 +123,8 @@ internal sealed class ViewModelViewModel
 
     public ViewBindingModel? NavigationInputModel { get; set; }
 
+    public ViewBindingModel? RouteContextFactory { get; set; }
+
     public int SelectionMode { get; set; }
 
     public int SelectionUnit { get; set; }
@@ -705,6 +707,8 @@ internal sealed class ViewModelModel
 
     public string NavigationInputModelPropertyName { get; set; } = "NavigationInputModel";
 
+    public string RouteContextFactoryPropertyName { get; set; } = "RouteContextFactory";
+
     public bool GenerateColumnDefinitionsProperty { get; set; } = true;
 
     public bool GenerateSchemaProperty { get; set; } = true;
@@ -714,6 +718,8 @@ internal sealed class ViewModelModel
     public bool GenerateNavigationModelProperty { get; set; }
 
     public bool GenerateNavigationInputModelProperty { get; set; }
+
+    public bool GenerateRouteContextFactoryProperty { get; set; }
 
     public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
@@ -117,6 +117,10 @@ internal sealed class ViewModelViewModel
 
     public ViewBindingModel? SelectionModel { get; set; }
 
+    public ViewBindingModel? NavigationModel { get; set; }
+
+    public ViewBindingModel? RouteNavigationModel { get; set; }
+
     public int SelectionMode { get; set; }
 
     public int SelectionUnit { get; set; }
@@ -695,11 +699,15 @@ internal sealed class ViewModelModel
 
     public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
 
+    public string NavigationModelPropertyName { get; set; } = "NavigationModel";
+
     public bool GenerateColumnDefinitionsProperty { get; set; } = true;
 
     public bool GenerateSchemaProperty { get; set; } = true;
 
     public bool GenerateFastPathOptionsProperty { get; set; } = true;
+
+    public bool GenerateNavigationModelProperty { get; set; }
 
     public bool IsDirectIncremental { get; set; }
 

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
@@ -339,6 +339,7 @@ internal static partial class Discovery
             SelectionModelPropertyName = GeneratorUtilities.GetString(arguments, "SelectionModelPropertyName"),
             NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName"),
             RouteNavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "RouteNavigationModelPropertyName"),
+            NavigationInputModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationInputModelPropertyName"),
             SelectionMode = GetEnumValue(arguments, "SelectionMode", 1),
             SelectionUnit = GetEnumValue(arguments, "SelectionUnit", 0),
             HasSelectionConfiguration = arguments.Keys.Any(static key =>
@@ -751,6 +752,15 @@ internal static partial class Discovery
                 request.RouteNavigationModelPropertyName,
                 "Avalonia.Controls.DataGridNavigation.IDataGridRouteNavigationModel",
                 "IDataGridRouteNavigationModel",
+                diagnostics),
+            NavigationInputModel = ResolveNavigationModelViewBinding(
+                request,
+                request.NavigationInputModelPropertyName,
+                "Avalonia.Controls.DataGridNavigation.IDataGridNavigationInputModel",
+                "IDataGridNavigationInputModel",
+                "GenerateNavigationInputModel",
+                "NavigationInputModelPropertyName",
+                true,
                 diagnostics),
             SelectionMode = request.SelectionMode,
             SelectionUnit = request.SelectionUnit,
@@ -1408,6 +1418,28 @@ internal static partial class Discovery
         string? propertyName,
         string interfaceMetadataName,
         string interfaceDisplayName,
+        ImmutableArray<Diagnostic>.Builder diagnostics) =>
+        ResolveNavigationModelViewBinding(
+            request,
+            propertyName,
+            interfaceMetadataName,
+            interfaceDisplayName,
+            "GenerateNavigationModel",
+            "NavigationModelPropertyName",
+            string.Equals(
+                interfaceMetadataName,
+                "Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel",
+                StringComparison.Ordinal),
+            diagnostics);
+
+    private static ViewBindingModel? ResolveNavigationModelViewBinding(
+        ViewRequest request,
+        string? propertyName,
+        string interfaceMetadataName,
+        string interfaceDisplayName,
+        string generatePropertyName,
+        string generatedPropertyName,
+        bool allowGeneratedModel,
         ImmutableArray<Diagnostic>.Builder diagnostics)
     {
         if (string.IsNullOrWhiteSpace(propertyName))
@@ -1415,20 +1447,22 @@ internal static partial class Discovery
             return null;
         }
 
-        bool usesGeneratedCellModel = string.Equals(
-            interfaceMetadataName,
-            "Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel",
-            StringComparison.Ordinal) &&
-            IsGeneratedNavigationModelProperty(request.ViewModelType, propertyName!);
+        bool usesGeneratedModel = allowGeneratedModel && IsGeneratedNavigationModelProperty(
+            request.ViewModelType,
+            propertyName!,
+            generatePropertyName,
+            generatedPropertyName);
         ViewBindingModel? binding = ResolveViewBinding(
             request,
             propertyName!,
-            usesGeneratedCellModel
-                ? "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel"
+            usesGeneratedModel
+                ? string.Equals(generatePropertyName, "GenerateNavigationInputModel", StringComparison.Ordinal)
+                    ? "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel"
+                    : "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel"
                 : null,
-            usesGeneratedCellModel,
+            usesGeneratedModel,
             diagnostics);
-        if (binding == null || usesGeneratedCellModel)
+        if (binding == null || usesGeneratedModel)
         {
             return binding;
         }
@@ -1453,11 +1487,15 @@ internal static partial class Discovery
         return null;
     }
 
-    private static bool IsGeneratedNavigationModelProperty(INamedTypeSymbol viewModelType, string propertyName)
+    private static bool IsGeneratedNavigationModelProperty(
+        INamedTypeSymbol viewModelType,
+        string propertyName,
+        string generatePropertyName,
+        string generatedPropertyName)
     {
         foreach (AttributeData attribute in viewModelType.GetAttributes())
         {
-            if (IsGeneratedNavigationModelProperty(attribute, propertyName))
+            if (IsGeneratedNavigationModelProperty(attribute, propertyName, generatePropertyName, generatedPropertyName))
             {
                 return true;
             }
@@ -1467,7 +1505,7 @@ internal static partial class Discovery
         {
             if (IsAttribute(attribute, ProDataGridGenerator.GenerateViewModelAttributeName) &&
                 SymbolEqualityComparer.Default.Equals(GetConstructorType(attribute, 0), viewModelType) &&
-                IsGeneratedNavigationModelProperty(attribute, propertyName))
+                IsGeneratedNavigationModelProperty(attribute, propertyName, generatePropertyName, generatedPropertyName))
             {
                 return true;
             }
@@ -1486,7 +1524,7 @@ internal static partial class Discovery
                     viewModelType,
                     namespaceName!,
                     GeneratorUtilities.GetBoolean(arguments, "IncludeNestedNamespaces", true)) &&
-                IsGeneratedNavigationModelProperty(attribute, propertyName))
+                IsGeneratedNavigationModelProperty(attribute, propertyName, generatePropertyName, generatedPropertyName))
             {
                 return true;
             }
@@ -1495,12 +1533,19 @@ internal static partial class Discovery
         return false;
     }
 
-    private static bool IsGeneratedNavigationModelProperty(AttributeData attribute, string propertyName)
+    private static bool IsGeneratedNavigationModelProperty(
+        AttributeData attribute,
+        string propertyName,
+        string generatePropertyName,
+        string generatedPropertyName)
     {
         Dictionary<string, TypedConstant> arguments = GeneratorUtilities.GetNamedArguments(attribute);
-        return GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationModel", false) &&
+        return GeneratorUtilities.GetBoolean(arguments, generatePropertyName, false) &&
             string.Equals(
-                GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName") ?? "NavigationModel",
+                GeneratorUtilities.GetString(arguments, generatedPropertyName) ??
+                    (string.Equals(generatePropertyName, "GenerateNavigationInputModel", StringComparison.Ordinal)
+                        ? "NavigationInputModel"
+                        : "NavigationModel"),
                 propertyName,
                 StringComparison.Ordinal);
     }
@@ -1732,6 +1777,7 @@ internal static partial class Discovery
         public string? SelectionModelPropertyName { get; set; }
         public string? NavigationModelPropertyName { get; set; }
         public string? RouteNavigationModelPropertyName { get; set; }
+        public string? NavigationInputModelPropertyName { get; set; }
         public int SelectionMode { get; set; } = 1;
         public int SelectionUnit { get; set; }
         public bool HasSelectionConfiguration { get; set; }

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
@@ -337,6 +337,8 @@ internal static partial class Discovery
             SearchModelPropertyName = GeneratorUtilities.GetString(arguments, "SearchModelPropertyName"),
             SearchTextPropertyName = GeneratorUtilities.GetString(arguments, "SearchTextPropertyName"),
             SelectionModelPropertyName = GeneratorUtilities.GetString(arguments, "SelectionModelPropertyName"),
+            NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName"),
+            RouteNavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "RouteNavigationModelPropertyName"),
             SelectionMode = GetEnumValue(arguments, "SelectionMode", 1),
             SelectionUnit = GetEnumValue(arguments, "SelectionUnit", 0),
             HasSelectionConfiguration = arguments.Keys.Any(static key =>
@@ -738,6 +740,18 @@ internal static partial class Discovery
             SearchModel = ResolveOptionalViewBinding(request, request.SearchModelPropertyName, diagnostics),
             SearchText = ResolveOptionalViewBinding(request, request.SearchTextPropertyName, diagnostics, requireSetter: true),
             SelectionModel = ResolveOptionalViewBinding(request, request.SelectionModelPropertyName, diagnostics),
+            NavigationModel = ResolveNavigationModelViewBinding(
+                request,
+                request.NavigationModelPropertyName,
+                "Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel",
+                "IDataGridNavigationModel",
+                diagnostics),
+            RouteNavigationModel = ResolveNavigationModelViewBinding(
+                request,
+                request.RouteNavigationModelPropertyName,
+                "Avalonia.Controls.DataGridNavigation.IDataGridRouteNavigationModel",
+                "IDataGridRouteNavigationModel",
+                diagnostics),
             SelectionMode = request.SelectionMode,
             SelectionUnit = request.SelectionUnit,
             ConfigureSelection = request.HasSelectionConfiguration,
@@ -1389,6 +1403,108 @@ internal static partial class Discovery
         return null;
     }
 
+    private static ViewBindingModel? ResolveNavigationModelViewBinding(
+        ViewRequest request,
+        string? propertyName,
+        string interfaceMetadataName,
+        string interfaceDisplayName,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(propertyName))
+        {
+            return null;
+        }
+
+        bool usesGeneratedCellModel = string.Equals(
+            interfaceMetadataName,
+            "Avalonia.Controls.DataGridNavigation.IDataGridNavigationModel",
+            StringComparison.Ordinal) &&
+            IsGeneratedNavigationModelProperty(request.ViewModelType, propertyName!);
+        ViewBindingModel? binding = ResolveViewBinding(
+            request,
+            propertyName!,
+            usesGeneratedCellModel
+                ? "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel"
+                : null,
+            usesGeneratedCellModel,
+            diagnostics);
+        if (binding == null || usesGeneratedCellModel)
+        {
+            return binding;
+        }
+
+        ITypeSymbol? propertyType = FindViewBindingMemberType(request.ViewModelType, propertyName!);
+        ITypeSymbol? unwrappedType = propertyType == null ? null : UnwrapNullable(propertyType);
+        if (unwrappedType is INamedTypeSymbol namedType &&
+            (string.Equals(GeneratorUtilities.GetMetadataName(namedType), interfaceMetadataName, StringComparison.Ordinal) ||
+             namedType.AllInterfaces.Any(implemented => string.Equals(
+                 GeneratorUtilities.GetMetadataName(implemented),
+                 interfaceMetadataName,
+                 StringComparison.Ordinal))))
+        {
+            return binding;
+        }
+
+        diagnostics.Add(Diagnostic.Create(
+            GeneratorDiagnostics.InvalidViewNavigationIntegration,
+            request.Location,
+            request.ViewName,
+            $"member '{propertyName}' must implement {interfaceDisplayName}"));
+        return null;
+    }
+
+    private static bool IsGeneratedNavigationModelProperty(INamedTypeSymbol viewModelType, string propertyName)
+    {
+        foreach (AttributeData attribute in viewModelType.GetAttributes())
+        {
+            if (IsGeneratedNavigationModelProperty(attribute, propertyName))
+            {
+                return true;
+            }
+        }
+
+        foreach (AttributeData attribute in viewModelType.ContainingAssembly.GetAttributes())
+        {
+            if (IsAttribute(attribute, ProDataGridGenerator.GenerateViewModelAttributeName) &&
+                SymbolEqualityComparer.Default.Equals(GetConstructorType(attribute, 0), viewModelType) &&
+                IsGeneratedNavigationModelProperty(attribute, propertyName))
+            {
+                return true;
+            }
+
+            if (!IsAttribute(attribute, ProDataGridGenerator.GenerateViewModelsForNamespaceAttributeName))
+            {
+                continue;
+            }
+
+            string? namespaceName = attribute.ConstructorArguments.Length > 0
+                ? attribute.ConstructorArguments[0].Value as string
+                : null;
+            Dictionary<string, TypedConstant> arguments = GeneratorUtilities.GetNamedArguments(attribute);
+            if (!string.IsNullOrWhiteSpace(namespaceName) &&
+                NamespaceMatches(
+                    viewModelType,
+                    namespaceName!,
+                    GeneratorUtilities.GetBoolean(arguments, "IncludeNestedNamespaces", true)) &&
+                IsGeneratedNavigationModelProperty(attribute, propertyName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsGeneratedNavigationModelProperty(AttributeData attribute, string propertyName)
+    {
+        Dictionary<string, TypedConstant> arguments = GeneratorUtilities.GetNamedArguments(attribute);
+        return GeneratorUtilities.GetBoolean(arguments, "GenerateNavigationModel", false) &&
+            string.Equals(
+                GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName") ?? "NavigationModel",
+                propertyName,
+                StringComparison.Ordinal);
+    }
+
     private static ViewBindingModel? ResolveFormulaViewBinding(
         ViewRequest request,
         ImmutableArray<Diagnostic>.Builder diagnostics)
@@ -1614,6 +1730,8 @@ internal static partial class Discovery
         public string? SearchModelPropertyName { get; set; }
         public string? SearchTextPropertyName { get; set; }
         public string? SelectionModelPropertyName { get; set; }
+        public string? NavigationModelPropertyName { get; set; }
+        public string? RouteNavigationModelPropertyName { get; set; }
         public int SelectionMode { get; set; } = 1;
         public int SelectionUnit { get; set; }
         public bool HasSelectionConfiguration { get; set; }

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
@@ -340,6 +340,7 @@ internal static partial class Discovery
             NavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationModelPropertyName"),
             RouteNavigationModelPropertyName = GeneratorUtilities.GetString(arguments, "RouteNavigationModelPropertyName"),
             NavigationInputModelPropertyName = GeneratorUtilities.GetString(arguments, "NavigationInputModelPropertyName"),
+            RouteContextFactoryPropertyName = GeneratorUtilities.GetString(arguments, "RouteContextFactoryPropertyName"),
             SelectionMode = GetEnumValue(arguments, "SelectionMode", 1),
             SelectionUnit = GetEnumValue(arguments, "SelectionUnit", 0),
             HasSelectionConfiguration = arguments.Keys.Any(static key =>
@@ -760,6 +761,15 @@ internal static partial class Discovery
                 "IDataGridNavigationInputModel",
                 "GenerateNavigationInputModel",
                 "NavigationInputModelPropertyName",
+                true,
+                diagnostics),
+            RouteContextFactory = ResolveNavigationModelViewBinding(
+                request,
+                request.RouteContextFactoryPropertyName,
+                "Avalonia.Controls.DataGridNavigation.IDataGridRouteContextFactory",
+                "IDataGridRouteContextFactory",
+                "GenerateRouteContextFactory",
+                "RouteContextFactoryPropertyName",
                 true,
                 diagnostics),
             SelectionMode = request.SelectionMode,
@@ -1455,11 +1465,7 @@ internal static partial class Discovery
         ViewBindingModel? binding = ResolveViewBinding(
             request,
             propertyName!,
-            usesGeneratedModel
-                ? string.Equals(generatePropertyName, "GenerateNavigationInputModel", StringComparison.Ordinal)
-                    ? "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel"
-                    : "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel"
-                : null,
+            usesGeneratedModel ? GetGeneratedNavigationPropertyType(generatePropertyName) : null,
             usesGeneratedModel,
             diagnostics);
         if (binding == null || usesGeneratedModel)
@@ -1486,6 +1492,15 @@ internal static partial class Discovery
             $"member '{propertyName}' must implement {interfaceDisplayName}"));
         return null;
     }
+
+    private static string GetGeneratedNavigationPropertyType(string generatePropertyName) => generatePropertyName switch
+    {
+        "GenerateNavigationInputModel" =>
+            "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationInputModel",
+        "GenerateRouteContextFactory" =>
+            "global::Avalonia.Controls.DataGridNavigation.DataGridRouteContextFactory",
+        _ => "global::Avalonia.Controls.DataGridNavigation.DataGridNavigationModel"
+    };
 
     private static bool IsGeneratedNavigationModelProperty(
         INamedTypeSymbol viewModelType,
@@ -1543,12 +1558,18 @@ internal static partial class Discovery
         return GeneratorUtilities.GetBoolean(arguments, generatePropertyName, false) &&
             string.Equals(
                 GeneratorUtilities.GetString(arguments, generatedPropertyName) ??
-                    (string.Equals(generatePropertyName, "GenerateNavigationInputModel", StringComparison.Ordinal)
-                        ? "NavigationInputModel"
-                        : "NavigationModel"),
+                    GetDefaultGeneratedNavigationPropertyName(generatePropertyName),
                 propertyName,
                 StringComparison.Ordinal);
     }
+
+    private static string GetDefaultGeneratedNavigationPropertyName(string generatePropertyName) =>
+        generatePropertyName switch
+        {
+            "GenerateNavigationInputModel" => "NavigationInputModel",
+            "GenerateRouteContextFactory" => "RouteContextFactory",
+            _ => "NavigationModel"
+        };
 
     private static ViewBindingModel? ResolveFormulaViewBinding(
         ViewRequest request,
@@ -1778,6 +1799,7 @@ internal static partial class Discovery
         public string? NavigationModelPropertyName { get; set; }
         public string? RouteNavigationModelPropertyName { get; set; }
         public string? NavigationInputModelPropertyName { get; set; }
+        public string? RouteContextFactoryPropertyName { get; set; }
         public int SelectionMode { get; set; } = 1;
         public int SelectionUnit { get; set; }
         public bool HasSelectionConfiguration { get; set; }


### PR DESCRIPTION
## What changed

- adds a public framework-neutral cell navigation policy model with semantic commands, cancel, redirect, move, leave, controller commands, hierarchy operations, and serializable policy state
- adds a framework-neutral input model that normalizes logical and physical keyboard input, gamepad and remote keys, pointer, touch, pen, click targets, and wheel gestures into semantic grid or route navigation
- lets ViewModels provide ordered bindings or dynamically resolve input without code-behind, behaviors, or control-template overrides; unresolved input preserves existing DataGrid behavior
- routes pointer navigation with the exact clicked cell context and keyboard navigation with the current cell context, so application routes can originate inside the grid without losing row, column, item, or origin
- adds a separate asynchronous application-route model with typed results, cancellation, guards, capabilities, history operations, route context, stable item-key factories, grid-owned controller requests, and single-flight concurrency
- documents and demonstrates adapters for ReactiveUI RoutingState, Prism, CommunityToolkit.Mvvm, Caliburn.Micro, plain MVVM, and Microsoft DI without adding framework dependencies to the core package
- extends the incremental source generator with navigation, input, and stable route-context factories; optional generated ViewModel properties; compiled generated-view bindings; namespace defaults; validation diagnostic PDGSG141; and generated-sample coverage
- adds gallery coverage for basic policies, boundaries and RTL, editing and selection, custom policy, hierarchy, state, application routes, ReactiveUI, MVVM frameworks, generated navigation, custom key maps, pointer targets, Enter routing, and wheel history
- publishes architecture, migration, API, input, framework integration, accessibility, performance, testing, route, and source-generator documentation

## Architecture and compatibility

Input resolution maps device-specific events to semantic commands once. The navigation model owns policy; the DataGrid owns authoritative cell context plus edit, focus, selection, and execution. Application routing remains framework-neutral through small resolver, navigator, context-factory, and controller interfaces. Optional spatial layout geometry is layered in stacked draft PR #341, where the layout owns geometric neighbor resolution while this PR remains navigation, input, and route-context only.

Existing grids keep their legacy keyboard, editing, selection, focus, hierarchy, pointer, wheel, and virtualization behavior when no custom model or binding handles an input. The new APIs are additive, framework-agnostic, AOT-friendly, and reflection-free in production.

## Validation

- full local Release solution: 3,679 tests passed, 0 failed
- core DataGrid: 2,820 passed
- incremental source generator: 193 passed
- gallery/sample: 359 passed, including real routed pointer clicks
- leak suite: 38 passed
- DocFX: 0 errors
- GitHub Actions at `17317d3c`: Build, Ubuntu/macOS/Windows tests, NativeAOT source-generation smoke, Pack, Windows leak tests, and native-source comparison passed

Draft retained for public API and stacked layout-integration review.