### PR TITLE
Add model-based DataGrid layouts with spatial navigation

### DIFF
--- a/docfx/articles/custom-layouts.md
+++ b/docfx/articles/custom-layouts.md
@@ -1,0 +1,163 @@
+# Custom layouts
+
+Applications can add layout types without deriving from DataGrid or replacing its presenter. A custom layout consists of a model and an algorithm:
+
+- `IDataGridLayoutModel` owns serializable/bindable configuration and creates an algorithm;
+- `IDataGridLayoutAlgorithm` measures, records bounds, arranges, handles item changes, and releases session resources;
+- `IDataGridLayoutNavigation` is optional and adds geometry-aware navigation;
+- `IDataGridLayoutContext` is the only container/estimator service the algorithm should use.
+
+`DataGridLayoutModelBase` implements invalidation and allocation-free equality checks for property setters. Prefer it unless the model already has another base type.
+
+## Minimal model
+
+```csharp
+public sealed class IndentedStackLayoutModel : DataGridLayoutModelBase
+{
+    private double _indent = 32;
+
+    public double Indent
+    {
+        get => _indent;
+        set => SetProperty(ref _indent, value);
+    }
+
+    public override IDataGridLayoutAlgorithm CreateAlgorithm() =>
+        new IndentedStackLayoutAlgorithm(this);
+}
+```
+
+`SetProperty` raises `LayoutInvalidated`. Use the overload with an explicit invalidation kind:
+
+- `Arrange` when recorded sizes/positions remain valid and only final placement changes;
+- `Measure` for size or spacing changes;
+- `Reset` when cached state no longer describes the same coordinate system.
+
+## Algorithm lifecycle
+
+```csharp
+public sealed class IndentedStackLayoutAlgorithm : IDataGridLayoutAlgorithm
+{
+    private readonly IndentedStackLayoutModel _model;
+
+    public IndentedStackLayoutAlgorithm(IndentedStackLayoutModel model) =>
+        _model = model;
+
+    public void Initialize(IDataGridLayoutContext context)
+    {
+        context.LayoutState ??= new State();
+    }
+
+    public Size Measure(IDataGridLayoutContext context, Size availableSize)
+    {
+        // Determine an anchor, request intersecting elements, measure and record
+        // their bounds, recycle outside the retained range, and return an extent.
+        throw new NotImplementedException();
+    }
+
+    public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+    {
+        foreach (Control element in context.RealizedElements)
+        {
+            int index = context.GetElementIndex(element);
+            if (index >= 0 && context.TryGetLayoutBounds(index, out Rect bounds))
+            {
+                Vector offset = context.ScrollOffset;
+                element.Arrange(new Rect(
+                    bounds.X - offset.X,
+                    bounds.Y - offset.Y,
+                    bounds.Width,
+                    bounds.Height));
+            }
+        }
+        return finalSize;
+    }
+
+    public void OnItemsChanged(
+        IDataGridLayoutContext context,
+        NotifyCollectionChangedEventArgs change)
+    {
+        context.LayoutState = new State();
+    }
+
+    public void Uninitialize(IDataGridLayoutContext context)
+    {
+        // Dispose only resources owned by this session.
+    }
+
+    private sealed class State { }
+}
+```
+
+The presenter calls `Initialize` once per activation of a retained session and `Uninitialize` when switching away or detaching. `OnItemsChanged` can process collection deltas, but resetting compact state is often cheaper and safer than retaining an item-count-sized index.
+
+## Context rules
+
+`GetOrCreateElementAt` prepares a normal DataGrid row/group container. The algorithm must never construct, reparent, cache, or dispose that control itself. `RecycleElement` marks a realized element as unnecessary; DataGrid performs the actual lifecycle work.
+
+`GetEstimatedItemSize` and `GetEstimatedItemOffset` must be preferred over realizing off-screen items. The vertical stack estimate is backed by the DataGrid row-height index and supports fixed and variable rows.
+
+Only bounds recorded with `SetLayoutBounds` are arranged. Bounds use layout-content coordinates. The built-in algorithms subtract `ScrollOffset` exactly once during arrange.
+
+The context expects a contiguous realized index interval because the current DataGrid display store is range-based. A custom algorithm may leave visual gaps inside that interval, but it should not request disconnected index islands in one pass.
+
+## Optional spatial navigation
+
+Implement `IDataGridLayoutNavigation` on the algorithm when geometric order differs from ordinary row order.
+
+```csharp
+public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) =>
+    direction is DataGridLayoutNavigationDirection.Up or
+        DataGridLayoutNavigationDirection.Down or
+        DataGridLayoutNavigationDirection.PageUp or
+        DataGridLayoutNavigationDirection.PageDown;
+
+public bool TryGetNavigationBounds(
+    IDataGridLayoutContext context,
+    int itemIndex,
+    Rect viewport,
+    out Rect bounds)
+{
+    // Return exact cached bounds or a side-effect-free estimate.
+}
+
+public bool TryResolveNavigation(
+    IDataGridLayoutContext context,
+    in DataGridLayoutNavigationRequest request,
+    out DataGridLayoutNavigationResult result)
+{
+    // Return false for a supported direction only at a true boundary.
+}
+```
+
+Navigation queries must not invalidate layout, mutate persistent anchor state, or force realization. `Viewport`, `NavigationAnchor`, returned bounds, and bounds from the context all share layout-content coordinates. Preserve the anchor's cross-axis component when selecting among candidates on another line.
+
+Do not claim directions that should retain standard DataGrid cell behavior. For example, a vertical custom stack normally owns `Up`, `Down`, page, first, and last, but not `Left` or `Right`.
+
+## State and memory design
+
+Good session state is bounded independently of `ItemCount`:
+
+- one running average for item/line dimensions;
+- a fixed-size ring buffer of nearby lines;
+- a Fenwick/index structure already supplied by DataGrid for vertical row heights;
+- a few anchor and extent scalars.
+
+Avoid `Rect[itemCount]`, one dictionary entry per source item, or retaining row controls. If exact random access truly needs per-item data, expose a documented memory option on the model and test both limits.
+
+## Testing a custom layout
+
+Cover at least:
+
+1. empty and one-item sequences;
+2. exact viewport edges and spacing;
+3. far random jumps without linear realization;
+4. fixed and variable item sizes;
+5. horizontal and vertical orientation when supported;
+6. insert/remove/move/reset notifications;
+7. invalidation kind for every model property;
+8. supported, unsupported, boundary, page, and non-realized navigation;
+9. attach/detach and externally retained model leak behavior;
+10. runtime switching back to the same model instance.
+
+The complete custom implementation used by the sample is `DataGridSample/Layouts/IndentedStackLayoutModel.cs`.

--- a/docfx/articles/custom-layouts.md
+++ b/docfx/articles/custom-layouts.md
@@ -93,13 +93,13 @@ The presenter calls `Initialize` once per activation of a retained session and `
 
 ## Context rules
 
-`GetOrCreateElementAt` prepares a normal DataGrid row/group container. The algorithm must never construct, reparent, cache, or dispose that control itself. `RecycleElement` marks a realized element as unnecessary; DataGrid performs the actual lifecycle work.
+`GetOrCreateElementAt` prepares a normal DataGrid row/group container. The algorithm must never construct, reparent, cache, or dispose that control itself. `RecycleElement` marks a realized element as unnecessary; DataGrid performs the actual lifecycle work after measurement. Because the display store is range-based, a marked element between the lowest and highest indexes requested in the same pass can remain realized.
 
 `GetEstimatedItemSize` and `GetEstimatedItemOffset` must be preferred over realizing off-screen items. The vertical stack estimate is backed by the DataGrid row-height index and supports fixed and variable rows.
 
 Only bounds recorded with `SetLayoutBounds` are arranged. Bounds use layout-content coordinates. The built-in algorithms subtract `ScrollOffset` exactly once during arrange.
 
-The context expects a contiguous realized index interval because the current DataGrid display store is range-based. A custom algorithm may leave visual gaps inside that interval, but it should not request disconnected index islands in one pass.
+The context expects a contiguous realized index interval because the current DataGrid display store is range-based. A custom algorithm may leave visual gaps inside that interval, but it should not request disconnected index islands in one pass. Keep the requested minimum-to-maximum span close to the realization window so retained container memory stays bounded by visible content rather than item count.
 
 ## Optional spatial navigation
 

--- a/docfx/articles/custom-layouts.md
+++ b/docfx/articles/custom-layouts.md
@@ -5,6 +5,7 @@ Applications can add layout types without deriving from DataGrid or replacing it
 - `IDataGridLayoutModel` owns serializable/bindable configuration and creates an algorithm;
 - `IDataGridLayoutAlgorithm` measures, records bounds, arranges, handles item changes, and releases session resources;
 - `IDataGridLayoutNavigation` is optional and adds geometry-aware navigation;
+- `IDataGridLayoutPresentationModel` is optional and selects row/cell or templated-item realization;
 - `IDataGridLayoutContext` is the only container/estimator service the algorithm should use.
 
 `DataGridLayoutModelBase` implements invalidation and allocation-free equality checks for property setters. Prefer it unless the model already has another base type.
@@ -93,9 +94,15 @@ The presenter calls `Initialize` once per activation of a retained session and `
 
 ## Context rules
 
-`GetOrCreateElementAt` prepares a normal DataGrid row/group container. The algorithm must never construct, reparent, cache, or dispose that control itself. `RecycleElement` marks a realized element as unnecessary; DataGrid performs the actual lifecycle work after measurement. Because the display store is range-based, a marked element between the lowest and highest indexes requested in the same pass can remain realized.
+`GetOrCreateElementAt` prepares the DataGrid-owned container selected by the model: a row, group header/footer, or templated `DataGridItemContainer`. The algorithm must never construct, reparent, cache, or dispose that control itself. `RecycleElement` marks a realized element as unnecessary; DataGrid performs the actual lifecycle work after measurement. Because the display store is range-based, a marked element between the lowest and highest indexes requested in the same pass can remain realized.
 
-`GetEstimatedItemSize` and `GetEstimatedItemOffset` must be preferred over realizing off-screen items. The vertical stack estimate is backed by the DataGrid row-height index and supports fixed and variable rows.
+`GetEstimatedItemSize` and `GetEstimatedItemOffset` must be preferred over realizing off-screen items. Row presentation uses the indexed fixed/variable row-height system. Item presentation uses `ItemSizeEstimate` before realization and measured template sizes afterward.
+
+## Optional item presentation
+
+Deriving from `DataGridLayoutModelBase` gives custom models `PresentationMode` and `ItemSizeEstimate`. Algorithms must not branch on the concrete container type: they measure and arrange the `Control` returned by the context, so the same algorithm can support both rows and item templates.
+
+If a model implements `IDataGridLayoutModel` directly, implement `IDataGridLayoutPresentationModel` to opt in. Raise a reset invalidation when the mode or estimate changes because the container kind and estimated coordinate space may change. See [Item-template layout presentation](item-layout-presentation.md).
 
 Only bounds recorded with `SetLayoutBounds` are arranged. Bounds use layout-content coordinates. The built-in algorithms subtract `ScrollOffset` exactly once during arrange.
 
@@ -159,5 +166,6 @@ Cover at least:
 8. supported, unsupported, boundary, page, and non-realized navigation;
 9. attach/detach and externally retained model leak behavior;
 10. runtime switching back to the same model instance.
+11. row/item presentation switching and bounded item-container recycling when supported.
 
 The complete custom implementation used by the sample is `DataGridSample/Layouts/IndentedStackLayoutModel.cs`.

--- a/docfx/articles/item-layout-presentation.md
+++ b/docfx/articles/item-layout-presentation.md
@@ -1,0 +1,111 @@
+# Item-template layout presentation
+
+Layout models can choose whether DataGrid realizes its traditional row/cell visual tree or one lightweight templated item per data row. This makes the same control suitable for table, list, card, tile, and wrap views without replacing the item source or the model-based selection, filtering, sorting, state, and navigation systems.
+
+## Choose the presentation in the model
+
+The optional `IDataGridLayoutPresentationModel` contract supplies two values:
+
+- `PresentationMode`: `Rows` for `DataGridRow`/`DataGridCell` presentation or `Items` for `DataGridItemContainer` presentation;
+- `ItemSizeEstimate`: the positive width and height used for off-screen extent, anchor, and navigation estimates before an item is measured.
+
+All built-in models derive from `DataGridLayoutModelBase`, so they expose both properties directly:
+
+```csharp
+public IDataGridLayoutModel CardsLayout { get; } =
+    new DataGridUniformGridLayoutModel
+    {
+        PresentationMode = DataGridLayoutPresentationMode.Items,
+        ItemSizeEstimate = new Size(260, 96),
+        MinItemWidth = 260,
+        MinItemHeight = 96,
+        MinColumnSpacing = 8,
+        MinRowSpacing = 8
+    };
+```
+
+Changing either property raises a reset invalidation. Bind stable model instances to `DataGrid.LayoutModel` when switching views at runtime.
+
+## Supply a compiled item template
+
+Set `DataGrid.ItemTemplate` exactly as you would set an ItemsControl template. Give every binding scope an `x:DataType` and use compiled bindings:
+
+```xml
+<DataGrid x:DataType="viewModels:CatalogViewModel"
+          ItemsSource="{CompiledBinding Products}"
+          LayoutModel="{CompiledBinding LayoutModel}"
+          UseLogicalScrollable="True"
+          SelectionUnit="FullRow">
+  <DataGrid.ItemTemplate>
+    <DataTemplate x:DataType="models:Product">
+      <Border Width="248"
+              Height="88"
+              Padding="10"
+              AutomationProperties.Name="{CompiledBinding Name}">
+        <StackPanel>
+          <TextBlock FontWeight="SemiBold"
+                     Text="{CompiledBinding Name}" />
+          <TextBlock Text="{CompiledBinding Category}" />
+        </StackPanel>
+      </Border>
+    </DataTemplate>
+  </DataGrid.ItemTemplate>
+
+  <!-- Columns remain semantic metadata in item mode. -->
+  <DataGrid.Columns>
+    <DataGridTextColumn Header="Name"
+                        Binding="{CompiledBinding Name}"
+                        x:DataType="models:Product" />
+  </DataGrid.Columns>
+</DataGrid>
+```
+
+In item mode:
+
+- column and row headers are hidden;
+- `DataGridRow` and `DataGridCell` are not created for data items;
+- one recyclable `DataGridItemContainer` hosts the template root;
+- columns remain available to filtering, sorting, clipboard/state models, current-position identity, and navigation policy;
+- grouping slots continue to use DataGrid group header/footer containers.
+
+Keep at least one visible semantic column when current-cell navigation is required. The column is not rendered as a cell, but the navigation position still preserves its display index.
+
+## Recycling and runtime switching
+
+`DataGridItemContainer` has `:selected`, `:current`, and `:pointerover` pseudo-classes. Its `Index`, `IsSelected`, and read-only `IsCurrent` properties are public for themes, tests, and automation-aware customization.
+
+The container pool is separate from the row pool. An `IRecyclingDataTemplate` receives the old root only when the same template is still active; a normal `IDataTemplate` builds a fresh root. Replacing `ItemTemplate`, switching between row and item presentation, or changing model geometry resets realization without replacing selection/currency state.
+
+`KeepRecycledContainersInVisualTree` and the existing recycle-pool limits apply to item containers as well as rows. Virtualizing layouts retain containers proportional to the realization window. `DataGridNonVirtualizingStackLayoutModel` intentionally realizes the full sequence.
+
+Use a representative `ItemSizeEstimate`. The measured desired size replaces the estimate for realized variable-size items, while the estimate keeps far scrolling and non-realized navigation allocation-free.
+
+## Selection, navigation, editing, and accessibility
+
+Pointer selection is row/item selection even if `SelectionUnit` was configured as `Cell`; `SelectionUnit="FullRow"` communicates the intent most clearly. Keyboard and programmatic navigation still flow through the semantic navigation model, then through the active layout's optional geometry resolver. Runtime switching preserves the current row, selected items, and current semantic column.
+
+Item presentation does not enter DataGrid cell edit mode: `BeginEdit()` returns `false` and cannot create a hidden row/cell tree. Put editable controls in the item template and bind them to view-model properties or commands when a card/list view needs editing.
+
+Each realized item exposes a `DataItem` automation peer with `ISelectionItemProvider`. Position-in-set, size-of-set, selected state, and selection-container relationships are supplied by DataGrid. Set a meaningful `AutomationProperties.Name` on the template root when the data item's `ToString()` is not an appropriate accessible name.
+
+## Custom models
+
+A custom model can opt into item presentation by implementing `IDataGridLayoutPresentationModel`. Deriving from `DataGridLayoutModelBase` provides the implementation automatically:
+
+```csharp
+public sealed class MasonryLayoutModel : DataGridLayoutModelBase
+{
+    public override IDataGridLayoutAlgorithm CreateAlgorithm() =>
+        new MasonryLayoutAlgorithm(this);
+}
+
+var model = new MasonryLayoutModel
+{
+    PresentationMode = DataGridLayoutPresentationMode.Items,
+    ItemSizeEstimate = new Size(240, 100)
+};
+```
+
+Algorithms remain presentation-agnostic. `IDataGridLayoutContext.GetOrCreateElementAt` returns the DataGrid-owned row, group, or item container selected by the active model; custom algorithms measure and arrange it without constructing containers themselves.
+
+See [Model-based layouts](model-based-layouts.md), [Custom layouts](custom-layouts.md), [Generated layouts](source-generators/layouts.md), and the `Layout Gallery` sample.

--- a/docfx/articles/model-based-layouts.md
+++ b/docfx/articles/model-based-layouts.md
@@ -1,0 +1,178 @@
+# Model-based layouts
+
+ProDataGrid can arrange its row containers as a virtualized stack, a non-virtualizing stack, a uniform grid, or a variable-size wrap layout. Set `DataGrid.LayoutModel` to opt in. A `null` model keeps the classic vertical-list implementation.
+
+The layout changes only spatial realization and arrangement. The same DataGrid continues to own columns, cells, selection, editing, filtering, sorting, grouping, row-height estimates, container preparation, and recycling.
+
+> [!IMPORTANT]
+> Model layouts use the logical scrolling presenter. Set `UseLogicalScrollable="True"`. Generated views do this automatically whenever they configure or bind a layout model.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    VM["View model: IDataGridLayoutModel"] --> Grid["DataGrid.LayoutModel"]
+    Grid --> Session["Per-grid, per-model layout session"]
+    Session --> Algorithm["IDataGridLayoutAlgorithm"]
+    Algorithm --> Context["IDataGridLayoutContext"]
+    Context --> Generator["Existing row/group container generator"]
+    Context --> Estimator["Existing fixed/variable row estimator"]
+    Context --> Recycler["Existing recycling pool"]
+    Algorithm -. optional .-> Navigation["IDataGridLayoutNavigation"]
+```
+
+An `IDataGridLayoutModel` is configuration and an algorithm factory. Each presenter keeps a session for every model instance it has seen. Switching back to a previous instance reuses its bounded state instead of rebuilding it. The active algorithm is initialized and uninitialized at attachment and switching boundaries.
+
+The layout context exposes only the mechanics needed by an algorithm:
+
+- item count and visible realization rectangle;
+- logical scroll offset and recommended anchor;
+- estimated item sizes and major-axis offsets;
+- get-or-create and recycle operations for DataGrid-owned containers;
+- bounds recording for realized items;
+- one per-session `LayoutState` object.
+
+Layout item indices describe the visible layout sequence. When grouping is active, that sequence includes visible group headers and footers. DataGrid translates collection-view row indices at the navigation boundary; custom algorithms must not treat an index as a data-source identity.
+
+## Runtime switching
+
+Keep model instances on the view model and bind the selected instance:
+
+```csharp
+public sealed class ResultsViewModel
+{
+    public IDataGridLayoutModel ListLayout { get; } =
+        new DataGridStackLayoutModel { Spacing = 2 };
+
+    public IDataGridLayoutModel TileLayout { get; } =
+        new DataGridUniformGridLayoutModel
+        {
+            MinItemWidth = 240,
+            MinItemHeight = 72,
+            MinColumnSpacing = 8,
+            MinRowSpacing = 8
+        };
+
+    public IDataGridLayoutModel LayoutModel { get; set; }
+}
+```
+
+```xml
+<DataGrid ItemsSource="{Binding Items}"
+          LayoutModel="{Binding LayoutModel}"
+          UseLogicalScrollable="True" />
+```
+
+Do not construct a new model from a converter on every binding evaluation. Reusing instances is what allows the presenter to restore the model's session immediately. A switch does not replace the item source, columns, selection model, or row generator.
+
+## Virtualizing stack
+
+`DataGridStackLayoutModel` is the general list layout.
+
+| Property | Default | Meaning |
+| --- | --- | --- |
+| `Orientation` | `Vertical` | Major scrolling and stacking axis. |
+| `Spacing` | `0` | Distance between consecutive items. |
+| `DisableVirtualization` | `false` | Realize the whole sequence while retaining stack geometry. |
+
+The vertical implementation delegates variable-height offset estimates to the existing indexed DataGrid row-height system. Finding a random scroll anchor is logarithmic; state is not allocated per layout item. Horizontal orientation uses the same algorithm with width as the major axis.
+
+```csharp
+var layout = new DataGridStackLayoutModel
+{
+    Orientation = DataGridLayoutOrientation.Vertical,
+    Spacing = 4
+};
+```
+
+Use `DisableVirtualization` only for deliberately bounded item counts. Prefer the separate non-virtualizing model when the intent should be visible in the type.
+
+## Non-virtualizing stack
+
+`DataGridNonVirtualizingStackLayoutModel` supports the ItemsRepeater non-virtualizing stack shape. It has `Orientation` and `Spacing`, and realizes every visible layout item.
+
+This model is useful for small embedded lists, print/export surfaces, and behavior comparisons. Its memory cost is proportional to the item count, by definition; it is not appropriate for large data sets.
+
+## Uniform grid
+
+`DataGridUniformGridLayoutModel` wraps equal-size cells and calculates line/index geometry in constant time.
+
+| Property | Default | Meaning |
+| --- | --- | --- |
+| `Orientation` | `Horizontal` | Fill rows horizontally or columns vertically. |
+| `MinItemWidth`, `MinItemHeight` | `NaN` | Explicit cell minimum, or natural size from the first measured item. |
+| `MinColumnSpacing`, `MinRowSpacing` | `0` | Minimum inter-cell spacing. |
+| `MaximumRowsOrColumns` | `int.MaxValue` | Maximum items on one fill line. |
+| `ItemsJustification` | `Start` | Distribution of unused cross-axis space. |
+| `ItemsStretch` | `None` | `None`, `Fill`, or aspect-preserving `Uniform` cell stretching. |
+
+`ItemsJustification` supports `Start`, `Center`, `End`, `SpaceAround`, `SpaceBetween`, and `SpaceEvenly`.
+
+```csharp
+var layout = new DataGridUniformGridLayoutModel
+{
+    MinItemWidth = 260,
+    MinItemHeight = 80,
+    MinColumnSpacing = 8,
+    MinRowSpacing = 8,
+    MaximumRowsOrColumns = 4,
+    ItemsJustification = DataGridUniformGridItemsJustification.SpaceBetween,
+    ItemsStretch = DataGridUniformGridItemsStretch.Fill
+};
+```
+
+Use explicit cell dimensions for predictable random jumps and zero warm-up measurement. Natural dimensions are convenient when the first row is representative.
+
+## Variable-size wrap
+
+`DataGridWrapLayoutModel` preserves each measured item's size and builds wrapping lines.
+
+| Property | Default | Meaning |
+| --- | --- | --- |
+| `Orientation` | `Horizontal` | Fill horizontally into rows or vertically into columns. |
+| `HorizontalSpacing` | `0` | Horizontal distance between items/columns. |
+| `VerticalSpacing` | `0` | Vertical distance between items/rows. |
+| `MaximumCachedLines` | `256` | Upper bound for exact line records retained by one session. |
+
+The algorithm keeps exponentially stable item/line averages for off-screen estimates and only a bounded set of exact line records. A far scroll jump estimates an anchor without measuring all preceding items, then refines the visible lines as containers are measured.
+
+```csharp
+var layout = new DataGridWrapLayoutModel
+{
+    HorizontalSpacing = 10,
+    VerticalSpacing = 8,
+    MaximumCachedLines = 128
+};
+```
+
+Increase `MaximumCachedLines` when users repeatedly move through a localized region containing highly variable items. Lower it when many retained layout models share a strict memory budget.
+
+## Navigation
+
+Layout navigation is an optional mechanics interface. `IDataGridLayoutNavigation` reports which directions it owns, resolves a target, and estimates bounds without realizing the target. The semantic navigation model still controls boundary modes, selection extension, editing/focus validation, route exit, command redirection, and completion events.
+
+All geometry in `DataGridLayoutNavigationRequest` and `DataGridLayoutNavigationResult` uses the same layout-content coordinate space, before subtracting the scroll offset. `Left` and `Right` are physical directions; a navigation policy can redirect them for logical right-to-left behavior. `LineStart` and `LineEnd` follow the active algorithm's fill line.
+
+A supported direction that returns no target means a real layout boundary. An unsupported direction remains available to classic DataGrid cell navigation. This distinction is important for a vertical stack: it owns vertical/page movement but leaves horizontal cell movement intact.
+
+The built-in uniform and wrap layouts preserve the cross-axis anchor while moving between lines. Page navigation uses viewport displacement and may return estimated bounds for a non-realized item. `ScrollIntoView` then uses the layout session to realize and refine the target.
+
+## Grouping, selection, and editing
+
+Collapsed group slots are removed from the visible layout sequence by the DataGrid adapter. Layouts can arrange group headers, group footers, and data rows without creating a second container system. Navigation translates a geometric target back to a collection-view row and skips group-only slots where a cell position is required.
+
+Selection identity, current cell, edit state, validation, conditional formatting, summaries, and column state do not live in the layout session. They therefore survive runtime layout changes.
+
+## Performance and memory checklist
+
+- Keep built-in/custom model instances and switch references instead of constructing repeatedly.
+- Use stack or uniform grid for the cheapest random-access geometry.
+- Give uniform grid explicit dimensions when possible.
+- Keep wrap's exact line cache bounded for your workload.
+- Never realize an item only to answer a navigation or extent query.
+- Store state proportional to realized/cached lines, not total item count.
+- Recycle through `IDataGridLayoutContext`; do not own row controls in the model or algorithm.
+- Use the non-virtualizing model only for bounded collections.
+- Profile representative item templates; layout cannot remove allocations inside templates.
+
+See [Custom layouts](custom-layouts.md), [Generated layouts](source-generators/layouts.md), and the `Layout Gallery` page in `DataGridSample`.

--- a/docfx/articles/model-based-layouts.md
+++ b/docfx/articles/model-based-layouts.md
@@ -58,8 +58,9 @@ public sealed class ResultsViewModel
 ```
 
 ```xml
-<DataGrid ItemsSource="{Binding Items}"
-          LayoutModel="{Binding LayoutModel}"
+<DataGrid x:DataType="viewModels:ResultsViewModel"
+          ItemsSource="{CompiledBinding Items}"
+          LayoutModel="{CompiledBinding LayoutModel}"
           UseLogicalScrollable="True" />
 ```
 

--- a/docfx/articles/model-based-layouts.md
+++ b/docfx/articles/model-based-layouts.md
@@ -1,8 +1,8 @@
 # Model-based layouts
 
-ProDataGrid can arrange its row containers as a virtualized stack, a non-virtualizing stack, a uniform grid, or a variable-size wrap layout. Set `DataGrid.LayoutModel` to opt in. A `null` model keeps the classic vertical-list implementation.
+ProDataGrid can arrange data as a virtualized stack, a non-virtualizing stack, a uniform grid, or a variable-size wrap layout. Set `DataGrid.LayoutModel` to opt in. A `null` model keeps the classic vertical-list implementation.
 
-The layout changes only spatial realization and arrangement. The same DataGrid continues to own columns, cells, selection, editing, filtering, sorting, grouping, row-height estimates, container preparation, and recycling.
+The layout changes spatial realization and arrangement. Its optional presentation contract also chooses traditional DataGrid rows/cells or lightweight custom item templates. The same DataGrid continues to own columns, selection, filtering, sorting, grouping, state, navigation, container preparation, and recycling.
 
 > [!IMPORTANT]
 > Model layouts use the logical scrolling presenter. Set `UseLogicalScrollable="True"`. Generated views do this automatically whenever they configure or bind a layout model.
@@ -15,8 +15,9 @@ flowchart LR
     Grid --> Session["Per-grid, per-model layout session"]
     Session --> Algorithm["IDataGridLayoutAlgorithm"]
     Algorithm --> Context["IDataGridLayoutContext"]
-    Context --> Generator["Existing row/group container generator"]
-    Context --> Estimator["Existing fixed/variable row estimator"]
+    Model -. optional .-> Presentation["IDataGridLayoutPresentationModel"]
+    Context --> Generator["DataGrid row/group/item container generator"]
+    Context --> Estimator["Row estimator or item-size estimate"]
     Context --> Recycler["Existing recycling pool"]
     Algorithm -. optional .-> Navigation["IDataGridLayoutNavigation"]
 ```
@@ -33,6 +34,14 @@ The layout context exposes only the mechanics needed by an algorithm:
 - one per-session `LayoutState` object.
 
 Layout item indices describe the visible layout sequence. When grouping is active, that sequence includes visible group headers and footers. DataGrid translates collection-view row indices at the navigation boundary; custom algorithms must not treat an index as a data-source identity.
+
+## Rows or item templates
+
+`DataGridLayoutModelBase` implements `IDataGridLayoutPresentationModel`. Its default `PresentationMode` is `Rows`, preserving the existing row, cell, header, row-height, editing, and column-virtualization behavior.
+
+Set `PresentationMode = DataGridLayoutPresentationMode.Items` and provide `DataGrid.ItemTemplate` for cards, tiles, or other custom item visuals. DataGrid then realizes recyclable `DataGridItemContainer` controls instead of rows/cells and automatically suppresses row and column headers. `ItemSizeEstimate` seeds off-screen geometry until actual template sizes are measured. Columns remain semantic metadata for the other DataGrid model systems.
+
+See [Item-template layout presentation](item-layout-presentation.md) for compiled XAML, recycling, editing, accessibility, and source-generator guidance.
 
 ## Runtime switching
 
@@ -164,7 +173,7 @@ The built-in uniform and wrap layouts preserve the cross-axis anchor while movin
 
 Collapsed group slots are removed from the visible layout sequence by the DataGrid adapter. Layouts can arrange group headers, group footers, and data rows without creating a second container system. Navigation translates a geometric target back to a collection-view row and skips group-only slots where a cell position is required.
 
-Selection identity, current cell, edit state, validation, conditional formatting, summaries, and column state do not live in the layout session. They therefore survive runtime layout changes.
+Selection identity, current cell, validation, conditional formatting, summaries, and column state do not live in the layout session. They therefore survive runtime layout changes. Row presentation retains normal cell editing; item presentation is display/template owned and does not enter DataGrid cell edit mode.
 
 ## Performance and memory checklist
 
@@ -177,5 +186,6 @@ Selection identity, current cell, edit state, validation, conditional formatting
 - Recycle through `IDataGridLayoutContext`; do not own row controls in the model or algorithm.
 - Use the non-virtualizing model only for bounded collections.
 - Profile representative item templates; layout cannot remove allocations inside templates.
+- Give item presentation a representative positive `ItemSizeEstimate`.
 
-See [Custom layouts](custom-layouts.md), [Generated layouts](source-generators/layouts.md), and the `Layout Gallery` page in `DataGridSample`.
+See [Item-template layout presentation](item-layout-presentation.md), [Custom layouts](custom-layouts.md), [Generated layouts](source-generators/layouts.md), and the `Layout Gallery` page in `DataGridSample`.

--- a/docfx/articles/model-based-layouts.md
+++ b/docfx/articles/model-based-layouts.md
@@ -156,6 +156,8 @@ All geometry in `DataGridLayoutNavigationRequest` and `DataGridLayoutNavigationR
 
 A supported direction that returns no target means a real layout boundary. An unsupported direction remains available to classic DataGrid cell navigation. This distinction is important for a vertical stack: it owns vertical/page movement but leaves horizontal cell movement intact.
 
+When the active boundary policy is `Wrap`, a layout-owned spatial boundary wraps in layout space: `Left` continues from `LineEnd`, `Right` from `LineStart`, `Up` from `Last`, and `Down` from `First`. An unsupported direction still uses classic DataGrid cell-axis wrapping. Logical RTL redirection resolves fresh layout geometry and does not apply the boundary policy a second time.
+
 The built-in uniform and wrap layouts preserve the cross-axis anchor while moving between lines. Page navigation uses viewport displacement and may return estimated bounds for a non-realized item. `ScrollIntoView` then uses the layout session to realize and refine the target.
 
 ## Grouping, selection, and editing

--- a/docfx/articles/navigation-model.md
+++ b/docfx/articles/navigation-model.md
@@ -137,6 +137,12 @@ behavior; `Always` provides spreadsheet traversal outside edit mode.
 frozen-right columns, and filler exclusion continue through the existing column
 navigation engine.
 
+With a spatial layout, a direction advertised by `IDataGridLayoutNavigation` wraps in
+layout space at a boundary: Left to layout line end, Right to layout line start, Up to
+the last layout item, and Down to the first. Directions not advertised by the layout
+retain classic DataGrid cell-axis wrapping. Logical RTL redirection re-resolves the
+layout target without applying the boundary policy twice.
+
 ## Editing, selection, and hierarchy
 
 The model never commits an editor itself. `Enter`, `Next`, `Previous`, `BeginEdit`,

--- a/docfx/articles/sample-gallery.md
+++ b/docfx/articles/sample-gallery.md
@@ -26,6 +26,7 @@ Highlights include:
 - Hierarchical data, hierarchical drag/drop, tree-like mimics, and live row-drag session inspection.
 - Row drag session samples with move/copy transitions, invalid-target feedback badges, and selection-drag coordination.
 - Virtualization and scrolling diagnostics (large datasets, row height estimators, recycling).
+- Runtime-switchable stack, uniform-grid, variable-wrap, non-virtualizing, and custom layouts in the `Layout Gallery` page.
 - Variable-height scrolling with `DataGridCustomDrawingColumn`, composition custom-visual backend, Skia custom draw operations, shared text cache, and layout fast path.
 - Live custom-drawing updates with composition backend + factory-driven invalidation (`DataGridCustomDrawingColumn.InvalidateCustomDrawingCells` and `IDataGridCellDrawOperationInvalidationSource`).
 - Styling showcases and column theme usage.

--- a/docfx/articles/scrolling-virtualization.md
+++ b/docfx/articles/scrolling-virtualization.md
@@ -98,6 +98,8 @@ Override the estimator per grid:
 
 For very large sources, keep `UseLogicalScrollable="True"` and prefer uniform row heights where possible. The sample app includes `LargeUniform` and `LargeVariableHeight` pages that stress-test scrolling with hundreds of thousands of rows.
 
+For multi-line, tiled, horizontal, or application-defined row arrangements, see [Model-based layouts](model-based-layouts.md). Those layouts reuse the same logical scrolling presenter, estimator, container generator, and recycling pipeline described here.
+
 ## Migrating Existing Usage
 
 - Prefer the v2 theme or update your template to use the ScrollViewer pattern; legacy scroll bars remain available when `UseLogicalScrollable="False"`.

--- a/docfx/articles/source-generators-feature-spec.md
+++ b/docfx/articles/source-generators-feature-spec.md
@@ -32,7 +32,7 @@ The generator does not own domain rules, persistence, networking, authentication
 | Connect DynamicData, async streams, channels, snapshots, or remote data | [Reactive, streaming, and remote data](source-generators/reactive-streaming-remote.md) |
 | Generate tree metadata, filtering, expansion, and wrapper-aware bindings | [Hierarchical data](source-generators/hierarchy.md) |
 | Preserve selection, current cell, layout, and state by stable key | [Selection, navigation, and state](source-generators/selection-navigation-state.md) |
-| Generate stack, uniform-grid, wrap, or custom model-based row layouts | [Generated layouts](source-generators/layouts.md) |
+| Generate stack, uniform-grid, wrap, or custom model-based row/item-template layouts | [Generated layouts](source-generators/layouts.md) |
 | Generate editing, validation, undo, clipboard, fill, formatting, and drag/drop adapters | [Editing and data workflows](source-generators/editing-and-data-workflows.md) |
 | Configure bands, indexed columns, templates, details, direct cells, and drawing | [Layout, templates, and rendering](source-generators/layout-templates-rendering.md) |
 | Generate pivot, outline, formula, and chart metadata | [Analytics and formulas](source-generators/analytics-and-formulas.md) |

--- a/docfx/articles/source-generators-feature-spec.md
+++ b/docfx/articles/source-generators-feature-spec.md
@@ -32,6 +32,7 @@ The generator does not own domain rules, persistence, networking, authentication
 | Connect DynamicData, async streams, channels, snapshots, or remote data | [Reactive, streaming, and remote data](source-generators/reactive-streaming-remote.md) |
 | Generate tree metadata, filtering, expansion, and wrapper-aware bindings | [Hierarchical data](source-generators/hierarchy.md) |
 | Preserve selection, current cell, layout, and state by stable key | [Selection, navigation, and state](source-generators/selection-navigation-state.md) |
+| Generate stack, uniform-grid, wrap, or custom model-based row layouts | [Generated layouts](source-generators/layouts.md) |
 | Generate editing, validation, undo, clipboard, fill, formatting, and drag/drop adapters | [Editing and data workflows](source-generators/editing-and-data-workflows.md) |
 | Configure bands, indexed columns, templates, details, direct cells, and drawing | [Layout, templates, and rendering](source-generators/layout-templates-rendering.md) |
 | Generate pivot, outline, formula, and chart metadata | [Analytics and formulas](source-generators/analytics-and-formulas.md) |

--- a/docfx/articles/source-generators/attribute-reference.md
+++ b/docfx/articles/source-generators/attribute-reference.md
@@ -213,6 +213,11 @@ Constructors:
 | `LayoutMaximumRowsOrColumns` | Uniform-grid line cap. |
 | `LayoutItemsJustification`, `LayoutItemsStretch` | Uniform-grid alignment/stretch. |
 | `LayoutMaximumCachedLines` | Variable-wrap exact-line cache bound. |
+| `LayoutPresentation` | `Rows` or `Items`; item mode realizes `DataGrid.ItemTemplate` instead of rows/cells. |
+| `LayoutItemWidthEstimate`, `LayoutItemHeightEstimate` | Positive finite off-screen size estimate for item presentation. |
+| `LayoutItemTemplateKey` | Dynamic-resource `IDataTemplate` used by item presentation. |
+| `LayoutItemTemplateImplementationType` | Accessible parameterless `IDataTemplate` implementation. |
+| `LayoutItemTemplateFactoryMethod` | Static recycling `(TItem, Control?) -> Control` factory. |
 
 See [Generated layouts](layouts.md) for emitted types, defaults, validation, and examples.
 

--- a/docfx/articles/source-generators/attribute-reference.md
+++ b/docfx/articles/source-generators/attribute-reference.md
@@ -200,6 +200,22 @@ Constructors:
 | `ViewThemeKey`, `DataGridThemeKey`, `ToolbarThemeKey`, `RecipeContentThemeKey` | Dynamic resource keys. |
 | `ViewClasses`, `DataGridClasses`, `ToolbarClasses`, `RecipeContentClasses` | Validated direct class tokens. |
 
+### Layouts
+
+| Option | Meaning |
+| --- | --- |
+| `LayoutModelPropertyName` | Compiled binding to a readable `IDataGridLayoutModel`; mutually exclusive with `Layout`. |
+| `Layout` | `None`, `Stack`, `NonVirtualizingStack`, `UniformGrid`, or `Wrap`. |
+| `LayoutOrientation` | Keep the model default, or select horizontal/vertical fill. |
+| `LayoutSpacing`, `LayoutDisableVirtualization` | Stack configuration. |
+| `LayoutHorizontalSpacing`, `LayoutVerticalSpacing` | Uniform-grid/wrap spacing. |
+| `LayoutMinItemWidth`, `LayoutMinItemHeight` | Uniform-grid cell minimums. |
+| `LayoutMaximumRowsOrColumns` | Uniform-grid line cap. |
+| `LayoutItemsJustification`, `LayoutItemsStretch` | Uniform-grid alignment/stretch. |
+| `LayoutMaximumCachedLines` | Variable-wrap exact-line cache bound. |
+
+See [Generated layouts](layouts.md) for emitted types, defaults, validation, and examples.
+
 ### Row details
 
 | Option | Meaning |

--- a/docfx/articles/source-generators/layout-templates-rendering.md
+++ b/docfx/articles/source-generators/layout-templates-rendering.md
@@ -2,6 +2,27 @@
 
 Generated layout and rendering metadata covers column bands, chooser state, frozen placement, runtime indexed families, recycling templates, row details, direct/drawn cells, and custom drawing caches. Visual resources and application-specific control composition remain user-owned.
 
+## Layout item templates
+
+Generated built-in or custom layouts can use `DataGridItemContainer` presentation instead of row/cell visuals. Set `LayoutPresentation = DataGridGeneratedLayoutPresentation.Items`, provide positive item estimates, and select exactly one item-template source:
+
+```csharp
+[GenerateDataGridView(
+    typeof(Product),
+    ViewName = "ProductCardsView",
+    Layout = DataGridGeneratedLayout.Wrap,
+    LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+    LayoutItemWidthEstimate = 240,
+    LayoutItemHeightEstimate = 92,
+    LayoutHorizontalSpacing = 8,
+    LayoutVerticalSpacing = 8,
+    LayoutItemTemplateFactoryMethod = nameof(Product.CreateCard))]
+```
+
+`LayoutItemTemplateKey`, `LayoutItemTemplateImplementationType`, and `LayoutItemTemplateFactoryMethod` follow the same resource/implementation/typed-factory choices as other generated templates. The factory contract is `(TItem, Control?) -> Control`; generated code emits a recycling template and passes the existing root back on reuse. The generator reports `PDGSG139` for a missing or conflicting template source, a non-positive/non-finite estimate, or item presentation without a layout model.
+
+Columns are still generated as semantic metadata but their headers/cells are not realized in item mode. See [Generated layouts](layouts.md) and [Item-template layout presentation](../item-layout-presentation.md).
+
 ## Column layout metadata
 
 Use stable keys for all persisted and interactive layout operations:

--- a/docfx/articles/source-generators/layouts.md
+++ b/docfx/articles/source-generators/layouts.md
@@ -55,8 +55,54 @@ The generator emits a concrete model initializer directly on the generated DataG
 | `LayoutItemsJustification` | Uniform grid | `Start` |
 | `LayoutItemsStretch` | Uniform grid | `None` |
 | `LayoutMaximumCachedLines` | Wrap | `256` |
+| `LayoutPresentation` | Generated built-in model | `Rows` |
+| `LayoutItemWidthEstimate` | Item presentation | `100` |
+| `LayoutItemHeightEstimate` | Item presentation | `32` |
+| `LayoutItemTemplateKey` | Item presentation | `null` |
+| `LayoutItemTemplateImplementationType` | Item presentation | `null` |
+| `LayoutItemTemplateFactoryMethod` | Item presentation | `null` |
 
 For uniform grid, horizontal spacing maps to `MinColumnSpacing` and vertical spacing maps to `MinRowSpacing`.
+
+## Item-template presentation
+
+Set `LayoutPresentation` to `Items` to generate a card/list/tile view that realizes `DataGridItemContainer` instead of `DataGridRow` and `DataGridCell`. Supply positive finite estimates and exactly one item-template source:
+
+```csharp
+public sealed class CardRow
+{
+    public string Title { get; init; } = string.Empty;
+
+    public static Control CreateCard(CardRow item, Control? existing)
+    {
+        TextBlock text = existing as TextBlock ?? new TextBlock();
+        text.Text = item.Title;
+        return text;
+    }
+}
+
+[GenerateDataGridViewModel(typeof(CardRow))]
+[GenerateDataGridView(
+    typeof(CardRow),
+    ViewName = "CardsPage",
+    Layout = DataGridGeneratedLayout.UniformGrid,
+    LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+    LayoutItemWidthEstimate = 240,
+    LayoutItemHeightEstimate = 92,
+    LayoutMinItemWidth = 240,
+    LayoutMinItemHeight = 92,
+    LayoutHorizontalSpacing = 8,
+    LayoutVerticalSpacing = 8,
+    LayoutItemTemplateFactoryMethod = nameof(CardRow.CreateCard))]
+public sealed partial class CardsViewModel
+{
+    public IReadOnlyList<CardRow> Items { get; } = LoadCards();
+}
+```
+
+The factory source emits a typed recycling template. A dynamic resource key and an accessible parameterless `IDataTemplate` implementation are the other supported sources. Item presentation hides row/column headers, never creates data cells, keeps generated columns as semantic metadata, and automatically enables logical scrolling.
+
+The generator reports `PDGSG139` when item presentation has no layout, has missing/conflicting template sources, or has invalid estimates. Row presentation cannot specify an item-template source.
 
 ## Stack examples
 
@@ -84,9 +130,13 @@ For uniform grid, horizontal spacing maps to `MinColumnSpacing` and vertical spa
     typeof(CardRow),
     ViewName = "CardsPage",
     Layout = DataGridGeneratedLayout.Wrap,
+    LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+    LayoutItemWidthEstimate = 240,
+    LayoutItemHeightEstimate = 92,
     LayoutHorizontalSpacing = 10,
     LayoutVerticalSpacing = 8,
-    LayoutMaximumCachedLines = 128)]
+    LayoutMaximumCachedLines = 128,
+    LayoutItemTemplateFactoryMethod = nameof(CardRow.CreateCard))]
 ```
 
 ## Bind a custom or runtime-switchable model
@@ -112,8 +162,10 @@ The generator validates that the named member is an accessible readable `IDataGr
 
 `Layout` and `LayoutModelPropertyName` are mutually exclusive. Conflicting built-in/custom configuration is reported at compile time. An inaccessible, missing, write-only, or wrong-typed custom property is also rejected.
 
+A custom model owns its own `PresentationMode` and `ItemSizeEstimate`. The generated view may still configure one of the three item-template sources alongside `LayoutModelPropertyName`; leave `LayoutPresentation` at its default because the bound model, rather than a generated built-in model, owns the presentation mode. The generator validates and emits the template independently.
+
 ## Namespace policy
 
 The same options exist on `GenerateDataGridViewsForNamespaceAttribute`, so an assembly can select a default layout for a model namespace. Type-level `GenerateDataGridView` declarations remain the place for view-specific overrides and distinct generated view names.
 
-See [Model-based layouts](../model-based-layouts.md) for runtime behavior and [Custom layouts](../custom-layouts.md) for extension contracts.
+See [Model-based layouts](../model-based-layouts.md), [Item-template layout presentation](../item-layout-presentation.md), and [Custom layouts](../custom-layouts.md).

--- a/docfx/articles/source-generators/layouts.md
+++ b/docfx/articles/source-generators/layouts.md
@@ -1,0 +1,119 @@
+# Generated layouts
+
+`GenerateDataGridView` and `GenerateDataGridViewsForNamespace` can configure any built-in layout or bind a custom `IDataGridLayoutModel` property. Generated code is reflection-free and automatically enables `UseLogicalScrollable` when a layout is present.
+
+## Built-in layout
+
+```csharp
+[GenerateDataGridViewModel(typeof(OrderRow))]
+[GenerateDataGridView(
+    typeof(OrderRow),
+    ViewName = "OrderTilesPage",
+    Layout = DataGridGeneratedLayout.UniformGrid,
+    LayoutMinItemWidth = 260,
+    LayoutMinItemHeight = 76,
+    LayoutHorizontalSpacing = 8,
+    LayoutVerticalSpacing = 8,
+    LayoutMaximumRowsOrColumns = 4,
+    LayoutItemsJustification = DataGridUniformGridItemsJustification.SpaceBetween,
+    LayoutItemsStretch = DataGridUniformGridItemsStretch.Fill)]
+public sealed partial class OrdersViewModel : ReactiveObject
+{
+    public IReadOnlyList<OrderRow> Items { get; } = LoadOrders();
+}
+```
+
+The generator emits a concrete model initializer directly on the generated DataGrid. No service lookup, reflection, or runtime enum conversion is used.
+
+## Layout enum
+
+`DataGridGeneratedLayout` has these values:
+
+| Value | Emitted model |
+| --- | --- |
+| `None` | No assignment; classic layout unless a custom binding is configured. |
+| `Stack` | `DataGridStackLayoutModel` |
+| `NonVirtualizingStack` | `DataGridNonVirtualizingStackLayoutModel` |
+| `UniformGrid` | `DataGridUniformGridLayoutModel` |
+| `Wrap` | `DataGridWrapLayoutModel` |
+
+`DataGridGeneratedLayoutOrientation` is `Default`, `Horizontal`, or `Vertical`. `Default` leaves the concrete model default unchanged.
+
+## Options
+
+| Attribute option | Applies to | Default |
+| --- | --- | --- |
+| `Layout` | Built-ins | `None` |
+| `LayoutOrientation` | All built-ins | `Default` |
+| `LayoutSpacing` | Stack models | `0` |
+| `LayoutDisableVirtualization` | Virtualizing stack | `false` |
+| `LayoutHorizontalSpacing` | Uniform/wrap | `0` |
+| `LayoutVerticalSpacing` | Uniform/wrap | `0` |
+| `LayoutMinItemWidth` | Uniform grid | `NaN` |
+| `LayoutMinItemHeight` | Uniform grid | `NaN` |
+| `LayoutMaximumRowsOrColumns` | Uniform grid | `int.MaxValue` |
+| `LayoutItemsJustification` | Uniform grid | `Start` |
+| `LayoutItemsStretch` | Uniform grid | `None` |
+| `LayoutMaximumCachedLines` | Wrap | `256` |
+
+For uniform grid, horizontal spacing maps to `MinColumnSpacing` and vertical spacing maps to `MinRowSpacing`.
+
+## Stack examples
+
+```csharp
+[GenerateDataGridView(
+    typeof(LogRow),
+    ViewName = "HorizontalLogPage",
+    Layout = DataGridGeneratedLayout.Stack,
+    LayoutOrientation = DataGridGeneratedLayoutOrientation.Horizontal,
+    LayoutSpacing = 6)]
+```
+
+```csharp
+[GenerateDataGridView(
+    typeof(PrintRow),
+    ViewName = "PrintRowsPage",
+    Layout = DataGridGeneratedLayout.NonVirtualizingStack,
+    LayoutSpacing = 2)]
+```
+
+## Wrap example
+
+```csharp
+[GenerateDataGridView(
+    typeof(CardRow),
+    ViewName = "CardsPage",
+    Layout = DataGridGeneratedLayout.Wrap,
+    LayoutHorizontalSpacing = 10,
+    LayoutVerticalSpacing = 8,
+    LayoutMaximumCachedLines = 128)]
+```
+
+## Bind a custom or runtime-switchable model
+
+Use `LayoutModelPropertyName` instead of `Layout`:
+
+```csharp
+[GenerateDataGridViewModel(typeof(OrderRow))]
+[GenerateDataGridView(
+    typeof(OrderRow),
+    ViewName = "OrdersPage",
+    LayoutModelPropertyName = nameof(LayoutModel))]
+public sealed partial class OrdersViewModel : ReactiveObject
+{
+    public IReadOnlyList<OrderRow> Items { get; } = LoadOrders();
+
+    public IDataGridLayoutModel LayoutModel { get; } =
+        new MyApplicationLayoutModel();
+}
+```
+
+The generator validates that the named member is an accessible readable `IDataGridLayoutModel`. It emits an `IPropertyInfo` accessor and a compiled one-way binding to `DataGrid.LayoutModelProperty`.
+
+`Layout` and `LayoutModelPropertyName` are mutually exclusive. Conflicting built-in/custom configuration is reported at compile time. An inaccessible, missing, write-only, or wrong-typed custom property is also rejected.
+
+## Namespace policy
+
+The same options exist on `GenerateDataGridViewsForNamespaceAttribute`, so an assembly can select a default layout for a model namespace. Type-level `GenerateDataGridView` declarations remain the place for view-specific overrides and distinct generated view names.
+
+See [Model-based layouts](../model-based-layouts.md) for runtime behavior and [Custom layouts](../custom-layouts.md) for extension contracts.

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -155,6 +155,8 @@
       href: source-generators/hierarchy.md
     - name: Selection, Navigation, and State
       href: source-generators/selection-navigation-state.md
+    - name: Layouts
+      href: source-generators/layouts.md
     - name: Editing and Data Workflows
       href: source-generators/editing-and-data-workflows.md
     - name: Layout, Templates, and Rendering
@@ -235,6 +237,10 @@
     href: keyboard-shortcuts.md
 - name: Layout and Behavior
   items:
+  - name: Model-based Layouts
+    href: model-based-layouts.md
+  - name: Custom Layouts
+    href: custom-layouts.md
   - name: Scrolling and Virtualization
     href: scrolling-virtualization.md
   - name: Cell Template Reuse

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -239,6 +239,8 @@
   items:
   - name: Model-based Layouts
     href: model-based-layouts.md
+  - name: Item-template Layout Presentation
+    href: item-layout-presentation.md
   - name: Custom Layouts
     href: custom-layouts.md
   - name: Scrolling and Virtualization

--- a/src/Avalonia.Controls.DataGrid.LeakTests/LeakTests.cs
+++ b/src/Avalonia.Controls.DataGrid.LeakTests/LeakTests.cs
@@ -19,6 +19,7 @@ using Avalonia.Controls.DataGridClipboard;
 using Avalonia.Controls.DataGridConditionalFormatting;
 using Avalonia.Controls.DataGridFiltering;
 using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.DataGridLayouts;
 using Avalonia.Controls.DataGridPivoting;
 using Avalonia.Controls.DataGridSearching;
 using Avalonia.Controls.DataGridSorting;
@@ -973,6 +974,47 @@ public class LeakTests
         GC.KeepAlive(formattingModel);
         GC.KeepAlive(hierarchicalModel);
         GC.KeepAlive(fastPathOptions);
+        GC.KeepAlive(items);
+    }
+
+    [ReleaseFact]
+    public void DataGrid_ExternalLayoutModel_DoesNotLeak()
+    {
+        var layoutModel = new DataGridWrapLayoutModel();
+        var items = new ObservableCollection<RowItem>
+        {
+            new RowItem("A"),
+            new RowItem("B")
+        };
+
+        WeakReference Run()
+        {
+            var grid = new DataGrid
+            {
+                AutoGenerateColumns = false,
+                ItemsSource = items,
+                LayoutModel = layoutModel,
+                UseLogicalScrollable = true
+            };
+            grid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Name",
+                Binding = new Binding(nameof(RowItem.Name))
+            });
+
+            var window = new Window { Content = grid };
+            window.SetThemeStyles();
+            ShowWindow(window);
+            var gridRef = new WeakReference(grid);
+            CleanupWindow(window);
+            return gridRef;
+        }
+
+        WeakReference gridRef = RunInSession(Run);
+        layoutModel.HorizontalSpacing = 4;
+
+        AssertCollected(gridRef);
+        GC.KeepAlive(layoutModel);
         GC.KeepAlive(items);
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridItemContainerAutomationPeerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridItemContainerAutomationPeerTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.Controls.Automation.Peers;
+using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Automation;
+
+public sealed class DataGridItemContainerAutomationPeerTests
+{
+    [AvaloniaFact]
+    public void Item_presentation_exposes_realized_selection_items_even_in_cell_selection_mode()
+    {
+        var items = new[] { new Item("One"), new Item("Two"), new Item("Three") };
+        var grid = new DataGrid
+        {
+            ItemsSource = items,
+            AutoGenerateColumns = false,
+            CanUserAddRows = false,
+            UseLogicalScrollable = true,
+            SelectionMode = DataGridSelectionMode.Extended,
+            SelectionUnit = DataGridSelectionUnit.Cell,
+            ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Width = 100, Height = 40, Text = item.Name }),
+            LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                ItemSizeEstimate = new Size(100, 40),
+                MinItemWidth = 100,
+                MinItemHeight = 40
+            }
+        };
+        grid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding(nameof(Item.Name))
+        });
+        var window = new Window { Width = 420, Height = 180 };
+        window.SetThemeStyles(DataGridTheme.FluentV2);
+        window.Content = grid;
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+
+            DataGridItemContainer[] containers = grid.GetVisualDescendants()
+                .OfType<DataGridItemContainer>()
+                .Where(static container => container.Index >= 0)
+                .OrderBy(static container => container.Index)
+                .ToArray();
+            Assert.True(
+                containers.Length >= 2,
+                $"realized={containers.Length}, display={grid.DisplayData.ScrollingElementCount}, " +
+                $"bounds={grid.Bounds}, presenter={grid.GetVisualDescendants().OfType<DataGridRowsPresenter>().Single().Bounds}");
+            var gridPeer = Assert.IsType<DataGridAutomationPeer>(
+                ControlAutomationPeer.CreatePeerForElement(grid));
+            ISelectionProvider selection = Assert.IsAssignableFrom<ISelectionProvider>(
+                gridPeer.GetProvider<ISelectionProvider>());
+            var firstPeer = Assert.IsType<DataGridItemContainerAutomationPeer>(
+                ControlAutomationPeer.CreatePeerForElement(containers[0]));
+            var secondPeer = Assert.IsType<DataGridItemContainerAutomationPeer>(
+                ControlAutomationPeer.CreatePeerForElement(containers[1]));
+            ISelectionItemProvider first = Assert.IsAssignableFrom<ISelectionItemProvider>(
+                firstPeer.GetProvider<ISelectionItemProvider>());
+            ISelectionItemProvider second = Assert.IsAssignableFrom<ISelectionItemProvider>(
+                secondPeer.GetProvider<ISelectionItemProvider>());
+
+            first.Select();
+            second.AddToSelection();
+
+            Assert.True(first.IsSelected);
+            Assert.True(second.IsSelected);
+            Assert.True(selection.CanSelectMultiple);
+            Assert.Same(selection, second.SelectionContainer);
+            Assert.Equal(new AutomationPeer[] { firstPeer, secondPeer }, selection.GetSelection().ToArray());
+            Assert.Equal(1, containers[0].GetValue(AutomationProperties.PositionInSetProperty));
+            Assert.Equal(items.Length, containers[0].GetValue(AutomationProperties.SizeOfSetProperty));
+            Assert.Equal(items[0].ToString(), firstPeer.GetName());
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private sealed record Item(string Name);
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -197,6 +197,62 @@ public class DataGridLayoutIntegrationTests
         }
     }
 
+    [AvaloniaFact]
+    public void Navigation_query_does_not_mutate_the_persistent_layout_anchor()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            var model = new NavigationTestLayoutModel();
+            grid.LayoutModel = model;
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.True(grid.CanNavigate(DataGridNavigationCommand.Down));
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+
+            Assert.Equal(3, model.Algorithm.NavigationAnchors.Count);
+            Assert.Equal(new Point(50, 15), model.Algorithm.NavigationAnchors[0]);
+            Assert.Equal(model.Algorithm.NavigationAnchors[0], model.Algorithm.NavigationAnchors[1]);
+            Assert.Equal(new Point(50, 75), model.Algorithm.NavigationAnchors[2]);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Logical_rtl_redirect_is_re_resolved_by_the_layout()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32
+            };
+            grid.FlowDirection = FlowDirection.RightToLeft;
+            grid.NavigationModel = new DataGridNavigationModel
+            {
+                HorizontalNavigationMode = DataGridHorizontalNavigationMode.Logical
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 1, columnIndex: 0);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Left));
+            Assert.Equal(2, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static Window CreateWindow(out DataGrid grid, int itemCount, int columnCount = 1)
     {
         var window = new Window { Width = 360, Height = 260 };
@@ -310,6 +366,8 @@ public class DataGridLayoutIntegrationTests
     {
         public int ResolveCount { get; private set; }
 
+        public List<Point> NavigationAnchors { get; } = [];
+
         public void Initialize(IDataGridLayoutContext context)
         {
         }
@@ -364,6 +422,7 @@ public class DataGridLayoutIntegrationTests
             out DataGridLayoutNavigationResult result)
         {
             ResolveCount++;
+            NavigationAnchors.Add(request.NavigationAnchor);
             int target = request.CurrentItemIndex + 2;
             result = new DataGridLayoutNavigationResult(target, GetBounds(target));
             return target < context.ItemCount;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Layouts;
+
+public class DataGridLayoutIntegrationTests
+{
+    [AvaloniaFact]
+    public void Stack_model_uses_datagrid_container_virtualization()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 10_000);
+        try
+        {
+            grid.LayoutModel = new DataGridStackLayoutModel { Spacing = 3 };
+            window.Show();
+            window.UpdateLayout();
+
+            DataGridRowsPresenter presenter = grid.GetVisualDescendants().OfType<DataGridRowsPresenter>().Single();
+            DataGridRow[] realized = GetRealizedRows(grid);
+            Assert.NotEmpty(realized);
+            Assert.True(realized.Length < 30);
+            Assert.True(presenter.Extent.Height > presenter.Viewport.Height);
+            Assert.Equal(3, realized[1].Bounds.Y - realized[0].Bounds.Bottom, precision: 3);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Layout_models_can_be_switched_at_runtime()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 100);
+        try
+        {
+            var stack = new DataGridStackLayoutModel();
+            var uniform = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32
+            };
+            grid.LayoutModel = stack;
+
+            window.Show();
+            window.UpdateLayout();
+            DataGridRow firstBefore = GetRealizedRows(grid).Single(row => row.Slot == 0);
+
+            grid.LayoutModel = uniform;
+            window.UpdateLayout();
+
+            DataGridRow[] tiledRows = GetRealizedRows(grid);
+            Assert.Contains(tiledRows, row => row.Bounds.X > 0);
+            Assert.Same(firstBefore, tiledRows.Single(row => row.Slot == 0));
+
+            grid.LayoutModel = stack;
+            window.UpdateLayout();
+            Assert.All(GetRealizedRows(grid), row => Assert.Equal(0, row.Bounds.X));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void User_defined_layout_algorithm_runs_through_public_context()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            var model = new TestLayoutModel();
+            grid.LayoutModel = model;
+
+            window.Show();
+            window.UpdateLayout();
+
+            Assert.True(model.Algorithm.MeasureCount > 0);
+            Assert.Equal(7, GetRealizedRows(grid).Single(row => row.Slot == 0).Bounds.X);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Scroll_into_view_uses_layout_geometry()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 500);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32
+            };
+            window.Show();
+            window.UpdateLayout();
+
+            Item target = ((IEnumerable<Item>)grid.ItemsSource!).ElementAt(420);
+            grid.ScrollIntoView(target, grid.ColumnsInternal[0]);
+            window.UpdateLayout();
+
+            DataGridRow row = GetRealizedRows(grid).Single(candidate => candidate.Index == 420);
+            DataGridRowsPresenter presenter = grid.GetVisualDescendants().OfType<DataGridRowsPresenter>().Single();
+            Assert.InRange(row.Bounds.Y, 0, presenter.Viewport.Height - 1);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static Window CreateWindow(out DataGrid grid, int itemCount)
+    {
+        var window = new Window { Width = 360, Height = 260 };
+        window.SetThemeStyles(DataGridTheme.FluentV2);
+        grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            ItemsSource = Enumerable.Range(0, itemCount).Select(index => new Item($"Item {index}")).ToArray(),
+            RowHeight = 24,
+            UseLogicalScrollable = true
+        };
+        grid.ColumnsInternal.Add(new DataGridTextColumn
+        {
+            Header = "Name",
+            Width = new DataGridLength(90),
+            Binding = new Binding(nameof(Item.Name))
+        });
+        window.Content = grid;
+        return window;
+    }
+
+    private static DataGridRow[] GetRealizedRows(DataGrid grid)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Where(row => !row.IsRecycled && row.Slot >= 0)
+            .OrderBy(row => row.Slot)
+            .ToArray();
+    }
+
+    private sealed record Item(string Name);
+
+    private sealed class TestLayoutModel : DataGridLayoutModelBase
+    {
+        public TestLayoutAlgorithm Algorithm { get; } = new();
+
+        public override IDataGridLayoutAlgorithm CreateAlgorithm() => Algorithm;
+    }
+
+    private sealed class TestLayoutAlgorithm : IDataGridLayoutAlgorithm
+    {
+        public int MeasureCount { get; private set; }
+
+        public void Initialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public Size Measure(IDataGridLayoutContext context, Size availableSize)
+        {
+            MeasureCount++;
+            int count = System.Math.Min(2, context.ItemCount);
+            for (int index = 0; index < count; index++)
+            {
+                Control element = context.GetOrCreateElementAt(index);
+                element.Measure(new Size(80, 30));
+                context.SetLayoutBounds(index, new Rect(7 + (index * 82), 5, 80, 30));
+            }
+            return new Size(171, 35);
+        }
+
+        public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+        {
+            IReadOnlyList<Control> realized = context.RealizedElements;
+            for (int index = 0; index < realized.Count; index++)
+            {
+                Control element = realized[index];
+                int itemIndex = context.GetElementIndex(element);
+                if (context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+                {
+                    element.Arrange(bounds);
+                }
+            }
+            return finalSize;
+        }
+
+        public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+        {
+        }
+
+        public void Uninitialize(IDataGridLayoutContext context)
+        {
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -5,9 +5,11 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -122,7 +124,80 @@ public class DataGridLayoutIntegrationTests
         }
     }
 
-    private static Window CreateWindow(out DataGrid grid, int itemCount)
+    [AvaloniaFact]
+    public void Uniform_grid_navigation_uses_spatial_neighbors()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 100);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+            Assert.Equal(1, grid.CurrentCell.RowIndex);
+
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+            Assert.True(grid.CurrentCell.RowIndex > 1);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Stack_cross_axis_navigation_falls_back_to_cell_columns()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20, columnCount: 2);
+        try
+        {
+            grid.LayoutModel = new DataGridStackLayoutModel();
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+            Assert.Equal(0, grid.CurrentCell.RowIndex);
+            Assert.Equal(1, grid.CurrentCell.Column.DisplayIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Layout_navigation_resolves_once_and_extends_selection()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            var model = new NavigationTestLayoutModel();
+            grid.LayoutModel = model;
+            grid.SelectionMode = DataGridSelectionMode.Extended;
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Down, KeyModifiers.Shift));
+            Assert.Equal(2, grid.CurrentCell.RowIndex);
+            Assert.Equal(1, model.Algorithm.ResolveCount);
+            Assert.Equal(3, grid.SelectedItems.Count);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static Window CreateWindow(out DataGrid grid, int itemCount, int columnCount = 1)
     {
         var window = new Window { Width = 360, Height = 260 };
         window.SetThemeStyles(DataGridTheme.FluentV2);
@@ -140,8 +215,25 @@ public class DataGridLayoutIntegrationTests
             Width = new DataGridLength(90),
             Binding = new Binding(nameof(Item.Name))
         });
+        if (columnCount > 1)
+        {
+            grid.ColumnsInternal.Add(new DataGridTextColumn
+            {
+                Header = "Name 2",
+                Width = new DataGridLength(90),
+                Binding = new Binding(nameof(Item.Name))
+            });
+        }
         window.Content = grid;
         return window;
+    }
+
+    private static void SetCurrentCell(DataGrid grid, int rowIndex, int columnIndex)
+    {
+        object item = ((System.Collections.IList)grid.ItemsSource!)[rowIndex]!;
+        DataGridColumn column = grid.Columns[columnIndex];
+        grid.CurrentCell = new DataGridCellInfo(item, column, rowIndex, column.Index, isValid: true);
+        grid.UpdateLayout();
     }
 
     private static DataGridRow[] GetRealizedRows(DataGrid grid)
@@ -205,5 +297,78 @@ public class DataGridLayoutIntegrationTests
         public void Uninitialize(IDataGridLayoutContext context)
         {
         }
+    }
+
+    private sealed class NavigationTestLayoutModel : DataGridLayoutModelBase
+    {
+        public NavigationTestLayoutAlgorithm Algorithm { get; } = new();
+
+        public override IDataGridLayoutAlgorithm CreateAlgorithm() => Algorithm;
+    }
+
+    private sealed class NavigationTestLayoutAlgorithm : IDataGridLayoutAlgorithm, IDataGridLayoutNavigation
+    {
+        public int ResolveCount { get; private set; }
+
+        public void Initialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public Size Measure(IDataGridLayoutContext context, Size availableSize)
+        {
+            int count = System.Math.Min(context.ItemCount, 10);
+            for (int index = 0; index < count; index++)
+            {
+                Control element = context.GetOrCreateElementAt(index);
+                element.Measure(new Size(100, 30));
+                context.SetLayoutBounds(index, GetBounds(index));
+            }
+
+            return new Size(100, context.ItemCount * 30);
+        }
+
+        public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+        {
+            foreach (Control element in context.RealizedElements)
+            {
+                element.Arrange(GetBounds(context.GetElementIndex(element)));
+            }
+
+            return finalSize;
+        }
+
+        public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+        {
+        }
+
+        public void Uninitialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) =>
+            direction == DataGridLayoutNavigationDirection.Down;
+
+        public bool TryGetNavigationBounds(
+            IDataGridLayoutContext context,
+            int itemIndex,
+            Rect viewport,
+            out Rect bounds)
+        {
+            bounds = GetBounds(itemIndex);
+            return itemIndex >= 0 && itemIndex < context.ItemCount;
+        }
+
+        public bool TryResolveNavigation(
+            IDataGridLayoutContext context,
+            in DataGridLayoutNavigationRequest request,
+            out DataGridLayoutNavigationResult result)
+        {
+            ResolveCount++;
+            int target = request.CurrentItemIndex + 2;
+            result = new DataGridLayoutNavigationResult(target, GetBounds(target));
+            return target < context.ItemCount;
+        }
+
+        private static Rect GetBounds(int index) => new(0, index * 30, 100, 30);
     }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -323,6 +323,99 @@ public class DataGridLayoutIntegrationTests
         }
     }
 
+    [AvaloniaTheory]
+    [InlineData(DataGridNavigationCommand.Right, 2, 0)]
+    [InlineData(DataGridNavigationCommand.Left, 3, 5)]
+    [InlineData(DataGridNavigationCommand.Down, 19, 0)]
+    [InlineData(DataGridNavigationCommand.Up, 0, 19)]
+    public void Owned_layout_boundary_wraps_through_spatial_geometry(
+        DataGridNavigationCommand command,
+        int sourceRowIndex,
+        int expectedRowIndex)
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32,
+                MaximumRowsOrColumns = 3
+            };
+            grid.NavigationModel = new DataGridNavigationModel
+            {
+                HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap,
+                VerticalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, sourceRowIndex, columnIndex: 0);
+
+            Assert.True(grid.Navigate(command));
+            Assert.Equal(expectedRowIndex, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Unsupported_stack_cross_axis_keeps_column_wrap()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20, columnCount: 2);
+        try
+        {
+            grid.LayoutModel = new DataGridStackLayoutModel();
+            grid.NavigationModel = new DataGridNavigationModel
+            {
+                HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 4, columnIndex: 1);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+            Assert.Equal(4, grid.CurrentCell.RowIndex);
+            Assert.Equal(0, grid.CurrentCell.Column.DisplayIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Logical_rtl_redirect_does_not_run_spatial_boundary_policy_twice()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32,
+                MaximumRowsOrColumns = 3
+            };
+            grid.FlowDirection = FlowDirection.RightToLeft;
+            grid.NavigationModel = new DataGridNavigationModel
+            {
+                HorizontalNavigationMode = DataGridHorizontalNavigationMode.Logical,
+                HorizontalBoundaryMode = DataGridNavigationBoundaryMode.Wrap
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 2, columnIndex: 0);
+
+            Assert.False(grid.Navigate(DataGridNavigationCommand.Left));
+            Assert.Equal(2, grid.CurrentCell.RowIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static Window CreateWindow(out DataGrid grid, int itemCount, int columnCount = 1)
     {
         var window = new Window { Width = 360, Height = 260 };

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Avalonia.Controls.DataGridLayouts;
 using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
@@ -69,6 +70,149 @@ public class DataGridLayoutIntegrationTests
             grid.LayoutModel = stack;
             window.UpdateLayout();
             Assert.All(GetRealizedRows(grid), row => Assert.Equal(0, row.Bounds.X));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Item_presentation_realizes_templates_without_rows_cells_or_headers()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 10_000);
+        try
+        {
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new Border
+                {
+                    Width = 96,
+                    Height = 40,
+                    Child = new TextBlock { Text = item.Name }
+                });
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                ItemSizeEstimate = new Size(96, 40),
+                MinItemWidth = 96,
+                MinItemHeight = 40,
+                MinColumnSpacing = 4,
+                MinRowSpacing = 4
+            };
+
+            window.Show();
+            window.UpdateLayout();
+
+            DataGridItemContainer[] items = GetRealizedItems(grid);
+            DataGridColumnHeadersPresenter headers = grid.GetVisualDescendants()
+                .OfType<DataGridColumnHeadersPresenter>()
+                .Single();
+            Assert.NotEmpty(items);
+            Assert.True(items.Length < 40);
+            Assert.Empty(GetRealizedRows(grid));
+            Assert.Empty(grid.GetVisualDescendants().OfType<DataGridCell>());
+            Assert.False(headers.IsVisible);
+            Assert.Equal("Item 0", ((TextBlock)((Border)items[0].Content!).Child!).Text);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Runtime_switch_between_row_and_item_presentation_reuses_item_containers()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 100);
+        try
+        {
+            var rows = new DataGridStackLayoutModel();
+            var items = new DataGridUniformGridLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                MinItemWidth = 90,
+                MinItemHeight = 36
+            };
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Width = 90, Height = 36, Text = item.Name });
+            grid.LayoutModel = items;
+            window.Show();
+            window.UpdateLayout();
+            DataGridItemContainer[] firstItems = GetRealizedItems(grid);
+
+            grid.LayoutModel = rows;
+            window.UpdateLayout();
+            Assert.NotEmpty(GetRealizedRows(grid));
+            Assert.Empty(GetRealizedItems(grid));
+
+            grid.LayoutModel = items;
+            window.UpdateLayout();
+            DataGridItemContainer[] secondItems = GetRealizedItems(grid);
+
+            Assert.NotEmpty(secondItems);
+            Assert.Contains(secondItems, candidate => firstItems.Contains(candidate));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Item_presentation_preserves_spatial_navigation_and_selection_state()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 100);
+        try
+        {
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Width = 90, Height = 36, Text = item.Name });
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                MinItemWidth = 90,
+                MinItemHeight = 36
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Right));
+            window.UpdateLayout();
+
+            Assert.Equal(1, grid.CurrentCell.RowIndex);
+            DataGridItemContainer current = GetRealizedItems(grid).Single(item => item.Index == 1);
+            Assert.True(current.IsCurrent);
+            Assert.True(current.IsSelected);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Changing_item_template_reprepares_recycled_containers()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            grid.LayoutModel = new DataGridStackLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items
+            };
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Height = 30, Text = "First " + item.Name });
+            window.Show();
+            window.UpdateLayout();
+            DataGridItemContainer[] before = GetRealizedItems(grid);
+
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Height = 30, Text = "Second " + item.Name });
+            window.UpdateLayout();
+
+            DataGridItemContainer after = GetRealizedItems(grid).Single(item => item.Index == 0);
+            Assert.Contains(after, before);
+            Assert.Equal("Second Item 0", ((TextBlock)after.Content!).Text);
         }
         finally
         {
@@ -461,6 +605,15 @@ public class DataGridLayoutIntegrationTests
             .OfType<DataGridRow>()
             .Where(row => !row.IsRecycled && row.Slot >= 0)
             .OrderBy(row => row.Slot)
+            .ToArray();
+    }
+
+    private static DataGridItemContainer[] GetRealizedItems(DataGrid grid)
+    {
+        return grid.GetVisualDescendants()
+            .OfType<DataGridItemContainer>()
+            .Where(item => item.Index >= 0)
+            .OrderBy(item => item.Index)
             .ToArray();
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -126,6 +126,7 @@ public class DataGridLayoutIntegrationTests
         Window window = CreateWindow(out DataGrid grid, itemCount: 100);
         try
         {
+            grid.KeepRecycledContainersInVisualTree = false;
             var rows = new DataGridStackLayoutModel();
             var items = new DataGridUniformGridLayoutModel
             {
@@ -144,6 +145,7 @@ public class DataGridLayoutIntegrationTests
             window.UpdateLayout();
             Assert.NotEmpty(GetRealizedRows(grid));
             Assert.Empty(GetRealizedItems(grid));
+            Assert.Empty(grid.GetVisualDescendants().OfType<DataGridItemContainer>());
 
             grid.LayoutModel = items;
             window.UpdateLayout();
@@ -151,6 +153,61 @@ public class DataGridLayoutIntegrationTests
 
             Assert.NotEmpty(secondItems);
             Assert.Contains(secondItems, candidate => firstItems.Contains(candidate));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Item_presentation_uses_model_estimate_before_realization()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 100);
+        try
+        {
+            var model = new EstimateProbeLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                ItemSizeEstimate = new Size(123, 57)
+            };
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Text = item.Name });
+            grid.LayoutModel = model;
+
+            window.Show();
+            window.UpdateLayout();
+
+            Assert.Equal(new Size(123, 57), model.Algorithm.FirstEstimate);
+            Assert.Equal(285, model.Algorithm.FifthOffset);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Item_presentation_rejects_cell_editing_without_creating_rows()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            grid.ItemTemplate = new FuncDataTemplate<Item>(
+                (item, _) => new TextBlock { Height = 30, Text = item.Name });
+            grid.LayoutModel = new DataGridStackLayoutModel
+            {
+                PresentationMode = DataGridLayoutPresentationMode.Items,
+                ItemSizeEstimate = new Size(100, 30)
+            };
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.False(grid.BeginEdit());
+            Assert.Null(grid.EditingRow);
+            Assert.Empty(GetRealizedRows(grid));
+            Assert.Empty(grid.GetVisualDescendants().OfType<DataGridCell>());
         }
         finally
         {
@@ -624,6 +681,57 @@ public class DataGridLayoutIntegrationTests
         public TestLayoutAlgorithm Algorithm { get; } = new();
 
         public override IDataGridLayoutAlgorithm CreateAlgorithm() => Algorithm;
+    }
+
+    private sealed class EstimateProbeLayoutModel : DataGridLayoutModelBase
+    {
+        public EstimateProbeLayoutAlgorithm Algorithm { get; } = new();
+
+        public override IDataGridLayoutAlgorithm CreateAlgorithm() => Algorithm;
+    }
+
+    private sealed class EstimateProbeLayoutAlgorithm : IDataGridLayoutAlgorithm
+    {
+        private bool _capturedInitialEstimate;
+
+        public Size FirstEstimate { get; private set; }
+
+        public double FifthOffset { get; private set; }
+
+        public void Initialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public Size Measure(IDataGridLayoutContext context, Size availableSize)
+        {
+            if (!_capturedInitialEstimate)
+            {
+                FirstEstimate = context.GetEstimatedItemSize(0);
+                FifthOffset = context.GetEstimatedItemOffset(5, DataGridLayoutOrientation.Vertical);
+                _capturedInitialEstimate = true;
+            }
+            Control element = context.GetOrCreateElementAt(0);
+            element.Measure(FirstEstimate);
+            context.SetLayoutBounds(0, new Rect(0, 0, FirstEstimate.Width, FirstEstimate.Height));
+            return new Size(FirstEstimate.Width, FifthOffset + FirstEstimate.Height);
+        }
+
+        public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+        {
+            if (context.RealizedElements.Count > 0)
+            {
+                context.RealizedElements[0].Arrange(new Rect(0, 0, FirstEstimate.Width, FirstEstimate.Height));
+            }
+            return finalSize;
+        }
+
+        public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+        {
+        }
+
+        public void Uninitialize(IDataGridLayoutContext context)
+        {
+        }
     }
 
     private sealed class TestLayoutAlgorithm : IDataGridLayoutAlgorithm

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutIntegrationTests.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -253,6 +254,75 @@ public class DataGridLayoutIntegrationTests
         }
     }
 
+    [AvaloniaFact]
+    public void Semantic_commands_map_to_the_expected_layout_directions()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            var model = new NavigationTestLayoutModel();
+            model.Algorithm.SupportAllDirections = true;
+            grid.LayoutModel = model;
+            window.Show();
+            window.UpdateLayout();
+
+            var cases = new[]
+            {
+                (DataGridNavigationCommand.Up, KeyModifiers.None, DataGridLayoutNavigationDirection.Up),
+                (DataGridNavigationCommand.Up, KeyModifiers.Control, DataGridLayoutNavigationDirection.First),
+                (DataGridNavigationCommand.Down, KeyModifiers.None, DataGridLayoutNavigationDirection.Down),
+                (DataGridNavigationCommand.Down, KeyModifiers.Control, DataGridLayoutNavigationDirection.Last),
+                (DataGridNavigationCommand.Left, KeyModifiers.None, DataGridLayoutNavigationDirection.Left),
+                (DataGridNavigationCommand.Left, KeyModifiers.Control, DataGridLayoutNavigationDirection.LineStart),
+                (DataGridNavigationCommand.Right, KeyModifiers.None, DataGridLayoutNavigationDirection.Right),
+                (DataGridNavigationCommand.Right, KeyModifiers.Control, DataGridLayoutNavigationDirection.LineEnd),
+                (DataGridNavigationCommand.PageUp, KeyModifiers.None, DataGridLayoutNavigationDirection.PageUp),
+                (DataGridNavigationCommand.PageDown, KeyModifiers.None, DataGridLayoutNavigationDirection.PageDown),
+                (DataGridNavigationCommand.RowStart, KeyModifiers.None, DataGridLayoutNavigationDirection.LineStart),
+                (DataGridNavigationCommand.RowEnd, KeyModifiers.None, DataGridLayoutNavigationDirection.LineEnd),
+                (DataGridNavigationCommand.ColumnStart, KeyModifiers.None, DataGridLayoutNavigationDirection.First),
+                (DataGridNavigationCommand.ColumnEnd, KeyModifiers.None, DataGridLayoutNavigationDirection.Last),
+                (DataGridNavigationCommand.GridStart, KeyModifiers.None, DataGridLayoutNavigationDirection.First),
+                (DataGridNavigationCommand.GridEnd, KeyModifiers.None, DataGridLayoutNavigationDirection.Last)
+            };
+
+            foreach ((DataGridNavigationCommand command, KeyModifiers modifiers, DataGridLayoutNavigationDirection expected) in cases)
+            {
+                SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+                Assert.True(grid.Navigate(command, modifiers));
+                Assert.Equal(expected, model.Algorithm.Directions[^1]);
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Owned_layout_boundary_does_not_fall_back_to_linear_navigation()
+    {
+        Window window = CreateWindow(out DataGrid grid, itemCount: 20);
+        try
+        {
+            var model = new NavigationTestLayoutModel();
+            model.Algorithm.ResolveTargets = false;
+            grid.LayoutModel = model;
+            window.Show();
+            window.UpdateLayout();
+            SetCurrentCell(grid, rowIndex: 0, columnIndex: 0);
+
+            Assert.False(grid.CanNavigate(DataGridNavigationCommand.Down));
+            Assert.True(grid.Navigate(DataGridNavigationCommand.Down));
+            Assert.Equal(0, grid.CurrentCell.RowIndex);
+            Assert.Equal(2, model.Algorithm.ResolveCount);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static Window CreateWindow(out DataGrid grid, int itemCount, int columnCount = 1)
     {
         var window = new Window { Width = 360, Height = 260 };
@@ -368,6 +438,12 @@ public class DataGridLayoutIntegrationTests
 
         public List<Point> NavigationAnchors { get; } = [];
 
+        public List<DataGridLayoutNavigationDirection> Directions { get; } = [];
+
+        public bool ResolveTargets { get; set; } = true;
+
+        public bool SupportAllDirections { get; set; }
+
         public void Initialize(IDataGridLayoutContext context)
         {
         }
@@ -404,7 +480,7 @@ public class DataGridLayoutIntegrationTests
         }
 
         public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) =>
-            direction == DataGridLayoutNavigationDirection.Down;
+            SupportAllDirections || direction == DataGridLayoutNavigationDirection.Down;
 
         public bool TryGetNavigationBounds(
             IDataGridLayoutContext context,
@@ -423,6 +499,13 @@ public class DataGridLayoutIntegrationTests
         {
             ResolveCount++;
             NavigationAnchors.Add(request.NavigationAnchor);
+            Directions.Add(request.Direction);
+            if (!ResolveTargets)
+            {
+                result = default;
+                return false;
+            }
+
             int target = request.CurrentItemIndex + 2;
             result = new DataGridLayoutNavigationResult(target, GetBounds(target));
             return target < context.ItemCount;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutModelBaseTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutModelBaseTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Specialized;
+using Avalonia.Controls.DataGridLayouts;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Layouts;
+
+public class DataGridLayoutModelBaseTests
+{
+    [Fact]
+    public void Property_change_raises_property_and_layout_notifications()
+    {
+        var model = new TestLayoutModel();
+        string? propertyName = null;
+        DataGridLayoutInvalidationKind? invalidation = null;
+        model.PropertyChanged += (_, e) => propertyName = e.PropertyName;
+        model.LayoutInvalidated += (_, e) => invalidation = e.Kind;
+
+        model.ItemSpacing = 12;
+
+        Assert.Equal(nameof(TestLayoutModel.ItemSpacing), propertyName);
+        Assert.Equal(DataGridLayoutInvalidationKind.Measure, invalidation);
+    }
+
+    [Fact]
+    public void Unchanged_property_does_not_raise_notifications()
+    {
+        var model = new TestLayoutModel();
+        var raised = false;
+        model.PropertyChanged += (_, _) => raised = true;
+        model.LayoutInvalidated += (_, _) => raised = true;
+
+        model.ItemSpacing = model.ItemSpacing;
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void Deferred_changes_raise_one_strongest_invalidation()
+    {
+        var model = new TestLayoutModel();
+        var raised = 0;
+        DataGridLayoutInvalidationKind? invalidation = null;
+        model.LayoutInvalidated += (_, e) =>
+        {
+            raised++;
+            invalidation = e.Kind;
+        };
+
+        using (model.DeferInvalidation())
+        {
+            model.ItemSpacing = 8;
+            model.ArrangementToken = 1;
+            model.ResetToken = 1;
+        }
+
+        Assert.Equal(1, raised);
+        Assert.Equal(DataGridLayoutInvalidationKind.Reset, invalidation);
+    }
+
+    [Fact]
+    public void Nested_deferred_changes_flush_after_outer_scope()
+    {
+        var model = new TestLayoutModel();
+        var raised = 0;
+        model.LayoutInvalidated += (_, _) => raised++;
+
+        using (model.DeferInvalidation())
+        {
+            model.ItemSpacing = 4;
+            using (model.DeferInvalidation())
+            {
+                model.ItemSpacing = 6;
+            }
+
+            Assert.Equal(0, raised);
+        }
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void CreateAlgorithm_returns_custom_algorithm()
+    {
+        var model = new TestLayoutModel();
+
+        Assert.IsType<TestLayoutAlgorithm>(model.CreateAlgorithm());
+    }
+
+    private sealed class TestLayoutModel : DataGridLayoutModelBase
+    {
+        private double _itemSpacing;
+        private int _arrangementToken;
+        private int _resetToken;
+
+        public double ItemSpacing
+        {
+            get => _itemSpacing;
+            set => SetProperty(ref _itemSpacing, value);
+        }
+
+        public int ArrangementToken
+        {
+            get => _arrangementToken;
+            set => SetProperty(ref _arrangementToken, value, DataGridLayoutInvalidationKind.Arrange);
+        }
+
+        public int ResetToken
+        {
+            get => _resetToken;
+            set => SetProperty(ref _resetToken, value, DataGridLayoutInvalidationKind.Reset);
+        }
+
+        public override IDataGridLayoutAlgorithm CreateAlgorithm()
+        {
+            return new TestLayoutAlgorithm();
+        }
+    }
+
+    private sealed class TestLayoutAlgorithm : IDataGridLayoutAlgorithm
+    {
+        public void Initialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public Size Measure(IDataGridLayoutContext context, Size availableSize)
+        {
+            return availableSize;
+        }
+
+        public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+        {
+            return finalSize;
+        }
+
+        public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+        {
+        }
+
+        public void Uninitialize(IDataGridLayoutContext context)
+        {
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutModelBaseTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridLayoutModelBaseTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Controls.DataGridLayouts;
 using Xunit;
@@ -87,6 +88,23 @@ public class DataGridLayoutModelBaseTests
         var model = new TestLayoutModel();
 
         Assert.IsType<TestLayoutAlgorithm>(model.CreateAlgorithm());
+    }
+
+    [Fact]
+    public void Presentation_properties_are_sanitized_and_raise_reset_invalidation()
+    {
+        var model = new TestLayoutModel();
+        var invalidations = new List<DataGridLayoutInvalidationKind>();
+        model.LayoutInvalidated += (_, e) => invalidations.Add(e.Kind);
+
+        model.PresentationMode = DataGridLayoutPresentationMode.Items;
+        model.ItemSizeEstimate = new Size(double.NaN, -12);
+
+        Assert.Equal(DataGridLayoutPresentationMode.Items, model.PresentationMode);
+        Assert.Equal(new Size(100, 1), model.ItemSizeEstimate);
+        Assert.Equal(
+            [DataGridLayoutInvalidationKind.Reset, DataGridLayoutInvalidationKind.Reset],
+            invalidations);
     }
 
     private sealed class TestLayoutModel : DataGridLayoutModelBase

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
@@ -131,6 +131,11 @@ public class DataGridStackLayoutModelTests
         algorithm.Initialize(context);
         algorithm.Measure(context, new Size(100, 100));
 
+        Assert.True(navigation.SupportsNavigation(DataGridLayoutNavigationDirection.Down));
+        Assert.False(navigation.SupportsNavigation(DataGridLayoutNavigationDirection.Left));
+        Assert.True(navigation.TryGetNavigationBounds(context, 50, context.RealizationRect, out Rect estimated));
+        Assert.Equal(1250, estimated.Y);
+
         bool movedDown = navigation.TryResolveNavigation(
             context,
             new DataGridLayoutNavigationRequest(10, DataGridLayoutNavigationDirection.Down, context.RealizationRect, new Point(50, 260)),

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
@@ -117,6 +117,36 @@ public class DataGridStackLayoutModelTests
         Assert.Equal(Enumerable.Range(0, 12), context.RealizedIndices);
     }
 
+    [Fact]
+    public void Navigation_resolves_adjacent_and_non_realized_page_targets()
+    {
+        var model = new DataGridStackLayoutModel { Spacing = 5 };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var navigation = Assert.IsAssignableFrom<IDataGridLayoutNavigation>(algorithm);
+        var context = new TestLayoutContext(
+            itemCount: 100,
+            itemSize: new Size(100, 20),
+            realizationRect: new Rect(0, 250, 100, 100),
+            scrollOffset: new Vector(0, 250));
+        algorithm.Initialize(context);
+        algorithm.Measure(context, new Size(100, 100));
+
+        bool movedDown = navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(10, DataGridLayoutNavigationDirection.Down, context.RealizationRect, new Point(50, 260)),
+            out DataGridLayoutNavigationResult down);
+        bool paged = navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(10, DataGridLayoutNavigationDirection.PageDown, context.RealizationRect, new Point(50, 260)),
+            out DataGridLayoutNavigationResult page);
+
+        Assert.True(movedDown);
+        Assert.Equal(11, down.ItemIndex);
+        Assert.True(paged);
+        Assert.True(page.ItemIndex > 11);
+        Assert.True(page.EstimatedBounds.Y >= 300);
+    }
+
     private sealed class TestLayoutContext : IDataGridLayoutContext
     {
         private readonly Size _itemSize;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridStackLayoutModelTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls.DataGridLayouts;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Layouts;
+
+public class DataGridStackLayoutModelTests
+{
+    [Fact]
+    public void Defaults_match_virtualized_vertical_list_behavior()
+    {
+        var model = new DataGridStackLayoutModel();
+
+        Assert.Equal(DataGridLayoutOrientation.Vertical, model.Orientation);
+        Assert.Equal(0, model.Spacing);
+        Assert.False(model.DisableVirtualization);
+    }
+
+    [Fact]
+    public void Orientation_change_requests_state_reset()
+    {
+        var model = new DataGridStackLayoutModel();
+        DataGridLayoutInvalidationKind? kind = null;
+        model.LayoutInvalidated += (_, e) => kind = e.Kind;
+
+        model.Orientation = DataGridLayoutOrientation.Horizontal;
+
+        Assert.Equal(DataGridLayoutInvalidationKind.Reset, kind);
+    }
+
+    [Fact]
+    public void Vertical_stack_realizes_only_the_window_and_uses_estimated_extent()
+    {
+        var model = new DataGridStackLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestLayoutContext(
+            itemCount: 100,
+            itemSize: new Size(120, 20),
+            realizationRect: new Rect(0, 200, 120, 100),
+            scrollOffset: new Vector(0, 200));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(120, 100));
+        algorithm.Arrange(context, new Size(120, 100));
+
+        Assert.Equal(120, extent.Width);
+        Assert.Equal(2000, extent.Height);
+        Assert.Equal(10, context.RealizedIndices.Min());
+        Assert.Equal(14, context.RealizedIndices.Max());
+        Assert.Equal(5, context.RealizedIndices.Count);
+        Assert.Equal(0, context.GetBounds(10).Y);
+    }
+
+    [Fact]
+    public void Spacing_participates_in_anchor_and_extent_math()
+    {
+        var model = new DataGridStackLayoutModel { Spacing = 5 };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestLayoutContext(
+            itemCount: 10,
+            itemSize: new Size(100, 20),
+            realizationRect: new Rect(0, 50, 100, 25),
+            scrollOffset: new Vector(0, 50));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(100, 25));
+
+        Assert.Equal(245, extent.Height);
+        Assert.Equal(2, context.RealizedIndices.Min());
+    }
+
+    [Fact]
+    public void Horizontal_stack_uses_width_as_the_major_axis()
+    {
+        var model = new DataGridStackLayoutModel
+        {
+            Orientation = DataGridLayoutOrientation.Horizontal
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestLayoutContext(
+            itemCount: 20,
+            itemSize: new Size(30, 40),
+            realizationRect: new Rect(90, 0, 90, 40),
+            scrollOffset: new Vector(90, 0));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(90, 40));
+
+        Assert.Equal(600, extent.Width);
+        Assert.Equal(40, extent.Height);
+        Assert.Equal(3, context.RealizedIndices.Min());
+        Assert.Equal(5, context.RealizedIndices.Max());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Non_virtualizing_modes_realize_every_item(bool useDisableVirtualization)
+    {
+        IDataGridLayoutModel model = useDisableVirtualization
+            ? new DataGridStackLayoutModel { DisableVirtualization = true }
+            : new DataGridNonVirtualizingStackLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestLayoutContext(
+            itemCount: 12,
+            itemSize: new Size(80, 10),
+            realizationRect: new Rect(0, 40, 80, 10),
+            scrollOffset: new Vector(0, 40));
+        algorithm.Initialize(context);
+
+        algorithm.Measure(context, new Size(80, 10));
+
+        Assert.Equal(Enumerable.Range(0, 12), context.RealizedIndices);
+    }
+
+    private sealed class TestLayoutContext : IDataGridLayoutContext
+    {
+        private readonly Size _itemSize;
+        private readonly List<Control> _realized = new();
+        private readonly Dictionary<int, FixedSizeControl> _elements = new();
+        private readonly Dictionary<int, Rect> _bounds = new();
+
+        public TestLayoutContext(int itemCount, Size itemSize, Rect realizationRect, Vector scrollOffset)
+        {
+            ItemCount = itemCount;
+            _itemSize = itemSize;
+            RealizationRect = realizationRect;
+            ScrollOffset = scrollOffset;
+        }
+
+        public int ItemCount { get; }
+
+        public Rect RealizationRect { get; }
+
+        public Vector ScrollOffset { get; }
+
+        public int RecommendedAnchorIndex => -1;
+
+        public Point LayoutOrigin { get; set; }
+
+        public object? LayoutState { get; set; }
+
+        public IReadOnlyList<Control> RealizedElements => _realized;
+
+        public IReadOnlyList<int> RealizedIndices => _elements.Keys.OrderBy(index => index).ToArray();
+
+        public Control GetOrCreateElementAt(int index)
+        {
+            if (!_elements.TryGetValue(index, out FixedSizeControl? element))
+            {
+                element = new FixedSizeControl(_itemSize, index);
+                _elements.Add(index, element);
+                _realized.Add(element);
+            }
+
+            return element;
+        }
+
+        public void RecycleElement(Control element)
+        {
+            int index = GetElementIndex(element);
+            if (index >= 0)
+            {
+                _elements.Remove(index);
+                _bounds.Remove(index);
+                _realized.Remove(element);
+            }
+        }
+
+        public int GetElementIndex(Control element)
+        {
+            return element is FixedSizeControl fixedSize ? fixedSize.Index : -1;
+        }
+
+        public Size GetEstimatedItemSize(int index)
+        {
+            return _itemSize;
+        }
+
+        public double GetEstimatedItemOffset(int index, DataGridLayoutOrientation orientation)
+        {
+            return index * (orientation == DataGridLayoutOrientation.Vertical ? _itemSize.Height : _itemSize.Width);
+        }
+
+        public void SetLayoutBounds(int index, Rect bounds)
+        {
+            _bounds[index] = bounds;
+        }
+
+        public bool TryGetLayoutBounds(int index, out Rect bounds)
+        {
+            return _bounds.TryGetValue(index, out bounds);
+        }
+
+        public Rect GetBounds(int index)
+        {
+            return _elements[index].Bounds;
+        }
+    }
+
+    private sealed class FixedSizeControl : Control
+    {
+        private readonly Size _size;
+
+        public FixedSizeControl(Size size, int index)
+        {
+            _size = size;
+            Index = index;
+        }
+
+        public int Index { get; }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            return _size;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls.DataGridLayouts;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
@@ -129,6 +129,15 @@ public class DataGridUniformGridLayoutModelTests
         algorithm.Initialize(context);
         algorithm.Measure(context, new Size(200, 20));
 
+        Assert.All(Enum.GetValues<DataGridLayoutNavigationDirection>(), direction =>
+            Assert.True(navigation.SupportsNavigation(direction)));
+        Assert.True(navigation.TryGetNavigationBounds(
+            context,
+            42,
+            new Rect(0, 0, 200, 20),
+            out Rect nonRealized));
+        Assert.Equal(new Rect(100, 200, 50, 20), nonRealized);
+
         Assert.True(navigation.TryResolveNavigation(
             context,
             new DataGridLayoutNavigationRequest(2, DataGridLayoutNavigationDirection.Down, new Rect(0, 0, 200, 20), new Point(125, 10)),

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
@@ -102,6 +102,18 @@ public class DataGridUniformGridLayoutModelTests
     }
 
     [Fact]
+    public void Items_justification_invalidates_measure_because_it_changes_recorded_bounds()
+    {
+        var model = new DataGridUniformGridLayoutModel();
+        DataGridLayoutInvalidationKind? kind = null;
+        model.LayoutInvalidated += (_, args) => kind = args.Kind;
+
+        model.ItemsJustification = DataGridUniformGridItemsJustification.Center;
+
+        Assert.Equal(DataGridLayoutInvalidationKind.Measure, kind);
+    }
+
+    [Fact]
     public void Natural_cell_size_is_measured_when_minimums_are_unspecified()
     {
         var model = new DataGridUniformGridLayoutModel();

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls.DataGridLayouts;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Layouts;
+
+public class DataGridUniformGridLayoutModelTests
+{
+    [Fact]
+    public void Defaults_match_items_repeater_uniform_grid()
+    {
+        var model = new DataGridUniformGridLayoutModel();
+
+        Assert.Equal(DataGridLayoutOrientation.Horizontal, model.Orientation);
+        Assert.True(double.IsNaN(model.MinItemWidth));
+        Assert.True(double.IsNaN(model.MinItemHeight));
+        Assert.Equal(int.MaxValue, model.MaximumRowsOrColumns);
+        Assert.Equal(DataGridUniformGridItemsJustification.Start, model.ItemsJustification);
+        Assert.Equal(DataGridUniformGridItemsStretch.None, model.ItemsStretch);
+    }
+
+    [Fact]
+    public void Horizontal_flow_realizes_only_intersecting_rows()
+    {
+        var model = new DataGridUniformGridLayoutModel
+        {
+            MinItemWidth = 50,
+            MinItemHeight = 20
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(1000, new Size(50, 20), new Rect(0, 100, 200, 40), new Vector(0, 100));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(200, 40));
+        algorithm.Arrange(context, new Size(200, 40));
+
+        Assert.Equal(new Size(200, 5000), extent);
+        Assert.Equal(Enumerable.Range(20, 8), context.RealizedIndices);
+        Assert.Equal(0, context.GetArrangedBounds(20).Y);
+    }
+
+    [Fact]
+    public void Vertical_flow_virtualizes_columns()
+    {
+        var model = new DataGridUniformGridLayoutModel
+        {
+            Orientation = DataGridLayoutOrientation.Vertical,
+            MinItemWidth = 40,
+            MinItemHeight = 25
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(40, new Size(40, 25), new Rect(80, 0, 40, 100), new Vector(80, 0));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(40, 100));
+
+        Assert.Equal(new Size(400, 100), extent);
+        Assert.Equal(Enumerable.Range(8, 4), context.RealizedIndices);
+    }
+
+    [Fact]
+    public void Fill_stretches_cells_across_the_available_line()
+    {
+        var model = new DataGridUniformGridLayoutModel
+        {
+            MinItemWidth = 100,
+            MinItemHeight = 30,
+            MinColumnSpacing = 10,
+            ItemsStretch = DataGridUniformGridItemsStretch.Fill
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(2, new Size(100, 30), new Rect(0, 0, 220, 30), default);
+        algorithm.Initialize(context);
+
+        algorithm.Measure(context, new Size(220, 30));
+
+        Assert.Equal(105, context.GetLayoutBounds(0).Width);
+        Assert.Equal(115, context.GetLayoutBounds(1).X);
+    }
+
+    [Fact]
+    public void Center_justification_aligns_a_partial_final_line()
+    {
+        var model = new DataGridUniformGridLayoutModel
+        {
+            MinItemWidth = 100,
+            MinItemHeight = 30,
+            MaximumRowsOrColumns = 2,
+            ItemsJustification = DataGridUniformGridItemsJustification.Center
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(3, new Size(100, 30), new Rect(0, 0, 300, 60), default);
+        algorithm.Initialize(context);
+
+        algorithm.Measure(context, new Size(300, 60));
+
+        Assert.Equal(100, context.GetLayoutBounds(2).X);
+    }
+
+    [Fact]
+    public void Natural_cell_size_is_measured_when_minimums_are_unspecified()
+    {
+        var model = new DataGridUniformGridLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(10, new Size(75, 25), new Rect(0, 0, 150, 25), default);
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(150, 25));
+
+        Assert.Equal(new Size(150, 125), extent);
+        Assert.Equal(2, context.RealizedIndices.Count);
+    }
+
+    private sealed class TestContext : IDataGridLayoutContext
+    {
+        private readonly Size _itemSize;
+        private readonly List<Control> _realized = new();
+        private readonly Dictionary<int, TestControl> _elements = new();
+        private readonly Dictionary<int, Rect> _layoutBounds = new();
+
+        public TestContext(int itemCount, Size itemSize, Rect realizationRect, Vector scrollOffset)
+        {
+            ItemCount = itemCount;
+            _itemSize = itemSize;
+            RealizationRect = realizationRect;
+            ScrollOffset = scrollOffset;
+        }
+
+        public int ItemCount { get; }
+        public Rect RealizationRect { get; }
+        public Vector ScrollOffset { get; }
+        public int RecommendedAnchorIndex => -1;
+        public Point LayoutOrigin { get; set; }
+        public object? LayoutState { get; set; }
+        public IReadOnlyList<Control> RealizedElements => _realized;
+        public IReadOnlyList<int> RealizedIndices => _elements.Keys.OrderBy(index => index).ToArray();
+
+        public Control GetOrCreateElementAt(int index)
+        {
+            if (!_elements.TryGetValue(index, out TestControl? element))
+            {
+                element = new TestControl(index, _itemSize);
+                _elements.Add(index, element);
+                _realized.Add(element);
+            }
+            return element;
+        }
+
+        public void RecycleElement(Control element)
+        {
+            int index = GetElementIndex(element);
+            if (index >= 0)
+            {
+                _elements.Remove(index);
+                _layoutBounds.Remove(index);
+                _realized.Remove(element);
+            }
+        }
+
+        public int GetElementIndex(Control element) => element is TestControl test ? test.Index : -1;
+        public Size GetEstimatedItemSize(int index) => _itemSize;
+
+        public double GetEstimatedItemOffset(int index, DataGridLayoutOrientation orientation) =>
+            index * (orientation == DataGridLayoutOrientation.Vertical ? _itemSize.Height : _itemSize.Width);
+
+        public void SetLayoutBounds(int index, Rect bounds) => _layoutBounds[index] = bounds;
+        public bool TryGetLayoutBounds(int index, out Rect bounds) => _layoutBounds.TryGetValue(index, out bounds);
+        public Rect GetLayoutBounds(int index) => _layoutBounds[index];
+        public Rect GetArrangedBounds(int index) => _elements[index].Bounds;
+    }
+
+    private sealed class TestControl : Control
+    {
+        private readonly Size _size;
+
+        public TestControl(int index, Size size)
+        {
+            Index = index;
+            _size = size;
+        }
+
+        public int Index { get; }
+
+        protected override Size MeasureOverride(Size availableSize) => _size;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridUniformGridLayoutModelTests.cs
@@ -115,6 +115,34 @@ public class DataGridUniformGridLayoutModelTests
         Assert.Equal(2, context.RealizedIndices.Count);
     }
 
+    [Fact]
+    public void Navigation_follows_grid_geometry_and_reports_estimated_bounds()
+    {
+        var model = new DataGridUniformGridLayoutModel
+        {
+            MinItemWidth = 50,
+            MinItemHeight = 20
+        };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var navigation = Assert.IsAssignableFrom<IDataGridLayoutNavigation>(algorithm);
+        var context = new TestContext(100, new Size(50, 20), new Rect(0, 0, 200, 20), default);
+        algorithm.Initialize(context);
+        algorithm.Measure(context, new Size(200, 20));
+
+        Assert.True(navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(2, DataGridLayoutNavigationDirection.Down, new Rect(0, 0, 200, 20), new Point(125, 10)),
+            out DataGridLayoutNavigationResult down));
+        Assert.Equal(6, down.ItemIndex);
+        Assert.Equal(new Rect(100, 20, 50, 20), down.EstimatedBounds);
+
+        Assert.True(navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(6, DataGridLayoutNavigationDirection.LineStart, new Rect(0, 0, 200, 20), new Point(125, 30)),
+            out DataGridLayoutNavigationResult lineStart));
+        Assert.Equal(4, lineStart.ItemIndex);
+    }
+
     private sealed class TestContext : IDataGridLayoutContext
     {
         private readonly Size _itemSize;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
@@ -96,6 +96,31 @@ public class DataGridWrapLayoutModelTests
         Assert.Equal(DataGridLayoutInvalidationKind.Measure, kind);
     }
 
+    [Fact]
+    public void Navigation_uses_variable_line_geometry_and_preserves_cross_axis_anchor()
+    {
+        var model = new DataGridWrapLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var navigation = Assert.IsAssignableFrom<IDataGridLayoutNavigation>(algorithm);
+        Size[] sizes = { new(100, 20), new(40, 30), new(60, 20), new(50, 20), new(50, 20) };
+        var context = new TestContext(sizes.Length, index => sizes[index], new Rect(0, 0, 100, 100), default);
+        algorithm.Initialize(context);
+        algorithm.Measure(context, new Size(100, 100));
+
+        Assert.True(navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(0, DataGridLayoutNavigationDirection.Down, new Rect(0, 0, 100, 100), new Point(85, 10)),
+            out DataGridLayoutNavigationResult down));
+        Assert.Equal(2, down.ItemIndex);
+        Assert.Equal(context.GetLayoutBounds(2), down.EstimatedBounds);
+
+        Assert.True(navigation.TryResolveNavigation(
+            context,
+            new DataGridLayoutNavigationRequest(2, DataGridLayoutNavigationDirection.LineStart, new Rect(0, 0, 100, 100), new Point(85, 35)),
+            out DataGridLayoutNavigationResult lineStart));
+        Assert.Equal(1, lineStart.ItemIndex);
+    }
+
     private sealed class TestContext : IDataGridLayoutContext
     {
         private readonly Func<int, Size> _sizeSelector;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls.DataGridLayouts;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Layouts;
+
+public class DataGridWrapLayoutModelTests
+{
+    [Fact]
+    public void Defaults_match_items_repeater_wrap_layout()
+    {
+        var model = new DataGridWrapLayoutModel();
+
+        Assert.Equal(DataGridLayoutOrientation.Horizontal, model.Orientation);
+        Assert.Equal(0, model.HorizontalSpacing);
+        Assert.Equal(0, model.VerticalSpacing);
+        Assert.Equal(256, model.MaximumCachedLines);
+    }
+
+    [Fact]
+    public void Horizontal_flow_wraps_variable_size_items()
+    {
+        var model = new DataGridWrapLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        Size[] sizes = { new(60, 20), new(60, 30), new(40, 10) };
+        var context = new TestContext(sizes.Length, index => sizes[index], new Rect(0, 0, 100, 100), default);
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(100, 100));
+
+        Assert.Equal(new Size(100, 50), extent);
+        Assert.Equal(new Rect(0, 0, 60, 20), context.GetLayoutBounds(0));
+        Assert.Equal(new Rect(0, 20, 60, 30), context.GetLayoutBounds(1));
+        Assert.Equal(new Rect(60, 20, 40, 10), context.GetLayoutBounds(2));
+    }
+
+    [Fact]
+    public void Random_jump_realizes_only_intersecting_lines()
+    {
+        var model = new DataGridWrapLayoutModel();
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(10_000, _ => new Size(40, 20), new Rect(0, 1000, 100, 40), new Vector(0, 1000));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(100, 40));
+        algorithm.Arrange(context, new Size(100, 40));
+
+        Assert.Equal(new Size(100, 100_000), extent);
+        Assert.Equal(Enumerable.Range(100, 4), context.RealizedIndices);
+        Assert.Equal(0, context.GetArrangedBounds(100).Y);
+    }
+
+    [Fact]
+    public void Vertical_flow_wraps_into_virtualized_columns()
+    {
+        var model = new DataGridWrapLayoutModel { Orientation = DataGridLayoutOrientation.Vertical };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(100, _ => new Size(20, 40), new Rect(40, 0, 20, 100), new Vector(40, 0));
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(20, 100));
+
+        Assert.Equal(new Size(1000, 100), extent);
+        Assert.Equal(Enumerable.Range(4, 2), context.RealizedIndices);
+    }
+
+    [Fact]
+    public void Spacing_participates_in_wrap_and_extent_math()
+    {
+        var model = new DataGridWrapLayoutModel { HorizontalSpacing = 10, VerticalSpacing = 5 };
+        IDataGridLayoutAlgorithm algorithm = model.CreateAlgorithm();
+        var context = new TestContext(4, _ => new Size(45, 20), new Rect(0, 0, 100, 100), default);
+        algorithm.Initialize(context);
+
+        Size extent = algorithm.Measure(context, new Size(100, 100));
+
+        Assert.Equal(new Size(100, 45), extent);
+        Assert.Equal(55, context.GetLayoutBounds(1).X);
+        Assert.Equal(25, context.GetLayoutBounds(2).Y);
+    }
+
+    [Fact]
+    public void Model_changes_request_layout_invalidation()
+    {
+        var model = new DataGridWrapLayoutModel();
+        DataGridLayoutInvalidationKind? kind = null;
+        model.LayoutInvalidated += (_, args) => kind = args.Kind;
+
+        model.MaximumCachedLines = 32;
+
+        Assert.Equal(DataGridLayoutInvalidationKind.Measure, kind);
+    }
+
+    private sealed class TestContext : IDataGridLayoutContext
+    {
+        private readonly Func<int, Size> _sizeSelector;
+        private readonly List<Control> _realized = new();
+        private readonly Dictionary<int, TestControl> _elements = new();
+        private readonly Dictionary<int, Rect> _layoutBounds = new();
+
+        public TestContext(int itemCount, Func<int, Size> sizeSelector, Rect realizationRect, Vector scrollOffset)
+        {
+            ItemCount = itemCount;
+            _sizeSelector = sizeSelector;
+            RealizationRect = realizationRect;
+            ScrollOffset = scrollOffset;
+        }
+
+        public int ItemCount { get; }
+        public Rect RealizationRect { get; }
+        public Vector ScrollOffset { get; }
+        public int RecommendedAnchorIndex => -1;
+        public Point LayoutOrigin { get; set; }
+        public object? LayoutState { get; set; }
+        public IReadOnlyList<Control> RealizedElements => _realized;
+        public IReadOnlyList<int> RealizedIndices => _elements.Keys.OrderBy(index => index).ToArray();
+
+        public Control GetOrCreateElementAt(int index)
+        {
+            if (!_elements.TryGetValue(index, out TestControl? element))
+            {
+                element = new TestControl(index, _sizeSelector(index));
+                _elements.Add(index, element);
+                _realized.Add(element);
+            }
+            return element;
+        }
+
+        public void RecycleElement(Control element)
+        {
+            int index = GetElementIndex(element);
+            if (index >= 0)
+            {
+                _elements.Remove(index);
+                _layoutBounds.Remove(index);
+                _realized.Remove(element);
+            }
+        }
+
+        public int GetElementIndex(Control element) => element is TestControl test ? test.Index : -1;
+        public Size GetEstimatedItemSize(int index) => _sizeSelector(index);
+
+        public double GetEstimatedItemOffset(int index, DataGridLayoutOrientation orientation)
+        {
+            Size estimate = _sizeSelector(index);
+            return index * (orientation == DataGridLayoutOrientation.Vertical ? estimate.Height : estimate.Width);
+        }
+
+        public void SetLayoutBounds(int index, Rect bounds) => _layoutBounds[index] = bounds;
+        public bool TryGetLayoutBounds(int index, out Rect bounds) => _layoutBounds.TryGetValue(index, out bounds);
+        public Rect GetLayoutBounds(int index) => _layoutBounds[index];
+        public Rect GetArrangedBounds(int index) => _elements[index].Bounds;
+    }
+
+    private sealed class TestControl : Control
+    {
+        private readonly Size _size;
+
+        public TestControl(int index, Size size)
+        {
+            Index = index;
+            _size = size;
+        }
+
+        public int Index { get; }
+
+        protected override Size MeasureOverride(Size availableSize) => _size;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layouts/DataGridWrapLayoutModelTests.cs
@@ -107,6 +107,11 @@ public class DataGridWrapLayoutModelTests
         algorithm.Initialize(context);
         algorithm.Measure(context, new Size(100, 100));
 
+        Assert.All(Enum.GetValues<DataGridLayoutNavigationDirection>(), direction =>
+            Assert.True(navigation.SupportsNavigation(direction)));
+        Assert.True(navigation.TryGetNavigationBounds(context, 4, new Rect(0, 0, 100, 100), out Rect bounds));
+        Assert.Equal(context.GetLayoutBounds(4), bounds);
+
         Assert.True(navigation.TryResolveNavigation(
             context,
             new DataGridLayoutNavigationRequest(0, DataGridLayoutNavigationDirection.Down, new Rect(0, 0, 100, 100), new Point(85, 10)),

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Navigation/DataGridNavigationInputModelTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Controls.DataGridLayouts;
 using Avalonia.Controls.DataGridNavigation;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -343,6 +344,34 @@ public class DataGridNavigationInputModelTests
             Assert.Equal(1, routed.Value.Context.ItemKey);
             Assert.Equal(new DataGridNavigationPosition(1, 0), routed.Value.Context.Position);
             Assert.Equal(DataGridRouteNavigationOrigin.Keyboard, routed.Value.Context.Origin);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Normalized_Key_Uses_Active_Spatial_Layout_Navigation()
+    {
+        Window window = CreateWindow(out DataGrid grid, rowCount: 100);
+        try
+        {
+            grid.LayoutModel = new DataGridUniformGridLayoutModel
+            {
+                MinItemWidth = 100,
+                MinItemHeight = 32
+            };
+            grid.NavigationInputModel = new DataGridNavigationInputModel(
+                DataGridNavigationInputBinding.KeyDown(
+                    DataGridNavigationInputKey.J,
+                    DataGridNavigationInputResult.Navigate(DataGridNavigationCommand.Down)));
+            window.UpdateLayout();
+            SetCurrentCell(grid, 0, 0);
+
+            RaiseKeyDown(grid, Key.J);
+
+            Assert.True(grid.CurrentCell.RowIndex > 1);
         }
         finally
         {

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridAutomationPeer.cs
@@ -32,7 +32,7 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
 
     /// <inheritdoc />
     public bool CanSelectMultiple =>
-        SupportsRowSelection(Owner.SelectionUnit) &&
+        SupportsRowSelection(Owner) &&
         Owner.SelectionMode == DataGridSelectionMode.Extended;
 
     /// <inheritdoc />
@@ -41,7 +41,7 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
     /// <inheritdoc />
     public IReadOnlyList<AutomationPeer> GetSelection()
     {
-        if (!SupportsRowSelection(Owner.SelectionUnit))
+        if (!SupportsRowSelection(Owner))
         {
             ReleaseAllUnrealizedPeers();
             return Array.Empty<AutomationPeer>();
@@ -62,19 +62,25 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
                 continue;
             }
 
-            DataGridRow? row = null;
+            Control? realizedElement = null;
             int slot = Owner.SlotFromRowIndex(rowIndex);
             if (slot >= Owner.DisplayData.FirstScrollingSlot &&
                 slot <= Owner.DisplayData.LastScrollingSlot &&
                 Owner.IsSlotVisible(slot))
             {
-                row = Owner.DisplayData.GetDisplayedElement(slot) as DataGridRow;
+                realizedElement = Owner.DisplayData.GetDisplayedElement(slot);
             }
 
             selected ??= new List<AutomationPeer>(selectedIndexes.Count);
-            if (row is { IsSelected: true } && row.IsAttachedToVisualTree())
+            if (realizedElement is DataGridRow { IsSelected: true } row && row.IsAttachedToVisualTree())
             {
                 selected.Add(GetOrCreate(row));
+                continue;
+            }
+            if (realizedElement is DataGridItemContainer { IsSelected: true } itemContainer &&
+                itemContainer.IsAttachedToVisualTree())
+            {
+                selected.Add(GetOrCreate(itemContainer));
                 continue;
             }
 
@@ -101,7 +107,7 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
     protected override object? GetProviderCore(Type providerType)
     {
         if (providerType == typeof(ISelectionProvider) &&
-            !SupportsRowSelection(Owner.SelectionUnit))
+            !SupportsRowSelection(Owner))
         {
             return null;
         }
@@ -144,7 +150,7 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
         if (e.Property == DataGrid.SelectionModeProperty ||
             e.Property == DataGrid.SelectionUnitProperty)
         {
-            if (!SupportsRowSelection(Owner.SelectionUnit))
+            if (!SupportsRowSelection(Owner))
             {
                 ReleaseAllUnrealizedPeers();
             }
@@ -180,6 +186,9 @@ class DataGridAutomationPeer : ControlAutomationPeer, ISelectionProvider
             selectionUnit == DataGridSelectionUnit.CellOrRowHeader ||
             selectionUnit == DataGridSelectionUnit.CellOrRowOrColumnHeader;
     }
+
+    internal static bool SupportsRowSelection(DataGrid owner) =>
+        owner.UsesLayoutItemPresentation || SupportsRowSelection(owner.SelectionUnit);
 
     private DataGridUnrealizedRowAutomationPeer GetOrCreateUnrealizedPeer(
         object item,

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridItemContainerAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridItemContainerAutomationPeer.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using Avalonia.Automation;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.Controls.Automation.Peers;
+
+namespace Avalonia.Automation.Peers;
+
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridItemContainerAutomationPeer : ControlAutomationPeer, ISelectionItemProvider
+{
+    private readonly DataGridItemContainer _container;
+    private bool _lastIsSelected;
+
+    public DataGridItemContainerAutomationPeer(DataGridItemContainer owner)
+        : base(owner)
+    {
+        _container = owner;
+        _lastIsSelected = owner.IsSelected;
+        owner.PropertyChanged += OnContainerPropertyChanged;
+    }
+
+    /// <inheritdoc />
+    public bool IsSelected => TryGetSelectableOwner(out _) && _container.IsSelected;
+
+    /// <inheritdoc />
+    public ISelectionProvider? SelectionContainer =>
+        TryGetSelectableOwner(out DataGrid? owner)
+            ? GetOrCreate(owner!).GetProvider<ISelectionProvider>()
+            : null;
+
+    /// <inheritdoc />
+    public void AddToSelection()
+    {
+        EnsureEnabled();
+        if (TryGetSelectableOwner(out _))
+        {
+            _container.IsSelected = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public void RemoveFromSelection()
+    {
+        EnsureEnabled();
+        if (TryGetSelectableOwner(out _))
+        {
+            _container.IsSelected = false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Select()
+    {
+        EnsureEnabled();
+        if (TryGetSelectableOwner(out DataGrid? owner))
+        {
+            owner!.SelectRowFromAutomation(_container.Slot);
+        }
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.DataItem;
+
+    protected override bool IsContentElementCore() => true;
+
+    protected override bool IsControlElementCore() => true;
+
+    protected override string? GetNameCore()
+    {
+        string? name = base.GetNameCore();
+        return string.IsNullOrWhiteSpace(name) ? _container.DataContext?.ToString() : name;
+    }
+
+    protected override object? GetProviderCore(Type providerType)
+    {
+        if (providerType == typeof(ISelectionItemProvider) && !TryGetSelectableOwner(out _))
+        {
+            return null;
+        }
+
+        return base.GetProviderCore(providerType);
+    }
+
+    private bool TryGetSelectableOwner(out DataGrid? owner)
+    {
+        owner = _container.OwningGrid;
+        return owner != null && owner.UsesLayoutItemPresentation && _container.Slot >= 0;
+    }
+
+    private void OnContainerPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != DataGridItemContainer.IsSelectedProperty && e.Property != StyledElement.DataContextProperty)
+        {
+            return;
+        }
+
+        bool isSelected = IsSelected;
+        bool wasSelected = _lastIsSelected;
+        _lastIsSelected = isSelected;
+        if (wasSelected != isSelected)
+        {
+            RaisePropertyChangedEvent(SelectionItemPatternIdentifiers.IsSelectedProperty, wasSelected, isSelected);
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
@@ -217,7 +217,7 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
 
         if (providerType == typeof(ISelectionItemProvider) &&
             (!TryGetCurrentRowIndex(out _) ||
-             !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner.SelectionUnit)))
+             !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner)))
         {
             return null;
         }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.CurrentCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.CurrentCell.cs
@@ -248,6 +248,10 @@ internal
                     cell.UpdatePseudoClasses();
                 }
             }
+            else if (displayedElement is DataGridItemContainer itemContainer)
+            {
+                itemContainer.ApplyState();
+            }
             else if (displayedElement is DataGridRowGroupHeader groupHeader)
             {
                 groupHeader.UpdatePseudoClasses();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Editing.cs
@@ -148,7 +148,7 @@ internal
         /// <returns>True if operation was successful. False otherwise.</returns>
         public bool BeginEdit(RoutedEventArgs editingEventArgs)
         {
-            if (CurrentColumnIndex == -1 || !CanEditSlot(CurrentSlot))
+            if (UsesLayoutItemPresentation || CurrentColumnIndex == -1 || !CanEditSlot(CurrentSlot))
             {
                 return false;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -1416,7 +1416,7 @@ internal
         {
             using var _ = BeginSelectionChangeScope(DataGridSelectionChangeSource.Pointer, pointerPressedEventArgs);
 
-            if (SelectionUnit != DataGridSelectionUnit.FullRow && columnIndex >= 0)
+            if (!UsesLayoutItemPresentation && SelectionUnit != DataGridSelectionUnit.FullRow && columnIndex >= 0)
             {
                 return UpdateCellSelectionOnMouseLeftButtonDown(pointerPressedEventArgs, columnIndex, slot, allowEdit, shift, ctrl);
             }
@@ -1718,7 +1718,7 @@ internal
 
             Debug.Assert(slot >= 0);
 
-            if (SelectionUnit != DataGridSelectionUnit.FullRow && columnIndex >= 0)
+            if (!UsesLayoutItemPresentation && SelectionUnit != DataGridSelectionUnit.FullRow && columnIndex >= 0)
             {
                 if (CurrentSlot != slot || CurrentColumnIndex != columnIndex)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Input.cs
@@ -599,29 +599,9 @@ internal
                 return true;
             }
 
-            if (_hierarchicalRowsEnabled && _hierarchicalAdapter != null)
+            if (TryProcessHierarchyLeft(alt))
             {
-                if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Collapse, subtree: alt))
-                {
-                    return true;
-                }
-
-                if (TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex))
-                {
-                    if (alt)
-                    {
-                        var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
-                        RunHierarchicalAction(() => _hierarchicalAdapter.CollapseAll(node));
-                        return true;
-                    }
-
-                    if (_hierarchicalAdapter.IsExpandable(hierarchicalIndex) &&
-                        _hierarchicalAdapter.IsExpanded(hierarchicalIndex))
-                    {
-                        _hierarchicalAdapter.Collapse(hierarchicalIndex);
-                        return true;
-                    }
-                }
+                return true;
             }
 
             int previousVisibleColumnIndex = -1;
@@ -695,29 +675,9 @@ internal
                 return true;
             }
 
-            if (_hierarchicalRowsEnabled && _hierarchicalAdapter != null)
+            if (TryProcessHierarchyRight(alt))
             {
-                if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Expand, subtree: alt))
-                {
-                    return true;
-                }
-
-                if (TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex) &&
-                    _hierarchicalAdapter.IsExpandable(hierarchicalIndex))
-                {
-                    if (alt)
-                    {
-                        var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
-                        RunHierarchicalAction(() => _hierarchicalAdapter.ExpandAll(node));
-                        return true;
-                    }
-
-                    if (!_hierarchicalAdapter.IsExpanded(hierarchicalIndex))
-                    {
-                        _hierarchicalAdapter.Expand(hierarchicalIndex);
-                        return true;
-                    }
-                }
+                return true;
             }
 
             int nextVisibleColumnIndex = -1;
@@ -774,6 +734,74 @@ internal
                 NoSelectionChangeCount--;
             }
             return _successfullyUpdatedSelection;
+        }
+
+        private bool TryProcessHierarchyLeft(bool subtree)
+        {
+            if (!_hierarchicalRowsEnabled || _hierarchicalAdapter == null)
+            {
+                return false;
+            }
+
+            if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Collapse, subtree))
+            {
+                return true;
+            }
+
+            if (!TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex))
+            {
+                return false;
+            }
+
+            if (subtree)
+            {
+                var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
+                RunHierarchicalAction(() => _hierarchicalAdapter.CollapseAll(node));
+                return true;
+            }
+
+            if (!_hierarchicalAdapter.IsExpandable(hierarchicalIndex) ||
+                !_hierarchicalAdapter.IsExpanded(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            _hierarchicalAdapter.Collapse(hierarchicalIndex);
+            return true;
+        }
+
+        private bool TryProcessHierarchyRight(bool subtree)
+        {
+            if (!_hierarchicalRowsEnabled || _hierarchicalAdapter == null)
+            {
+                return false;
+            }
+
+            if (TryHandleGroupSlotAsNode(CurrentSlot, GroupSlotAction.Expand, subtree))
+            {
+                return true;
+            }
+
+            if (!TryGetHierarchicalIndexFromSlot(CurrentSlot, out var hierarchicalIndex) ||
+                !_hierarchicalAdapter.IsExpandable(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            if (subtree)
+            {
+                var node = _hierarchicalAdapter.NodeAt(hierarchicalIndex);
+                RunHierarchicalAction(() => _hierarchicalAdapter.ExpandAll(node));
+                return true;
+            }
+
+            if (_hierarchicalAdapter.IsExpanded(hierarchicalIndex))
+            {
+                return false;
+            }
+
+            _hierarchicalAdapter.Expand(hierarchicalIndex);
+            return true;
         }
 
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layout.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layout.cs
@@ -173,7 +173,8 @@ internal
             if (_rowsPresenter != null)
             {
                 // RowCount doesn't need to be considered, doing so might cause extra Visibility changes
-                _rowsPresenter.IsVisible = (ColumnsInternal.FirstVisibleNonFillerColumn != null);
+                _rowsPresenter.IsVisible = UsesLayoutItemPresentation ||
+                    (ColumnsInternal.FirstVisibleNonFillerColumn != null);
             }
         }
 
@@ -182,7 +183,8 @@ internal
         {
             if (_topLeftCornerHeader != null)
             {
-                _topLeftCornerHeader.IsVisible = (HeadersVisibility == DataGridHeadersVisibility.All);
+                _topLeftCornerHeader.IsVisible = !UsesLayoutItemPresentation &&
+                    (HeadersVisibility == DataGridHeadersVisibility.All);
 
                 if (_topLeftCornerHeader.IsVisible)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Controls.Templates;
+using Avalonia.Metadata;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -15,6 +17,13 @@ namespace Avalonia.Controls
     partial class DataGrid
     {
         private IDataGridLayoutModel? _layoutModel;
+        private DataGridLayoutPresentationMode _activeLayoutPresentationMode;
+
+        /// <summary>
+        /// Identifies the <see cref="ItemTemplate"/> styled property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate?> ItemTemplateProperty =
+            ItemsControl.ItemTemplateProperty.AddOwner<DataGrid>();
 
         /// <summary>
         /// Identifies the <see cref="LayoutModel"/> direct property.
@@ -52,7 +61,10 @@ namespace Avalonia.Controls
                         OnLayoutModelInvalidated);
                 }
 
+                DataGridLayoutPresentationMode oldPresentation = GetLayoutPresentationMode(oldValue);
+                DataGridLayoutPresentationMode newPresentation = GetLayoutPresentationMode(value);
                 SetAndRaise(LayoutModelProperty, ref _layoutModel, value);
+                _activeLayoutPresentationMode = newPresentation;
                 ResetLayoutNavigationAnchor();
 
                 if (value != null)
@@ -63,10 +75,35 @@ namespace Avalonia.Controls
                         OnLayoutModelInvalidated);
                 }
 
+                if (oldPresentation != newPresentation)
+                {
+                    ResetDisplayedRows();
+                    EnsureTopLeftCornerHeader();
+                    InvalidateColumnHeadersMeasure();
+                }
+
                 _rowsPresenter?.OnLayoutModelChanged(oldValue, value);
                 InvalidateMeasure();
             }
         }
+
+        /// <summary>
+        /// Gets or sets the template used to present data items when the active layout model uses
+        /// <see cref="DataGridLayoutPresentationMode.Items"/>.
+        /// </summary>
+        /// <remarks>
+        /// The explicit template is resolved before templates declared in the logical tree and the
+        /// application. Recycling templates receive the previous content root when a container is reused.
+        /// </remarks>
+        [InheritDataTypeFromItems(nameof(ItemsSource))]
+        public IDataTemplate? ItemTemplate
+        {
+            get => GetValue(ItemTemplateProperty);
+            set => SetValue(ItemTemplateProperty, value);
+        }
+
+        internal bool UsesLayoutItemPresentation =>
+            LayoutModel != null && _activeLayoutPresentationMode == DataGridLayoutPresentationMode.Items;
 
         internal int LayoutItemCount => VisibleSlotCount;
 
@@ -132,7 +169,14 @@ namespace Avalonia.Controls
                 ResetDisplayedRows();
             }
 
-            GetDisplayedSlotElementHeight(slot);
+            if (UsesLayoutItemPresentation && !IsGroupSlot(slot))
+            {
+                InsertDisplayedElement(slot, GenerateLayoutItemContainer(slot), wasNewlyAdded: false, updateSlotInformation: true);
+            }
+            else
+            {
+                GetDisplayedSlotElementHeight(slot);
+            }
             return DisplayData.GetDisplayedElement(slot);
         }
 
@@ -164,6 +208,13 @@ namespace Avalonia.Controls
                 return default;
             }
 
+            if (UsesLayoutItemPresentation && LayoutModel is IDataGridLayoutPresentationModel presentation)
+            {
+                Size estimate = presentation.ItemSizeEstimate;
+                double height = GetSlotElementHeight(slot);
+                return new Size(Math.Max(1, estimate.Width), Math.Max(1, height > 0 ? height : estimate.Height));
+            }
+
             double width = RowHeadersDesiredWidth + ColumnsInternal.VisibleEdgedColumnsWidth +
                 ColumnsInternal.FillerColumn.FillerWidth;
             return new Size(Math.Max(0, width), Math.Max(0, GetSlotElementHeight(slot)));
@@ -191,6 +242,7 @@ namespace Avalonia.Controls
             int slot = element switch
             {
                 DataGridRow row => row.Slot,
+                DataGridItemContainer item => item.Slot,
                 DataGridRowGroupHeader header => header.RowGroupInfo?.Slot ?? -1,
                 DataGridRowGroupFooter footer => footer.RowGroupInfo?.Slot ?? -1,
                 _ => -1
@@ -291,6 +343,14 @@ namespace Avalonia.Controls
             ResetLayoutNavigationAnchor();
             if (sender is IDataGridLayoutModel model)
             {
+                DataGridLayoutPresentationMode presentation = GetLayoutPresentationMode(model);
+                if (presentation != _activeLayoutPresentationMode)
+                {
+                    _activeLayoutPresentationMode = presentation;
+                    ResetDisplayedRows();
+                    EnsureTopLeftCornerHeader();
+                    InvalidateColumnHeadersMeasure();
+                }
                 _rowsPresenter?.OnLayoutModelInvalidated(model, e.Kind);
             }
 
@@ -303,6 +363,36 @@ namespace Avalonia.Controls
                 _rowsPresenter?.InvalidateMeasure();
                 InvalidateMeasure();
             }
+        }
+
+        internal bool IsLayoutItemSelected(int slot) => slot >= 0 && _selectedItems.ContainsSlot(slot);
+
+        private static DataGridLayoutPresentationMode GetLayoutPresentationMode(IDataGridLayoutModel? model) =>
+            model is IDataGridLayoutPresentationModel presentation
+                ? presentation.PresentationMode
+                : DataGridLayoutPresentationMode.Rows;
+
+        private DataGridItemContainer GenerateLayoutItemContainer(int slot)
+        {
+            int rowIndex = RowIndexFromSlot(slot);
+            object item = DataConnection.GetDataItem(rowIndex);
+            DataGridItemContainer container = DisplayData.GetRecycledItemContainer() ?? new DataGridItemContainer();
+            IDataTemplate template = this.FindDataTemplate(item, ItemTemplate) ?? FuncDataTemplate.Default;
+            container.Prepare(this, rowIndex, slot, item, template);
+            return container;
+        }
+
+        private void OnItemTemplateChanged()
+        {
+            if (!UsesLayoutItemPresentation)
+            {
+                return;
+            }
+
+            _rowsPresenter?.OnLayoutModelInvalidated(LayoutModel!, DataGridLayoutInvalidationKind.Reset);
+            ResetDisplayedRows();
+            _rowsPresenter?.InvalidateMeasure();
+            InvalidateMeasure();
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -53,6 +53,7 @@ namespace Avalonia.Controls
                 }
 
                 SetAndRaise(LayoutModelProperty, ref _layoutModel, value);
+                ResetLayoutNavigationAnchor();
 
                 if (value != null)
                 {
@@ -287,6 +288,7 @@ namespace Avalonia.Controls
 
         private void OnLayoutModelInvalidated(object? sender, DataGridLayoutInvalidatedEventArgs e)
         {
+            ResetLayoutNavigationAnchor();
             if (sender is IDataGridLayoutModel model)
             {
                 _rowsPresenter?.OnLayoutModelInvalidated(model, e.Kind);

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using Avalonia.Controls.DataGridLayouts;
+
+namespace Avalonia.Controls
+{
+    #if !DATAGRID_INTERNAL
+    public
+    #else
+    internal
+    #endif
+    partial class DataGrid
+    {
+        private IDataGridLayoutModel? _layoutModel;
+
+        /// <summary>
+        /// Identifies the <see cref="LayoutModel"/> direct property.
+        /// </summary>
+        public static readonly DirectProperty<DataGrid, IDataGridLayoutModel?> LayoutModelProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, IDataGridLayoutModel?>(
+                nameof(LayoutModel),
+                grid => grid.LayoutModel,
+                (grid, value) => grid.LayoutModel = value);
+
+        /// <summary>
+        /// Gets or sets the model that controls row realization and spatial arrangement.
+        /// </summary>
+        /// <remarks>
+        /// A <c>null</c> value uses the classic vertical list implementation. Assign any built-in
+        /// model or a user-defined <see cref="IDataGridLayoutModel"/> to enable the extensible layout
+        /// engine. Layout algorithm state is retained per model instance for fast runtime switching.
+        /// </remarks>
+        public IDataGridLayoutModel? LayoutModel
+        {
+            get => _layoutModel;
+            set
+            {
+                if (ReferenceEquals(_layoutModel, value))
+                {
+                    return;
+                }
+
+                IDataGridLayoutModel? oldValue = _layoutModel;
+                if (oldValue != null)
+                {
+                    oldValue.LayoutInvalidated -= OnLayoutModelInvalidated;
+                }
+
+                SetAndRaise(LayoutModelProperty, ref _layoutModel, value);
+
+                if (value != null)
+                {
+                    value.LayoutInvalidated += OnLayoutModelInvalidated;
+                }
+
+                _rowsPresenter?.OnLayoutModelChanged(oldValue, value);
+                InvalidateMeasure();
+            }
+        }
+
+        internal int LayoutItemCount => VisibleSlotCount;
+
+        internal int GetLayoutSlot(int layoutIndex)
+        {
+            if (layoutIndex < 0 || layoutIndex >= VisibleSlotCount)
+            {
+                return -1;
+            }
+
+            if (_collapsedSlotsTable.IsEmpty)
+            {
+                return layoutIndex;
+            }
+
+            int low = layoutIndex;
+            int high = SlotCount - 1;
+            while (low < high)
+            {
+                int middle = low + ((high - low) / 2);
+                int visibleThroughMiddle = middle + 1 - _collapsedSlotsTable.GetIndexCount(0, middle);
+                if (visibleThroughMiddle <= layoutIndex)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+
+            return _collapsedSlotsTable.Contains(low) ? GetNextVisibleSlot(low) : low;
+        }
+
+        internal int GetLayoutIndexFromSlot(int slot)
+        {
+            if (slot < 0 || slot >= SlotCount || _collapsedSlotsTable.Contains(slot))
+            {
+                return -1;
+            }
+
+            return slot - _collapsedSlotsTable.GetIndexCount(0, slot);
+        }
+
+        internal Control GetOrCreateLayoutElement(int layoutIndex)
+        {
+            int slot = GetLayoutSlot(layoutIndex);
+            if (slot < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(layoutIndex));
+            }
+
+            if (IsSlotVisible(slot))
+            {
+                return DisplayData.GetDisplayedElement(slot);
+            }
+
+            bool isAdjacent = DisplayData.FirstScrollingSlot == -1 ||
+                slot == GetPreviousVisibleSlot(DisplayData.FirstScrollingSlot) ||
+                slot == GetNextVisibleSlot(DisplayData.LastScrollingSlot);
+            if (!isAdjacent)
+            {
+                ResetDisplayedRows();
+            }
+
+            GetDisplayedSlotElementHeight(slot);
+            return DisplayData.GetDisplayedElement(slot);
+        }
+
+        internal void CompleteLayoutRealization(int firstLayoutIndex, int lastLayoutIndex)
+        {
+            if (firstLayoutIndex < 0 || lastLayoutIndex < firstLayoutIndex)
+            {
+                ResetDisplayedRows();
+                return;
+            }
+
+            int firstSlot = GetLayoutSlot(firstLayoutIndex);
+            int lastSlot = GetLayoutSlot(lastLayoutIndex);
+            if (firstSlot < 0 || lastSlot < firstSlot)
+            {
+                ResetDisplayedRows();
+                return;
+            }
+
+            RemoveNonDisplayedRows(firstSlot, lastSlot);
+            DisplayData.NumTotallyDisplayedScrollingElements = DisplayData.NumDisplayedScrollingElements;
+        }
+
+        internal Size GetEstimatedLayoutItemSize(int layoutIndex)
+        {
+            int slot = GetLayoutSlot(layoutIndex);
+            if (slot < 0)
+            {
+                return default;
+            }
+
+            double width = RowHeadersDesiredWidth + ColumnsInternal.VisibleEdgedColumnsWidth +
+                ColumnsInternal.FillerColumn.FillerWidth;
+            return new Size(Math.Max(0, width), Math.Max(0, GetSlotElementHeight(slot)));
+        }
+
+        internal double GetEstimatedLayoutItemOffset(int layoutIndex, DataGridLayoutOrientation orientation)
+        {
+            if (layoutIndex <= 0)
+            {
+                return 0;
+            }
+
+            if (orientation == DataGridLayoutOrientation.Horizontal)
+            {
+                return layoutIndex * Math.Max(0, GetEstimatedLayoutItemSize(Math.Min(layoutIndex - 1, VisibleSlotCount - 1)).Width);
+            }
+
+            int slot = layoutIndex >= VisibleSlotCount ? SlotCount : GetLayoutSlot(layoutIndex);
+            EnsureScrollHeightIndex(refreshEstimatorChanges: false);
+            return Math.Max(0, _scrollHeightIndex.GetOffsetToSlot(Math.Max(0, slot)));
+        }
+
+        internal int GetLayoutIndex(Control element)
+        {
+            int slot = element switch
+            {
+                DataGridRow row => row.Slot,
+                DataGridRowGroupHeader header => header.RowGroupInfo?.Slot ?? -1,
+                DataGridRowGroupFooter footer => footer.RowGroupInfo?.Slot ?? -1,
+                _ => -1
+            };
+            return GetLayoutIndexFromSlot(slot);
+        }
+
+        private void OnLayoutModelInvalidated(object? sender, DataGridLayoutInvalidatedEventArgs e)
+        {
+            if (sender is IDataGridLayoutModel model)
+            {
+                _rowsPresenter?.OnLayoutModelInvalidated(model, e.Kind);
+            }
+
+            if (e.Kind == DataGridLayoutInvalidationKind.Arrange)
+            {
+                _rowsPresenter?.InvalidateArrange();
+            }
+            else
+            {
+                _rowsPresenter?.InvalidateMeasure();
+                InvalidateMeasure();
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -256,6 +256,22 @@ namespace Avalonia.Controls
             return false;
         }
 
+        internal bool SupportsLayoutNavigation(DataGridLayoutNavigationDirection direction) =>
+            _rowsPresenter?.SupportsLayoutNavigation(direction) == true;
+
+        internal bool TryGetLayoutNavigationBounds(int currentRowIndex, out Rect bounds)
+        {
+            bounds = default;
+            if (_rowsPresenter == null || currentRowIndex < 0)
+            {
+                return false;
+            }
+
+            int slot = SlotFromRowIndex(currentRowIndex);
+            int layoutIndex = GetLayoutIndexFromSlot(slot);
+            return layoutIndex >= 0 && _rowsPresenter.TryGetLayoutNavigationBounds(layoutIndex, out bounds);
+        }
+
         private static int GetNavigationScanStep(
             DataGridLayoutNavigationDirection direction,
             int currentLayoutIndex,

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -211,8 +211,15 @@ namespace Avalonia.Controls
             if (UsesLayoutItemPresentation && LayoutModel is IDataGridLayoutPresentationModel presentation)
             {
                 Size estimate = presentation.ItemSizeEstimate;
-                double height = GetSlotElementHeight(slot);
-                return new Size(Math.Max(1, estimate.Width), Math.Max(1, height > 0 ? height : estimate.Height));
+                if (IsSlotVisible(slot))
+                {
+                    Size desired = DisplayData.GetDisplayedElement(slot).DesiredSize;
+                    return new Size(
+                        Math.Max(1, desired.Width > 0 ? desired.Width : estimate.Width),
+                        Math.Max(1, desired.Height > 0 ? desired.Height : estimate.Height));
+                }
+
+                return new Size(Math.Max(1, estimate.Width), Math.Max(1, estimate.Height));
             }
 
             double width = RowHeadersDesiredWidth + ColumnsInternal.VisibleEdgedColumnsWidth +

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Layouts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Utilities;
 
 namespace Avalonia.Controls
 {
@@ -45,14 +46,20 @@ namespace Avalonia.Controls
                 IDataGridLayoutModel? oldValue = _layoutModel;
                 if (oldValue != null)
                 {
-                    oldValue.LayoutInvalidated -= OnLayoutModelInvalidated;
+                    WeakEventHandlerManager.Unsubscribe<DataGridLayoutInvalidatedEventArgs, DataGrid>(
+                        oldValue,
+                        nameof(IDataGridLayoutModel.LayoutInvalidated),
+                        OnLayoutModelInvalidated);
                 }
 
                 SetAndRaise(LayoutModelProperty, ref _layoutModel, value);
 
                 if (value != null)
                 {
-                    value.LayoutInvalidated += OnLayoutModelInvalidated;
+                    WeakEventHandlerManager.Subscribe<IDataGridLayoutModel, DataGridLayoutInvalidatedEventArgs, DataGrid>(
+                        value,
+                        nameof(IDataGridLayoutModel.LayoutInvalidated),
+                        OnLayoutModelInvalidated);
                 }
 
                 _rowsPresenter?.OnLayoutModelChanged(oldValue, value);
@@ -188,6 +195,78 @@ namespace Avalonia.Controls
                 _ => -1
             };
             return GetLayoutIndexFromSlot(slot);
+        }
+
+        internal bool TryResolveLayoutNavigation(
+            int currentRowIndex,
+            DataGridLayoutNavigationDirection direction,
+            Point navigationAnchor,
+            out int targetRowIndex,
+            out Rect estimatedBounds)
+        {
+            targetRowIndex = -1;
+            estimatedBounds = default;
+            if (_rowsPresenter == null || LayoutModel == null || currentRowIndex < 0)
+            {
+                return false;
+            }
+
+            int currentSlot = SlotFromRowIndex(currentRowIndex);
+            int currentLayoutIndex = GetLayoutIndexFromSlot(currentSlot);
+            if (currentLayoutIndex < 0)
+            {
+                return false;
+            }
+
+            Rect viewport = new(
+                _rowsPresenter.Offset.X,
+                _rowsPresenter.Offset.Y,
+                _rowsPresenter.Viewport.Width,
+                _rowsPresenter.Viewport.Height);
+            DataGridLayoutNavigationRequest request = new(
+                currentLayoutIndex,
+                direction,
+                viewport,
+                navigationAnchor);
+            if (!_rowsPresenter.TryResolveLayoutNavigation(request, out DataGridLayoutNavigationResult result))
+            {
+                return false;
+            }
+
+            int targetLayoutIndex = result.ItemIndex;
+            int scanStep = GetNavigationScanStep(direction, currentLayoutIndex, targetLayoutIndex);
+            while (targetLayoutIndex >= 0 && targetLayoutIndex < LayoutItemCount)
+            {
+                int targetSlot = GetLayoutSlot(targetLayoutIndex);
+                int rowIndex = targetSlot >= 0 && !IsGroupSlot(targetSlot)
+                    ? RowIndexFromSlot(targetSlot)
+                    : -1;
+                if (rowIndex >= 0)
+                {
+                    targetRowIndex = rowIndex;
+                    estimatedBounds = _rowsPresenter.TryGetLayoutBounds(targetLayoutIndex, out Rect exactBounds)
+                        ? exactBounds
+                        : result.EstimatedBounds;
+                    return targetRowIndex != currentRowIndex;
+                }
+
+                targetLayoutIndex += scanStep;
+            }
+
+            return false;
+        }
+
+        private static int GetNavigationScanStep(
+            DataGridLayoutNavigationDirection direction,
+            int currentLayoutIndex,
+            int targetLayoutIndex)
+        {
+            return direction switch
+            {
+                DataGridLayoutNavigationDirection.First or DataGridLayoutNavigationDirection.LineStart => 1,
+                DataGridLayoutNavigationDirection.Last or DataGridLayoutNavigationDirection.LineEnd => -1,
+                _ => targetLayoutIndex >= currentLayoutIndex ? 1 : -1
+            };
         }
 
         private void OnLayoutModelInvalidated(object? sender, DataGridLayoutInvalidatedEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -264,7 +264,8 @@ namespace Avalonia.Controls
                 lastRowIndex >= 0 ? 0 : -1,
                 lastRowIndex,
                 firstColumn?.DisplayIndex ?? -1,
-                lastColumn?.DisplayIndex ?? -1);
+                lastColumn?.DisplayIndex ?? -1,
+                layoutPlan.IsOwned);
         }
 
         private LayoutNavigationPlan CreateLayoutNavigationPlan(

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -130,7 +130,26 @@ namespace Avalonia.Controls
             switch (result.Decision)
             {
                 case DataGridNavigationDecision.Move:
-                    handled = TryApplyNavigationTarget(result.Target, modifiers);
+                    if (TryCreateSpatialBoundaryWrapPlan(
+                        command,
+                        modifiers,
+                        request,
+                        result,
+                        layoutPlan,
+                        out DataGridNavigationCommand wrapCommand,
+                        out LayoutNavigationPlan wrapPlan))
+                    {
+                        handled = ExecuteDefaultNavigation(
+                            wrapCommand,
+                            keyEventArgs,
+                            modifiers,
+                            allowCtrlForTab,
+                            wrapPlan);
+                    }
+                    else
+                    {
+                        handled = TryApplyNavigationTarget(result.Target, modifiers);
+                    }
                     if (!handled)
                     {
                         failureReason = DataGridNavigationFailureReason.InvalidTarget;
@@ -264,9 +283,70 @@ namespace Avalonia.Controls
                 lastRowIndex >= 0 ? 0 : -1,
                 lastRowIndex,
                 firstColumn?.DisplayIndex ?? -1,
-                lastColumn?.DisplayIndex ?? -1,
-                layoutPlan.IsOwned);
+                lastColumn?.DisplayIndex ?? -1);
         }
+
+        private bool TryCreateSpatialBoundaryWrapPlan(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers,
+            DataGridNavigationRequest request,
+            DataGridNavigationResult result,
+            LayoutNavigationPlan layoutPlan,
+            out DataGridNavigationCommand wrapCommand,
+            out LayoutNavigationPlan wrapPlan)
+        {
+            wrapCommand = DataGridNavigationCommand.None;
+            wrapPlan = default;
+            if (!layoutPlan.IsOwned || layoutPlan.HasTarget ||
+                NavigationModel is not DataGridNavigationModel policy ||
+                !TryGetSpatialBoundaryWrapCommand(command, policy, out wrapCommand) ||
+                result.Target != GetLegacyBoundaryWrapTarget(command, request))
+            {
+                return false;
+            }
+
+            wrapPlan = CreateLayoutNavigationPlan(wrapCommand, modifiers, request.CurrentPosition);
+            return wrapPlan.IsOwned;
+        }
+
+        private static bool TryGetSpatialBoundaryWrapCommand(
+            DataGridNavigationCommand command,
+            DataGridNavigationModel policy,
+            out DataGridNavigationCommand wrapCommand)
+        {
+            wrapCommand = command switch
+            {
+                DataGridNavigationCommand.Left when
+                    policy.HorizontalBoundaryMode == DataGridNavigationBoundaryMode.Wrap => DataGridNavigationCommand.RowEnd,
+                DataGridNavigationCommand.Right when
+                    policy.HorizontalBoundaryMode == DataGridNavigationBoundaryMode.Wrap => DataGridNavigationCommand.RowStart,
+                DataGridNavigationCommand.Up when
+                    policy.VerticalBoundaryMode == DataGridNavigationBoundaryMode.Wrap => DataGridNavigationCommand.ColumnEnd,
+                DataGridNavigationCommand.Down when
+                    policy.VerticalBoundaryMode == DataGridNavigationBoundaryMode.Wrap => DataGridNavigationCommand.ColumnStart,
+                _ => DataGridNavigationCommand.None
+            };
+            return wrapCommand != DataGridNavigationCommand.None;
+        }
+
+        private static DataGridNavigationPosition GetLegacyBoundaryWrapTarget(
+            DataGridNavigationCommand command,
+            DataGridNavigationRequest request) => command switch
+            {
+                DataGridNavigationCommand.Left => new DataGridNavigationPosition(
+                    request.CurrentPosition.RowIndex,
+                    request.LastColumnDisplayIndex),
+                DataGridNavigationCommand.Right => new DataGridNavigationPosition(
+                    request.CurrentPosition.RowIndex,
+                    request.FirstColumnDisplayIndex),
+                DataGridNavigationCommand.Up => new DataGridNavigationPosition(
+                    request.LastRowIndex,
+                    request.CurrentPosition.ColumnDisplayIndex),
+                DataGridNavigationCommand.Down => new DataGridNavigationPosition(
+                    request.FirstRowIndex,
+                    request.CurrentPosition.ColumnDisplayIndex),
+                _ => DataGridNavigationPosition.Unset
+            };
 
         private LayoutNavigationPlan CreateLayoutNavigationPlan(
             DataGridNavigationCommand command,

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.Model.cs
@@ -3,7 +3,9 @@
 
 #nullable disable
 
+using System;
 using Avalonia.Controls.DataGridNavigation;
+using Avalonia.Controls.DataGridLayouts;
 using Avalonia.Controls.Utils;
 using Avalonia.Input;
 
@@ -11,6 +13,12 @@ namespace Avalonia.Controls
 {
     partial class DataGrid
     {
+        private Point _layoutNavigationAnchor;
+        private bool _layoutNavigationAnchorValid;
+        private int _layoutNavigationAnchorRowIndex = -1;
+        private object _layoutNavigationAnchorItem;
+        private IDataGridLayoutModel _layoutNavigationAnchorModel;
+
         /// <summary>
         /// Attempts to execute a semantic navigation command through the current <see cref="NavigationModel"/>.
         /// </summary>
@@ -70,7 +78,8 @@ namespace Avalonia.Controls
             DataGridNavigationRequest request = CreateNavigationRequest(
                 command,
                 DataGridNavigationOrigin.Programmatic,
-                modifiers);
+                modifiers,
+                out LayoutNavigationPlan layoutPlan);
             if (NavigationModel is not IDataGridNavigationQueryModel queryModel)
             {
                 return request.ProposedPosition.HasValue || CanExecuteNavigationWithoutTarget(command);
@@ -83,7 +92,9 @@ namespace Avalonia.Controls
                 DataGridNavigationDecision.Redirect => result.RedirectedCommand != DataGridNavigationCommand.None,
                 DataGridNavigationDecision.Stay => false,
                 DataGridNavigationDecision.LeaveGrid => false,
-                _ => request.ProposedPosition.HasValue || CanExecuteNavigationWithoutTarget(command)
+                _ => layoutPlan.IsOwned
+                    ? layoutPlan.HasTarget
+                    : request.ProposedPosition.HasValue || CanExecuteNavigationWithoutTarget(command)
             };
         }
 
@@ -109,6 +120,7 @@ namespace Avalonia.Controls
                 command,
                 origin,
                 modifiers,
+                out LayoutNavigationPlan layoutPlan,
                 proposedPosition);
             DataGridNavigationPosition oldPosition = request.CurrentPosition;
             DataGridNavigationResult result = NavigationModel.Resolve(request);
@@ -126,8 +138,20 @@ namespace Avalonia.Controls
                     break;
 
                 case DataGridNavigationDecision.Redirect:
-                    handled = result.RedirectedCommand != DataGridNavigationCommand.None &&
-                        ExecuteDefaultNavigation(result.RedirectedCommand, keyEventArgs, modifiers, allowCtrlForTab);
+                    if (result.RedirectedCommand != DataGridNavigationCommand.None)
+                    {
+                        CreateNavigationRequest(result.RedirectedCommand, origin, modifiers, out LayoutNavigationPlan redirectedLayoutPlan);
+                        handled = ExecuteDefaultNavigation(
+                            result.RedirectedCommand,
+                            keyEventArgs,
+                            modifiers,
+                            allowCtrlForTab,
+                            redirectedLayoutPlan);
+                    }
+                    else
+                    {
+                        handled = false;
+                    }
                     if (!handled)
                     {
                         failureReason = DataGridNavigationFailureReason.BoundaryReached;
@@ -147,7 +171,7 @@ namespace Avalonia.Controls
                     break;
 
                 default:
-                    handled = ExecuteDefaultNavigation(command, keyEventArgs, modifiers, allowCtrlForTab);
+                    handled = ExecuteDefaultNavigation(command, keyEventArgs, modifiers, allowCtrlForTab, layoutPlan);
                     if (!handled && !CreateNavigationPosition().IsValid)
                     {
                         failureReason = ResolveUnavailableNavigationReason();
@@ -174,9 +198,15 @@ namespace Avalonia.Controls
             DataGridNavigationCommand command,
             KeyEventArgs keyEventArgs,
             KeyModifiers modifiers,
-            bool allowCtrlForTab)
+            bool allowCtrlForTab,
+            LayoutNavigationPlan layoutPlan)
         {
             KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out bool shift, out bool alt);
+            if (layoutPlan.IsOwned)
+            {
+                return ExecuteLayoutNavigation(command, keyEventArgs, modifiers, allowCtrlForTab, alt, layoutPlan);
+            }
+
             return command switch
             {
                 DataGridNavigationCommand.Up => ProcessUpKey(shift, ctrl),
@@ -207,11 +237,14 @@ namespace Avalonia.Controls
             DataGridNavigationCommand command,
             DataGridNavigationOrigin origin,
             KeyModifiers modifiers,
+            out LayoutNavigationPlan layoutPlan,
             DataGridNavigationPosition? proposedPosition = null)
         {
             DataGridNavigationPosition current = CreateNavigationPosition();
-            DataGridNavigationPosition? proposed = proposedPosition ??
-                (TryGetProposedNavigationPosition(command, modifiers, out DataGridNavigationPosition target)
+            layoutPlan = CreateLayoutNavigationPlan(command, modifiers, current);
+            DataGridNavigationPosition? proposed = proposedPosition ?? (layoutPlan.IsOwned
+                ? layoutPlan.HasTarget ? layoutPlan.Target : null
+                : TryGetProposedNavigationPosition(command, modifiers, out DataGridNavigationPosition target)
                     ? target
                     : null);
             DataGridColumn firstColumn = ColumnsInternal.FirstVisibleNonFillerColumn;
@@ -233,6 +266,166 @@ namespace Avalonia.Controls
                 firstColumn?.DisplayIndex ?? -1,
                 lastColumn?.DisplayIndex ?? -1);
         }
+
+        private LayoutNavigationPlan CreateLayoutNavigationPlan(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers,
+            DataGridNavigationPosition current)
+        {
+            if (LayoutModel == null || !current.IsValid || CurrentColumn == null ||
+                !TryMapLayoutNavigationDirection(command, modifiers, out DataGridLayoutNavigationDirection direction) ||
+                !SupportsLayoutNavigation(direction))
+            {
+                return default;
+            }
+
+            TryGetLayoutNavigationBounds(current.RowIndex, out Rect sourceBounds);
+            Point anchor = GetLayoutNavigationAnchor(current.RowIndex, sourceBounds);
+            bool hasTarget = TryResolveLayoutNavigation(
+                current.RowIndex,
+                direction,
+                anchor,
+                out int targetRowIndex,
+                out Rect estimatedBounds);
+            DataGridColumn targetColumn = command switch
+            {
+                DataGridNavigationCommand.GridStart => ColumnsInternal.FirstVisibleNonFillerColumn,
+                DataGridNavigationCommand.GridEnd => GetLastVisibleNonFillerNavigationColumn(),
+                _ => CurrentColumn
+            };
+            DataGridNavigationPosition target = hasTarget && targetColumn != null
+                ? new DataGridNavigationPosition(targetRowIndex, targetColumn.DisplayIndex)
+                : DataGridNavigationPosition.Unset;
+            return new LayoutNavigationPlan(
+                direction,
+                target,
+                sourceBounds,
+                estimatedBounds,
+                anchor,
+                hasTarget && target.IsValid);
+        }
+
+        private static bool TryMapLayoutNavigationDirection(
+            DataGridNavigationCommand command,
+            KeyModifiers modifiers,
+            out DataGridLayoutNavigationDirection direction)
+        {
+            bool edge = (modifiers & (KeyModifiers.Control | KeyModifiers.Meta)) != 0;
+            direction = command switch
+            {
+                DataGridNavigationCommand.Up => edge ? DataGridLayoutNavigationDirection.First : DataGridLayoutNavigationDirection.Up,
+                DataGridNavigationCommand.Down => edge ? DataGridLayoutNavigationDirection.Last : DataGridLayoutNavigationDirection.Down,
+                DataGridNavigationCommand.Left => edge ? DataGridLayoutNavigationDirection.LineStart : DataGridLayoutNavigationDirection.Left,
+                DataGridNavigationCommand.Right => edge ? DataGridLayoutNavigationDirection.LineEnd : DataGridLayoutNavigationDirection.Right,
+                DataGridNavigationCommand.PageUp => DataGridLayoutNavigationDirection.PageUp,
+                DataGridNavigationCommand.PageDown => DataGridLayoutNavigationDirection.PageDown,
+                DataGridNavigationCommand.RowStart => DataGridLayoutNavigationDirection.LineStart,
+                DataGridNavigationCommand.RowEnd => DataGridLayoutNavigationDirection.LineEnd,
+                DataGridNavigationCommand.ColumnStart or DataGridNavigationCommand.GridStart => DataGridLayoutNavigationDirection.First,
+                DataGridNavigationCommand.ColumnEnd or DataGridNavigationCommand.GridEnd => DataGridLayoutNavigationDirection.Last,
+                _ => default
+            };
+            return command is DataGridNavigationCommand.Up or DataGridNavigationCommand.Down or
+                DataGridNavigationCommand.Left or DataGridNavigationCommand.Right or
+                DataGridNavigationCommand.PageUp or DataGridNavigationCommand.PageDown or
+                DataGridNavigationCommand.RowStart or DataGridNavigationCommand.RowEnd or
+                DataGridNavigationCommand.ColumnStart or DataGridNavigationCommand.ColumnEnd or
+                DataGridNavigationCommand.GridStart or DataGridNavigationCommand.GridEnd;
+        }
+
+        private bool ExecuteLayoutNavigation(
+            DataGridNavigationCommand command,
+            KeyEventArgs keyEventArgs,
+            KeyModifiers modifiers,
+            bool allowCtrlForTab,
+            bool alt,
+            LayoutNavigationPlan plan)
+        {
+            if (WaitForLostFocus(() => ExecuteDefaultNavigationWithFreshLayoutPlan(
+                command,
+                keyEventArgs,
+                modifiers,
+                allowCtrlForTab)))
+            {
+                return true;
+            }
+
+            if ((command == DataGridNavigationCommand.Left && TryProcessHierarchyLeft(alt)) ||
+                (command == DataGridNavigationCommand.Right && TryProcessHierarchyRight(alt)))
+            {
+                return true;
+            }
+
+            if (!plan.HasTarget || !TryApplyNavigationTarget(plan.Target, modifiers))
+            {
+                return false;
+            }
+
+            UpdateLayoutNavigationAnchor(plan);
+            return true;
+        }
+
+        private void ExecuteDefaultNavigationWithFreshLayoutPlan(
+            DataGridNavigationCommand command,
+            KeyEventArgs keyEventArgs,
+            KeyModifiers modifiers,
+            bool allowCtrlForTab)
+        {
+            DataGridNavigationPosition current = CreateNavigationPosition();
+            LayoutNavigationPlan plan = CreateLayoutNavigationPlan(command, modifiers, current);
+            ExecuteDefaultNavigation(command, keyEventArgs, modifiers, allowCtrlForTab, plan);
+        }
+
+        private Point GetLayoutNavigationAnchor(int currentRowIndex, Rect sourceBounds)
+        {
+            if (_layoutNavigationAnchorValid &&
+                _layoutNavigationAnchorRowIndex == currentRowIndex &&
+                ReferenceEquals(_layoutNavigationAnchorItem, CurrentItem) &&
+                ReferenceEquals(_layoutNavigationAnchorModel, LayoutModel))
+            {
+                return _layoutNavigationAnchor;
+            }
+
+            return GetBoundsCenter(sourceBounds);
+        }
+
+        private void UpdateLayoutNavigationAnchor(LayoutNavigationPlan plan)
+        {
+            Rect targetBounds = TryGetLayoutNavigationBounds(plan.Target.RowIndex, out Rect actualBounds)
+                ? actualBounds
+                : plan.EstimatedBounds;
+            Point targetCenter = GetBoundsCenter(targetBounds);
+            Point sourceCenter = GetBoundsCenter(plan.SourceBounds);
+            _layoutNavigationAnchor = plan.Direction switch
+            {
+                DataGridLayoutNavigationDirection.Up or DataGridLayoutNavigationDirection.Down =>
+                    new Point(plan.Anchor.X, targetCenter.Y),
+                DataGridLayoutNavigationDirection.Left or DataGridLayoutNavigationDirection.Right =>
+                    new Point(targetCenter.X, plan.Anchor.Y),
+                DataGridLayoutNavigationDirection.PageUp or DataGridLayoutNavigationDirection.PageDown
+                    when Math.Abs(targetCenter.X - sourceCenter.X) > Math.Abs(targetCenter.Y - sourceCenter.Y) =>
+                    new Point(targetCenter.X, plan.Anchor.Y),
+                DataGridLayoutNavigationDirection.PageUp or DataGridLayoutNavigationDirection.PageDown =>
+                    new Point(plan.Anchor.X, targetCenter.Y),
+                _ => targetCenter
+            };
+            _layoutNavigationAnchorValid = true;
+            _layoutNavigationAnchorRowIndex = plan.Target.RowIndex;
+            _layoutNavigationAnchorItem = CurrentItem;
+            _layoutNavigationAnchorModel = LayoutModel;
+        }
+
+        private void ResetLayoutNavigationAnchor()
+        {
+            _layoutNavigationAnchor = default;
+            _layoutNavigationAnchorValid = false;
+            _layoutNavigationAnchorRowIndex = -1;
+            _layoutNavigationAnchorItem = null;
+            _layoutNavigationAnchorModel = null;
+        }
+
+        private static Point GetBoundsCenter(Rect bounds) =>
+            new(bounds.X + (bounds.Width / 2), bounds.Y + (bounds.Height / 2));
 
         private DataGridNavigationPosition CreateNavigationPosition()
         {
@@ -472,6 +665,34 @@ namespace Avalonia.Controls
             }
 
             return DataGridNavigationFailureReason.NoCurrentCell;
+        }
+
+        private readonly struct LayoutNavigationPlan
+        {
+            public LayoutNavigationPlan(
+                DataGridLayoutNavigationDirection direction,
+                DataGridNavigationPosition target,
+                Rect sourceBounds,
+                Rect estimatedBounds,
+                Point anchor,
+                bool hasTarget)
+            {
+                Direction = direction;
+                Target = target;
+                SourceBounds = sourceBounds;
+                EstimatedBounds = estimatedBounds;
+                Anchor = anchor;
+                HasTarget = hasTarget;
+                IsOwned = true;
+            }
+
+            public bool IsOwned { get; }
+            public bool HasTarget { get; }
+            public DataGridLayoutNavigationDirection Direction { get; }
+            public DataGridNavigationPosition Target { get; }
+            public Rect SourceBounds { get; }
+            public Rect EstimatedBounds { get; }
+            public Point Anchor { get; }
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Navigation.cs
@@ -164,6 +164,11 @@ internal
                 }
             }
 
+            if (LayoutModel != null && _rowsPresenter != null)
+            {
+                return _rowsPresenter.ScrollLayoutIndexIntoView(GetLayoutIndexFromSlot(slot));
+            }
+
             double oldHorizontalOffset = HorizontalOffset;
 
             //scroll horizontally unless we're on a RowGroupHeader and we're not forcing horizontal scrolling

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Display.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Display.cs
@@ -399,6 +399,17 @@ namespace Avalonia.Controls
                     dataGridRow.Clip = new RectangleGeometry();
                 }
             }
+            else if (element is DataGridItemContainer itemContainer)
+            {
+                if (itemContainer.IsKeyboardFocusWithin || CurrentSlot == slot)
+                {
+                    Focus(NavigationMethod.Unspecified, KeyModifiers.None);
+                    RequestFocusAfterRowRecycle();
+                }
+
+                HideRecycledElement(itemContainer);
+                DisplayData.RecycleItemContainer(itemContainer);
+            }
             else if (element is DataGridRowGroupHeader groupHeader)
             {
                 OnUnloadingRowGroup(new DataGridRowGroupHeaderEventArgs(groupHeader));
@@ -499,6 +510,13 @@ namespace Avalonia.Controls
 
                 HideRecycledElement(row);
                 return false;
+            }
+
+            if (element is DataGridItemContainer itemContainer)
+            {
+                HideRecycledElement(itemContainer);
+                DisplayData.RecycleItemContainer(itemContainer);
+                return true;
             }
 
             if (element is DataGridRowGroupHeader groupHeader)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Generation.cs
@@ -269,6 +269,10 @@ namespace Avalonia.Controls
             {
                 slotElement = GenerateRowGroupFooter(slot, rowGroupInfo: RowGroupFootersTable.GetValueAt(slot));
             }
+            else if (UsesLayoutItemPresentation)
+            {
+                slotElement = GenerateLayoutItemContainer(slot);
+            }
             else
             {
                 // If we're grouping, the GroupLevel needs to be fixed later by methods calling this
@@ -292,6 +296,7 @@ namespace Avalonia.Controls
             Debug.Assert(element != null);
 
             DataGridRow row = null;
+            DataGridItemContainer itemContainer = null;
             DataGridRowGroupHeader groupHeader = null;
             DataGridRowGroupFooter groupFooter = null;
             double elementHeight = 0;
@@ -315,6 +320,13 @@ namespace Avalonia.Controls
                         {
                             element.Clip = null;
                             Debug.Assert(row.Index == RowIndexFromSlot(slot));
+                        }
+                    }
+                    else if ((itemContainer = element as DataGridItemContainer) != null)
+                    {
+                        if (!ReferenceEquals(itemContainer.Parent, _rowsPresenter))
+                        {
+                            _rowsPresenter.Children.Add(itemContainer);
                         }
                     }
                     else
@@ -351,6 +363,10 @@ namespace Avalonia.Controls
                     if (row != null)
                     {
                         _rowsPresenter.RegisterAnchorCandidate(row);
+                    }
+                    else if (itemContainer != null)
+                    {
+                        _rowsPresenter.RegisterAnchorCandidate(itemContainer);
                     }
                     else if (groupHeader != null)
                     {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Lifecycle.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Lifecycle.cs
@@ -520,6 +520,7 @@ namespace Avalonia.Controls
             for (int i = _rowsPresenter.Children.Count - 1; i >= 0; i--)
             {
                 if (_rowsPresenter.Children[i] is DataGridRow
+                    or DataGridItemContainer
                     or DataGridRowGroupHeader
                     or DataGridRowGroupFooter)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.Selection.cs
@@ -28,6 +28,10 @@ namespace Avalonia.Controls
                 row.ApplyCellsState();
                 EnsureRowDetailsVisibility(row, raiseNotification: true, animate: true, isSelectedOverride: isSelectedOverride);
             }
+            else if (element is DataGridItemContainer itemContainer)
+            {
+                itemContainer.ApplyState(isSelectedOverride);
+            }
             else
             {
                 // Assume it's a RowGroupHeader
@@ -124,12 +128,16 @@ namespace Avalonia.Controls
                     slot > -1 && slot <= DisplayData.LastScrollingSlot;
                     slot++)
                     {
-                        if (DisplayData.GetDisplayedElement(slot) is DataGridRow row)
+                        Control element = DisplayData.GetDisplayedElement(slot);
+                        int selectedSlot = element switch
                         {
-                            if (_selectedItems.ContainsSlot(row.Slot))
-                            {
-                                SelectSlot(row.Slot, false);
-                            }
+                            DataGridRow row => row.Slot,
+                            DataGridItemContainer itemContainer => itemContainer.Slot,
+                            _ => -1
+                        };
+                        if (selectedSlot >= 0 && _selectedItems.ContainsSlot(selectedSlot))
+                        {
+                            SelectSlot(selectedSlot, false);
                         }
                     }
                     _selectedItems.ClearRows();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
@@ -898,6 +898,11 @@ internal
         {
             Debug.Assert(_collapsedSlotsTable.Contains(slot) || !IsSlotOutOfBounds(slot));
 
+            if (LayoutModel != null && _rowsPresenter != null)
+            {
+                return _rowsPresenter.ScrollLayoutIndexIntoView(GetLayoutIndexFromSlot(slot));
+            }
+
             if (DisplayData.FirstScrollingSlot == -1)
             {
                 if (SlotCount == 0 || ColumnsItemsInternal.Count == 0 || MathUtilities.LessThanOrClose(CellsEstimatedHeight, 0))

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Rows.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using Avalonia.Collections;
+using Avalonia.Controls.DataGridLayouts;
 using Avalonia.Controls.Utils;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
@@ -1532,6 +1533,13 @@ internal
                 return element is DataGridRow row && row.HasDeferredHeight
                     ? row.DeferredHeight
                     : element.DesiredSize.Height;
+            }
+
+            if (UsesLayoutItemPresentation &&
+                !IsGroupSlot(slot) &&
+                LayoutModel is IDataGridLayoutPresentationModel presentation)
+            {
+                return Math.Max(1, presentation.ItemSizeEstimate.Height);
             }
 
             return GetSlotElementHeight(slot);

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Selection.cs
@@ -473,6 +473,10 @@ internal
                     row.ApplyState();
                     row.ApplyCellsState();
                 }
+                else if (element is DataGridItemContainer itemContainer)
+                {
+                    itemContainer.ApplyState();
+                }
                 else if (element is DataGridRowGroupHeader groupHeader)
                 {
                     groupHeader.UpdatePseudoClasses();

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -223,6 +223,12 @@ internal
                 return;
             }
 
+            if (LayoutModel != null)
+            {
+                _rowsPresenter.InvalidateMeasure();
+                return;
+            }
+
             var effectiveHeight = newViewport.Height;
             if (!double.IsNaN(Height) && !double.IsInfinity(Height) && Height > 0)
             {
@@ -543,6 +549,7 @@ internal
                 VerticalScrollBarVisibilityProperty);
 
             ItemsSourceProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnItemsSourcePropertyChanged(e));
+            ItemTemplateProperty.Changed.AddClassHandler<DataGrid>(static (x, _) => x.OnItemTemplateChanged());
             CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnCanUserResizeColumnsChanged(e));
             ColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnColumnWidthChanged(e));
             ColumnWidthSharingScopeProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnColumnWidthSharingScopeChanged(e));
@@ -924,7 +931,8 @@ internal
         {
             get
             {
-                return (HeadersVisibility & DataGridHeadersVisibility.Column) == DataGridHeadersVisibility.Column;
+                return !UsesLayoutItemPresentation &&
+                    (HeadersVisibility & DataGridHeadersVisibility.Column) == DataGridHeadersVisibility.Column;
             }
         }
 
@@ -932,7 +940,8 @@ internal
         {
             get
             {
-                return (HeadersVisibility & DataGridHeadersVisibility.Row) == DataGridHeadersVisibility.Row;
+                return !UsesLayoutItemPresentation &&
+                    (HeadersVisibility & DataGridHeadersVisibility.Row) == DataGridHeadersVisibility.Row;
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
@@ -257,10 +257,12 @@ namespace Avalonia.Controls
             }
         }
 
-        private Control GetLogicalScrollingElement(int logicalIndex)
+        internal Control GetLogicalScrollingElement(int logicalIndex)
         {
             return _scrollingElements[(_headScrollingElements + logicalIndex) % _scrollingElements.Count];
         }
+
+        internal int ScrollingElementCount => _scrollingElements.Count;
 
         private void RecycleScrollingElement(Control element)
         {

--- a/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDisplayData.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Controls
     internal class DataGridDisplayData
     {
         private readonly Stack<DataGridRow> _recycledRows;
+        private readonly Stack<DataGridItemContainer> _recycledItemContainers;
         private readonly Dictionary<object, Stack<DataGridRow>> _keyedRecycledRows;
         private readonly Stack<DataGridRowGroupHeader> _recycledGroupHeaders;
         private readonly Stack<DataGridRowGroupFooter> _recycledGroupFooters;
@@ -36,6 +37,7 @@ namespace Avalonia.Controls
             _owner = owner;
             _scrollingElements = new List<Control>();
             _recycledRows = new Stack<DataGridRow>();
+            _recycledItemContainers = new Stack<DataGridItemContainer>();
             _keyedRecycledRows = new Dictionary<object, Stack<DataGridRow>>();
             _recycledGroupHeaders = new Stack<DataGridRowGroupHeader>();
             _recycledGroupFooters = new Stack<DataGridRowGroupFooter>();
@@ -114,6 +116,18 @@ namespace Avalonia.Controls
             return row;
         }
 
+        internal void RecycleItemContainer(DataGridItemContainer container)
+        {
+            container.DetachFromDataGrid();
+            HideElement(container);
+            PushToRecyclePool(_recycledItemContainers, container);
+        }
+
+        internal DataGridItemContainer? GetRecycledItemContainer()
+        {
+            return PopFromRecyclePool(_recycledItemContainers, RestoreElementForReuse);
+        }
+
         internal void TrimRecycledPools(DataGridRowsPresenter owner, int maxRecycledRows, int maxRecycledGroupHeaders, int maxRecycledGroupFooters)
         {
             while (_recycledRows.Count > maxRecycledRows)
@@ -121,6 +135,13 @@ namespace Avalonia.Controls
                 var row = _recycledRows.Pop();
                 owner.UnregisterAnchorCandidate(row);
                 owner.RemoveTrackedChild(row);
+            }
+
+            while (_recycledItemContainers.Count > maxRecycledRows)
+            {
+                DataGridItemContainer container = _recycledItemContainers.Pop();
+                owner.UnregisterAnchorCandidate(container);
+                owner.RemoveTrackedChild(container);
             }
 
             int keyedRowCount = 0;
@@ -221,6 +242,7 @@ namespace Avalonia.Controls
             else
             {
                 _recycledRows.Clear();
+                _recycledItemContainers.Clear();
                 _keyedRecycledRows.Clear();
                 _recycledGroupHeaders.Clear();
                 _recycledGroupFooters.Clear();
@@ -282,6 +304,10 @@ namespace Avalonia.Controls
                         HideElement(row);
                         row.Clip = new RectangleGeometry();
                     }
+                    break;
+
+                case DataGridItemContainer itemContainer:
+                    RecycleItemContainer(itemContainer);
                     break;
 
                 case DataGridRowGroupHeader groupHeader:
@@ -460,6 +486,7 @@ namespace Avalonia.Controls
         internal void ClearRecyclePools()
         {
             _recycledRows.Clear();
+            _recycledItemContainers.Clear();
             _keyedRecycledRows.Clear();
             _recycledGroupHeaders.Clear();
             _recycledGroupFooters.Clear();

--- a/src/Avalonia.Controls.DataGrid/DataGridItemContainer.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridItemContainer.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Automation;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Input;
+
+namespace Avalonia.Controls;
+
+/// <summary>
+/// Hosts one templated data item when a layout model uses item presentation.
+/// </summary>
+/// <remarks>
+/// The container is recycled independently from <see cref="DataGridRow"/> and never creates
+/// <see cref="DataGridCell"/> instances. Style it with the <c>:selected</c>, <c>:current</c>, and
+/// <c>:pointerover</c> pseudo-classes; place item visuals in <see cref="ContentControl.Content"/>.
+/// </remarks>
+[PseudoClasses(":selected", ":current", ":pointerover")]
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridItemContainer : ContentControl
+{
+    private bool _isSelected;
+    private bool _isCurrent;
+    private IDataTemplate? _appliedTemplate;
+
+    /// <summary>
+    /// Identifies the <see cref="IsSelected"/> direct property.
+    /// </summary>
+    public static readonly DirectProperty<DataGridItemContainer, bool> IsSelectedProperty =
+        AvaloniaProperty.RegisterDirect<DataGridItemContainer, bool>(
+            nameof(IsSelected),
+            container => container.IsSelected,
+            (container, value) => container.IsSelected = value);
+
+    /// <summary>
+    /// Identifies the <see cref="IsCurrent"/> direct property.
+    /// </summary>
+    public static readonly DirectProperty<DataGridItemContainer, bool> IsCurrentProperty =
+        AvaloniaProperty.RegisterDirect<DataGridItemContainer, bool>(
+            nameof(IsCurrent),
+            container => container.IsCurrent);
+
+    static DataGridItemContainer()
+    {
+        FocusableProperty.OverrideDefaultValue<DataGridItemContainer>(false);
+        IsTabStopProperty.OverrideDefaultValue<DataGridItemContainer>(false);
+        PointerPressedEvent.AddClassHandler<DataGridItemContainer>(
+            static (container, e) => container.OnItemPointerPressed(e));
+        AutomationProperties.IsOffscreenBehaviorProperty.OverrideDefaultValue<DataGridItemContainer>(
+            IsOffscreenBehavior.FromClip);
+    }
+
+    /// <summary>
+    /// Gets the zero-based row index represented by this container, or <c>-1</c> while recycled.
+    /// </summary>
+    public int Index { get; internal set; } = -1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the represented item is selected.
+    /// </summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected == value)
+            {
+                return;
+            }
+
+            DataGrid? owner = OwningGrid;
+            if (owner != null && Slot >= 0 && !owner.IsSelectionUpdateFromRowSuppressed)
+            {
+                using var origin = owner.BeginSelectionChangeScope(DataGridSelectionChangeSource.Programmatic);
+                if (!owner.TryPreviewSetRowSelection(Slot, value, setAnchorSlot: false))
+                {
+                    return;
+                }
+
+                using var commit = owner.BeginSelectionCommit();
+                SetSelectedCore(value);
+                return;
+            }
+
+            SetSelectedCore(value);
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the represented item owns the current DataGrid position.
+    /// </summary>
+    public bool IsCurrent => _isCurrent;
+
+    internal DataGrid? OwningGrid { get; private set; }
+
+    internal int Slot { get; private set; } = -1;
+
+    internal void Prepare(
+        DataGrid owner,
+        int index,
+        int slot,
+        object item,
+        IDataTemplate template)
+    {
+        OwningGrid = owner;
+        Index = index;
+        Slot = slot;
+        DataContext = item;
+
+        Control? existing = ReferenceEquals(_appliedTemplate, template) ? Content as Control : null;
+        Control? content = template is IRecyclingDataTemplate recycling
+            ? recycling.Build(item, existing)
+            : template.Build(item);
+        Content = content ?? new Control();
+        _appliedTemplate = template;
+        ApplyState();
+    }
+
+    internal void DetachFromDataGrid()
+    {
+        SetSelectedCore(false);
+        SetCurrentCore(false);
+        OwningGrid = null;
+        Index = -1;
+        Slot = -1;
+        DataContext = null;
+    }
+
+    internal void ApplyState(bool? isSelectedOverride = null)
+    {
+        DataGrid? owner = OwningGrid;
+        bool selected = isSelectedOverride ?? (owner?.IsLayoutItemSelected(Slot) == true);
+        SetSelectedCore(selected);
+        SetCurrentCore(owner?.CurrentSlot == Slot);
+    }
+
+    private void SetSelectedCore(bool value)
+    {
+        SetAndRaise(IsSelectedProperty, ref _isSelected, value);
+        PseudoClasses.Set(":selected", value);
+    }
+
+    private void SetCurrentCore(bool value)
+    {
+        SetAndRaise(IsCurrentProperty, ref _isCurrent, value);
+        PseudoClasses.Set(":current", value);
+    }
+
+    private void OnItemPointerPressed(PointerPressedEventArgs e)
+    {
+        if (e.Handled || OwningGrid == null || Slot < 0)
+        {
+            return;
+        }
+
+        PointerPointProperties properties = e.GetCurrentPoint(this).Properties;
+        if (properties.IsLeftButtonPressed)
+        {
+            DataGridColumn? column = OwningGrid.CurrentColumn ?? OwningGrid.ColumnsInternal.FirstVisibleNonFillerColumn;
+            e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(
+                e,
+                column?.Index ?? -1,
+                Slot,
+                allowEdit: false);
+        }
+        else if (properties.IsRightButtonPressed)
+        {
+            DataGridColumn? column = OwningGrid.CurrentColumn ?? OwningGrid.ColumnsInternal.FirstVisibleNonFillerColumn;
+            e.Handled = OwningGrid.UpdateStateOnMouseRightButtonDown(
+                e,
+                column?.Index ?? -1,
+                Slot,
+                allowEdit: false);
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGridItemContainer.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridItemContainer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Avalonia.Automation;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -112,6 +113,8 @@ sealed class DataGridItemContainer : ContentControl
         Index = index;
         Slot = slot;
         DataContext = item;
+        SetValue(AutomationProperties.PositionInSetProperty, index + 1);
+        SetValue(AutomationProperties.SizeOfSetProperty, owner.DataConnection.Count);
 
         Control? existing = ReferenceEquals(_appliedTemplate, template) ? Content as Control : null;
         Control? content = template is IRecyclingDataTemplate recycling
@@ -130,6 +133,23 @@ sealed class DataGridItemContainer : ContentControl
         Index = -1;
         Slot = -1;
         DataContext = null;
+        ClearValue(AutomationProperties.PositionInSetProperty);
+        ClearValue(AutomationProperties.SizeOfSetProperty);
+    }
+
+    /// <inheritdoc />
+    protected override AutomationPeer OnCreateAutomationPeer() =>
+        new DataGridItemContainerAutomationPeer(this);
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == IsSelectedProperty && OwningGrid != null && Slot >= 0)
+        {
+            OwningGrid.SetRowSelection(Slot, change.GetNewValue<bool>(), setAnchorSlot: false);
+        }
+
+        base.OnPropertyChanged(change);
     }
 
     internal void ApplyState(bool? isSelectedOverride = null)

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutInvalidation.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutInvalidation.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Identifies the least expensive layout pass that can apply a model change.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridLayoutInvalidationKind
+{
+    /// <summary>
+    /// Only existing item bounds need to be arranged again.
+    /// </summary>
+    Arrange,
+
+    /// <summary>
+    /// Item geometry and the extent need to be measured again.
+    /// </summary>
+    Measure,
+
+    /// <summary>
+    /// Cached geometry and realization state must be reset before measuring.
+    /// </summary>
+    Reset
+}
+
+/// <summary>
+/// Provides data for <see cref="IDataGridLayoutModel.LayoutInvalidated"/>.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridLayoutInvalidatedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataGridLayoutInvalidatedEventArgs"/> class.
+    /// </summary>
+    /// <param name="kind">The required invalidation kind.</param>
+    public DataGridLayoutInvalidatedEventArgs(DataGridLayoutInvalidationKind kind)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>
+    /// Gets the required invalidation kind.
+    /// </summary>
+    public DataGridLayoutInvalidationKind Kind { get; }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutModelBase.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutModelBase.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Provides property notification, invalidation batching, and change helpers for DataGrid layout models.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+abstract class DataGridLayoutModelBase : IDataGridLayoutModel
+{
+    private int _updateNesting;
+    private DataGridLayoutInvalidationKind? _pendingInvalidation;
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <inheritdoc/>
+    public event EventHandler<DataGridLayoutInvalidatedEventArgs>? LayoutInvalidated;
+
+    /// <inheritdoc/>
+    public abstract IDataGridLayoutAlgorithm CreateAlgorithm();
+
+    /// <summary>
+    /// Defers layout invalidation until the returned scope is disposed.
+    /// </summary>
+    /// <returns>A scope that flushes the strongest pending invalidation when disposed.</returns>
+    public IDisposable DeferInvalidation()
+    {
+        _updateNesting++;
+        return new InvalidationScope(this);
+    }
+
+    /// <summary>
+    /// Sets a property value and raises model notifications when the value changed.
+    /// </summary>
+    /// <typeparam name="T">The property value type.</typeparam>
+    /// <param name="field">The backing field.</param>
+    /// <param name="value">The new value.</param>
+    /// <param name="invalidationKind">The layout work required by the change.</param>
+    /// <param name="propertyName">The property name supplied by the compiler.</param>
+    /// <returns><c>true</c> when the value changed.</returns>
+    protected bool SetProperty<T>(
+        ref T field,
+        T value,
+        DataGridLayoutInvalidationKind invalidationKind = DataGridLayoutInvalidationKind.Measure,
+        [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        Invalidate(invalidationKind);
+        return true;
+    }
+
+    /// <summary>
+    /// Raises a layout invalidation request.
+    /// </summary>
+    /// <param name="kind">The required invalidation kind.</param>
+    protected void Invalidate(DataGridLayoutInvalidationKind kind)
+    {
+        if (_updateNesting > 0)
+        {
+            if (!_pendingInvalidation.HasValue || kind > _pendingInvalidation.Value)
+            {
+                _pendingInvalidation = kind;
+            }
+            return;
+        }
+
+        LayoutInvalidated?.Invoke(this, new DataGridLayoutInvalidatedEventArgs(kind));
+    }
+
+    private void EndInvalidationScope()
+    {
+        if (_updateNesting == 0)
+        {
+            return;
+        }
+
+        _updateNesting--;
+        if (_updateNesting == 0 && _pendingInvalidation is { } kind)
+        {
+            _pendingInvalidation = null;
+            LayoutInvalidated?.Invoke(this, new DataGridLayoutInvalidatedEventArgs(kind));
+        }
+    }
+
+    private sealed class InvalidationScope : IDisposable
+    {
+        private DataGridLayoutModelBase? _owner;
+
+        public InvalidationScope(DataGridLayoutModelBase owner)
+        {
+            _owner = owner;
+        }
+
+        public void Dispose()
+        {
+            DataGridLayoutModelBase? owner = _owner;
+            _owner = null;
+            owner?.EndInvalidationScope();
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutModelBase.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutModelBase.cs
@@ -16,10 +16,12 @@ public
 #else
 internal
 #endif
-abstract class DataGridLayoutModelBase : IDataGridLayoutModel
+abstract class DataGridLayoutModelBase : IDataGridLayoutModel, IDataGridLayoutPresentationModel
 {
     private int _updateNesting;
     private DataGridLayoutInvalidationKind? _pendingInvalidation;
+    private DataGridLayoutPresentationMode _presentationMode;
+    private Size _itemSizeEstimate = new(100, 32);
 
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -29,6 +31,20 @@ abstract class DataGridLayoutModelBase : IDataGridLayoutModel
 
     /// <inheritdoc/>
     public abstract IDataGridLayoutAlgorithm CreateAlgorithm();
+
+    /// <inheritdoc/>
+    public DataGridLayoutPresentationMode PresentationMode
+    {
+        get => _presentationMode;
+        set => SetProperty(ref _presentationMode, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <inheritdoc/>
+    public Size ItemSizeEstimate
+    {
+        get => _itemSizeEstimate;
+        set => SetProperty(ref _itemSizeEstimate, SanitizeItemSize(value), DataGridLayoutInvalidationKind.Reset);
+    }
 
     /// <summary>
     /// Defers layout invalidation until the returned scope is disposed.
@@ -97,6 +113,17 @@ abstract class DataGridLayoutModelBase : IDataGridLayoutModel
             _pendingInvalidation = null;
             LayoutInvalidated?.Invoke(this, new DataGridLayoutInvalidatedEventArgs(kind));
         }
+    }
+
+    private static Size SanitizeItemSize(Size value)
+    {
+        double width = double.IsNaN(value.Width) || double.IsInfinity(value.Width)
+            ? 100
+            : Math.Max(1, value.Width);
+        double height = double.IsNaN(value.Height) || double.IsInfinity(value.Height)
+            ? 32
+            : Math.Max(1, value.Height);
+        return new Size(width, height);
     }
 
     private sealed class InvalidationScope : IDisposable

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutOrientation.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutOrientation.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Defines the direction in which a DataGrid layout places consecutive items.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridLayoutOrientation
+{
+    /// <summary>
+    /// Items advance from top to bottom.
+    /// </summary>
+    Vertical,
+
+    /// <summary>
+    /// Items advance from left to right.
+    /// </summary>
+    Horizontal
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutPresentationMode.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridLayoutPresentationMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Selects the visual container used for items arranged by a DataGrid layout model.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridLayoutPresentationMode
+{
+    /// <summary>
+    /// Realizes conventional <see cref="DataGridRow"/> and <see cref="DataGridCell"/> containers.
+    /// </summary>
+    Rows,
+
+    /// <summary>
+    /// Realizes lightweight <see cref="DataGridItemContainer"/> containers whose content is built
+    /// from <see cref="DataGrid.ItemTemplate"/>.
+    /// </summary>
+    Items
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridNonVirtualizingStackLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridNonVirtualizingStackLayoutModel.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Arranges and measures every DataGrid row in one horizontal or vertical line.
+/// </summary>
+/// <remarks>
+/// Use this layout for small collections that require size-to-content behavior. Prefer
+/// <see cref="DataGridStackLayoutModel"/> for large collections.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridNonVirtualizingStackLayoutModel : DataGridLayoutModelBase
+{
+    private DataGridLayoutOrientation _orientation = DataGridLayoutOrientation.Vertical;
+    private double _spacing;
+
+    /// <summary>
+    /// Gets or sets the direction in which rows are stacked.
+    /// </summary>
+    public DataGridLayoutOrientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <summary>
+    /// Gets or sets the distance between adjacent rows.
+    /// </summary>
+    public double Spacing
+    {
+        get => _spacing;
+        set => SetProperty(ref _spacing, value);
+    }
+
+    /// <inheritdoc/>
+    public override IDataGridLayoutAlgorithm CreateAlgorithm()
+    {
+        return new DataGridStackLayoutAlgorithm(this);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm
+{
+    private readonly IDataGridLayoutModel _model;
+    private readonly bool _forceNonVirtualizing;
+
+    public DataGridStackLayoutAlgorithm(
+        DataGridStackLayoutModel model,
+        bool forceNonVirtualizing)
+    {
+        _model = model;
+        _forceNonVirtualizing = forceNonVirtualizing;
+    }
+
+    public DataGridStackLayoutAlgorithm(DataGridNonVirtualizingStackLayoutModel model)
+    {
+        _model = model;
+        _forceNonVirtualizing = true;
+    }
+
+    public void Initialize(IDataGridLayoutContext context)
+    {
+        context.LayoutState = new State();
+    }
+
+    public Size Measure(IDataGridLayoutContext context, Size availableSize)
+    {
+        int itemCount = context.ItemCount;
+        if (itemCount <= 0)
+        {
+            RecycleOutsideRange(context, 0, -1);
+            context.LayoutOrigin = default;
+            return default;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = GetOrientation();
+        double spacing = Math.Max(0, GetSpacing());
+        bool virtualizing = !_forceNonVirtualizing && !GetDisableVirtualization();
+        double realizationStart = virtualizing ? GetMajorStart(context.RealizationRect, orientation) : 0;
+        double realizationEnd = virtualizing ? GetMajorEnd(context.RealizationRect, orientation) : double.PositiveInfinity;
+        realizationStart = Math.Max(0, realizationStart);
+
+        int firstIndex = virtualizing
+            ? FindFirstRealizedIndex(context, orientation, spacing, realizationStart, itemCount)
+            : 0;
+        double majorPosition = GetEstimatedOffset(context, firstIndex, orientation, spacing);
+        int lastIndex = firstIndex - 1;
+        double maxMinor = state.MaxMinor;
+        Size measureConstraint = GetMeasureConstraint(availableSize, orientation);
+
+        for (int index = firstIndex; index < itemCount; index++)
+        {
+            Control element = context.GetOrCreateElementAt(index);
+            element.Measure(measureConstraint);
+
+            Size desiredSize = element.DesiredSize;
+            double major = Math.Max(0, GetMajor(desiredSize, orientation));
+            double minor = Math.Max(0, GetMinor(desiredSize, orientation));
+            double availableMinor = GetMinor(availableSize, orientation);
+            if (IsFinite(availableMinor))
+            {
+                minor = Math.Max(minor, availableMinor);
+            }
+
+            context.SetLayoutBounds(index, CreateRect(majorPosition, 0, major, minor, orientation));
+            maxMinor = Math.Max(maxMinor, minor);
+            lastIndex = index;
+            majorPosition += major;
+
+            if (virtualizing && majorPosition >= realizationEnd)
+            {
+                break;
+            }
+
+            majorPosition += spacing;
+        }
+
+        state.MaxMinor = maxMinor;
+        RecycleOutsideRange(context, firstIndex, lastIndex);
+        context.LayoutOrigin = default;
+
+        double estimatedMajor = GetEstimatedOffset(context, itemCount, orientation, spacing);
+        if (itemCount > 0)
+        {
+            estimatedMajor -= spacing;
+        }
+        estimatedMajor = Math.Max(majorPosition, estimatedMajor);
+
+        return CreateSize(estimatedMajor, maxMinor, orientation);
+    }
+
+    public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+    {
+        Vector offset = context.ScrollOffset;
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = 0; index < realized.Count; index++)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex >= 0 && context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+            {
+                element.Arrange(new Rect(
+                    bounds.X - offset.X,
+                    bounds.Y - offset.Y,
+                    bounds.Width,
+                    bounds.Height));
+            }
+        }
+
+        return finalSize;
+    }
+
+    public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+    {
+        context.LayoutState = new State();
+    }
+
+    public void Uninitialize(IDataGridLayoutContext context)
+    {
+    }
+
+    private DataGridLayoutOrientation GetOrientation()
+    {
+        return _model switch
+        {
+            DataGridStackLayoutModel model => model.Orientation,
+            DataGridNonVirtualizingStackLayoutModel model => model.Orientation,
+            _ => DataGridLayoutOrientation.Vertical
+        };
+    }
+
+    private double GetSpacing()
+    {
+        return _model switch
+        {
+            DataGridStackLayoutModel model => model.Spacing,
+            DataGridNonVirtualizingStackLayoutModel model => model.Spacing,
+            _ => 0
+        };
+    }
+
+    private bool GetDisableVirtualization()
+    {
+        return _model is DataGridStackLayoutModel { DisableVirtualization: true };
+    }
+
+    private static State GetState(IDataGridLayoutContext context)
+    {
+        if (context.LayoutState is State state)
+        {
+            return state;
+        }
+
+        state = new State();
+        context.LayoutState = state;
+        return state;
+    }
+
+    private static int FindFirstRealizedIndex(
+        IDataGridLayoutContext context,
+        DataGridLayoutOrientation orientation,
+        double spacing,
+        double realizationStart,
+        int itemCount)
+    {
+        int low = 0;
+        int high = itemCount;
+        while (low < high)
+        {
+            int middle = low + ((high - low) / 2);
+            double offset = GetEstimatedOffset(context, middle, orientation, spacing);
+            Size estimatedSize = context.GetEstimatedItemSize(middle);
+            double end = offset + Math.Max(1, GetMajor(estimatedSize, orientation));
+            if (end <= realizationStart)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        return Math.Max(0, Math.Min(itemCount - 1, low));
+    }
+
+    private static double GetEstimatedOffset(
+        IDataGridLayoutContext context,
+        int index,
+        DataGridLayoutOrientation orientation,
+        double spacing)
+    {
+        return Math.Max(0, context.GetEstimatedItemOffset(index, orientation)) + (spacing * index);
+    }
+
+    private static void RecycleOutsideRange(IDataGridLayoutContext context, int firstIndex, int lastIndex)
+    {
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = realized.Count - 1; index >= 0; index--)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex < firstIndex || itemIndex > lastIndex)
+            {
+                context.RecycleElement(element);
+            }
+        }
+    }
+
+    private static Size GetMeasureConstraint(Size availableSize, DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical
+            ? new Size(availableSize.Width, double.PositiveInfinity)
+            : new Size(double.PositiveInfinity, availableSize.Height);
+    }
+
+    private static double GetMajor(Size size, DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical ? size.Height : size.Width;
+    }
+
+    private static double GetMinor(Size size, DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical ? size.Width : size.Height;
+    }
+
+    private static double GetMajorStart(Rect rect, DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical ? rect.Y : rect.X;
+    }
+
+    private static double GetMajorEnd(Rect rect, DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical ? rect.Bottom : rect.Right;
+    }
+
+    private static Rect CreateRect(
+        double majorStart,
+        double minorStart,
+        double majorSize,
+        double minorSize,
+        DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical
+            ? new Rect(minorStart, majorStart, minorSize, majorSize)
+            : new Rect(majorStart, minorStart, majorSize, minorSize);
+    }
+
+    private static Size CreateSize(
+        double majorSize,
+        double minorSize,
+        DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Vertical
+            ? new Size(minorSize, majorSize)
+            : new Size(majorSize, minorSize);
+    }
+
+    private static bool IsFinite(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    private sealed class State
+    {
+        public double MaxMinor { get; set; }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
@@ -28,7 +28,7 @@ internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm
 
     public void Initialize(IDataGridLayoutContext context)
     {
-        context.LayoutState = new State();
+        context.LayoutState ??= new State();
     }
 
     public Size Measure(IDataGridLayoutContext context, Size availableSize)
@@ -49,10 +49,17 @@ internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm
         double realizationEnd = virtualizing ? GetMajorEnd(context.RealizationRect, orientation) : double.PositiveInfinity;
         realizationStart = Math.Max(0, realizationStart);
 
-        int firstIndex = virtualizing
-            ? FindFirstRealizedIndex(context, orientation, spacing, realizationStart, itemCount)
-            : 0;
+        int recommendedAnchor = context.RecommendedAnchorIndex;
+        int firstIndex = virtualizing && recommendedAnchor >= 0
+            ? Math.Min(itemCount - 1, recommendedAnchor)
+            : virtualizing
+                ? FindFirstRealizedIndex(context, orientation, spacing, realizationStart, itemCount)
+                : 0;
         double majorPosition = GetEstimatedOffset(context, firstIndex, orientation, spacing);
+        if (virtualizing && recommendedAnchor >= 0)
+        {
+            realizationEnd = majorPosition + Math.Max(1, GetMajor(context.RealizationRect.Size, orientation));
+        }
         int lastIndex = firstIndex - 1;
         double maxMinor = state.MaxMinor;
         Size measureConstraint = GetMeasureConstraint(availableSize, orientation);

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.DataGridLayouts;
 
-internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm
+internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm, IDataGridLayoutNavigation
 {
     private readonly IDataGridLayoutModel _model;
     private readonly bool _forceNonVirtualizing;
@@ -133,6 +133,115 @@ internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm
 
     public void Uninitialize(IDataGridLayoutContext context)
     {
+    }
+
+    public bool TryResolveNavigation(
+        IDataGridLayoutContext context,
+        in DataGridLayoutNavigationRequest request,
+        out DataGridLayoutNavigationResult result)
+    {
+        result = default;
+        int itemCount = context.ItemCount;
+        int current = request.CurrentItemIndex;
+        if (current < 0 || current >= itemCount)
+        {
+            return false;
+        }
+
+        DataGridLayoutOrientation orientation = GetOrientation();
+        int target;
+        switch (request.Direction)
+        {
+            case DataGridLayoutNavigationDirection.Up when orientation == DataGridLayoutOrientation.Vertical:
+            case DataGridLayoutNavigationDirection.Left when orientation == DataGridLayoutOrientation.Horizontal:
+                target = current - 1;
+                break;
+            case DataGridLayoutNavigationDirection.Down when orientation == DataGridLayoutOrientation.Vertical:
+            case DataGridLayoutNavigationDirection.Right when orientation == DataGridLayoutOrientation.Horizontal:
+                target = current + 1;
+                break;
+            case DataGridLayoutNavigationDirection.PageUp:
+            case DataGridLayoutNavigationDirection.PageDown:
+                target = FindPageTarget(context, request, orientation);
+                break;
+            case DataGridLayoutNavigationDirection.First:
+                target = 0;
+                break;
+            case DataGridLayoutNavigationDirection.Last:
+                target = itemCount - 1;
+                break;
+            default:
+                return false;
+        }
+
+        if (target < 0 || target >= itemCount || target == current)
+        {
+            return false;
+        }
+
+        result = new DataGridLayoutNavigationResult(
+            target,
+            GetEstimatedBounds(context, target, orientation, Math.Max(0, GetSpacing())));
+        return true;
+    }
+
+    private int FindPageTarget(
+        IDataGridLayoutContext context,
+        in DataGridLayoutNavigationRequest request,
+        DataGridLayoutOrientation orientation)
+    {
+        double spacing = Math.Max(0, GetSpacing());
+        Rect currentBounds = context.TryGetLayoutBounds(request.CurrentItemIndex, out Rect exactBounds)
+            ? exactBounds
+            : GetEstimatedBounds(context, request.CurrentItemIndex, orientation, spacing);
+        double viewportMajor = GetMajor(request.Viewport.Size, orientation);
+        if (!IsFinite(viewportMajor) || viewportMajor <= 0)
+        {
+            viewportMajor = Math.Max(1, GetMajor(currentBounds.Size, orientation));
+        }
+
+        bool forward = request.Direction == DataGridLayoutNavigationDirection.PageDown;
+        double coordinate = Math.Max(0, GetMajorStart(currentBounds, orientation) + (forward ? viewportMajor : -viewportMajor));
+        int low = 0;
+        int high = context.ItemCount - 1;
+        while (low < high)
+        {
+            int middle = low + ((high - low) / 2);
+            Rect bounds = GetEstimatedBounds(context, middle, orientation, spacing);
+            double end = GetMajorStart(bounds, orientation) + Math.Max(1, GetMajor(bounds.Size, orientation));
+            if (end < coordinate)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        if (low == request.CurrentItemIndex)
+        {
+            low += forward ? 1 : -1;
+        }
+        return Math.Max(0, Math.Min(context.ItemCount - 1, low));
+    }
+
+    private static Rect GetEstimatedBounds(
+        IDataGridLayoutContext context,
+        int index,
+        DataGridLayoutOrientation orientation,
+        double spacing)
+    {
+        if (context.TryGetLayoutBounds(index, out Rect bounds))
+        {
+            return bounds;
+        }
+
+        Size estimated = context.GetEstimatedItemSize(index);
+        double major = Math.Max(1, GetMajor(estimated, orientation));
+        double minor = Math.Max(1, GetMinor(estimated, orientation));
+        double offset = GetEstimatedOffset(context, index, orientation, spacing);
+        return CreateRect(offset, 0, major, minor, orientation);
     }
 
     private DataGridLayoutOrientation GetOrientation()

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutAlgorithm.cs
@@ -135,12 +135,49 @@ internal sealed class DataGridStackLayoutAlgorithm : IDataGridLayoutAlgorithm, I
     {
     }
 
+    public bool SupportsNavigation(DataGridLayoutNavigationDirection direction)
+    {
+        DataGridLayoutOrientation orientation = GetOrientation();
+        return direction is DataGridLayoutNavigationDirection.PageUp or
+            DataGridLayoutNavigationDirection.PageDown or
+            DataGridLayoutNavigationDirection.First or
+            DataGridLayoutNavigationDirection.Last ||
+            orientation == DataGridLayoutOrientation.Vertical &&
+                direction is DataGridLayoutNavigationDirection.Up or DataGridLayoutNavigationDirection.Down ||
+            orientation == DataGridLayoutOrientation.Horizontal &&
+                direction is DataGridLayoutNavigationDirection.Left or DataGridLayoutNavigationDirection.Right;
+    }
+
+    public bool TryGetNavigationBounds(
+        IDataGridLayoutContext context,
+        int itemIndex,
+        Rect viewport,
+        out Rect bounds)
+    {
+        if (itemIndex < 0 || itemIndex >= context.ItemCount)
+        {
+            bounds = default;
+            return false;
+        }
+
+        bounds = GetEstimatedBounds(
+            context,
+            itemIndex,
+            GetOrientation(),
+            Math.Max(0, GetSpacing()));
+        return true;
+    }
+
     public bool TryResolveNavigation(
         IDataGridLayoutContext context,
         in DataGridLayoutNavigationRequest request,
         out DataGridLayoutNavigationResult result)
     {
         result = default;
+        if (!SupportsNavigation(request.Direction))
+        {
+            return false;
+        }
         int itemCount = context.ItemCount;
         int current = request.CurrentItemIndex;
         if (current < 0 || current >= itemCount)

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridStackLayoutModel.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Arranges DataGrid rows in one virtualized horizontal or vertical line.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridStackLayoutModel : DataGridLayoutModelBase
+{
+    private DataGridLayoutOrientation _orientation = DataGridLayoutOrientation.Vertical;
+    private double _spacing;
+    private bool _disableVirtualization;
+
+    /// <summary>
+    /// Gets or sets the direction in which rows are stacked.
+    /// </summary>
+    public DataGridLayoutOrientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <summary>
+    /// Gets or sets the distance between adjacent rows.
+    /// </summary>
+    public double Spacing
+    {
+        get => _spacing;
+        set => SetProperty(ref _spacing, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether every row is realized and measured.
+    /// </summary>
+    public bool DisableVirtualization
+    {
+        get => _disableVirtualization;
+        set => SetProperty(ref _disableVirtualization, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <inheritdoc/>
+    public override IDataGridLayoutAlgorithm CreateAlgorithm()
+    {
+        return new DataGridStackLayoutAlgorithm(this, forceNonVirtualizing: false);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
@@ -1,0 +1,252 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgorithm
+{
+    private readonly DataGridUniformGridLayoutModel _model;
+
+    public DataGridUniformGridLayoutAlgorithm(DataGridUniformGridLayoutModel model)
+    {
+        _model = model;
+    }
+
+    public void Initialize(IDataGridLayoutContext context)
+    {
+        context.LayoutState = new State();
+    }
+
+    public Size Measure(IDataGridLayoutContext context, Size availableSize)
+    {
+        int itemCount = context.ItemCount;
+        if (itemCount <= 0)
+        {
+            RecycleOutsideRange(context, 0, -1);
+            context.LayoutOrigin = default;
+            return default;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation flowOrientation = _model.Orientation;
+        double availableU = GetU(availableSize, flowOrientation);
+        if (!IsFinitePositive(availableU))
+        {
+            availableU = GetU(context.RealizationRect.Size, flowOrientation);
+        }
+
+        Size baseCell = ResolveBaseCellSize(context, availableSize, state);
+        double baseU = Math.Max(1, GetU(baseCell, flowOrientation));
+        double baseV = Math.Max(1, GetV(baseCell, flowOrientation));
+        double spacingU = Math.Max(0, GetSpacingU(flowOrientation));
+        double spacingV = Math.Max(0, GetSpacingV(flowOrientation));
+        int maximum = _model.MaximumRowsOrColumns <= 0 ? int.MaxValue : _model.MaximumRowsOrColumns;
+        int itemsPerLine = IsFinitePositive(availableU)
+            ? Math.Max(1, (int)Math.Floor((availableU + spacingU) / (baseU + spacingU)))
+            : Math.Min(itemCount, maximum);
+        itemsPerLine = Math.Min(itemsPerLine, maximum);
+
+        double cellU = baseU;
+        double cellV = baseV;
+        if (IsFinitePositive(availableU) && _model.ItemsStretch != DataGridUniformGridItemsStretch.None)
+        {
+            double stretchedU = Math.Max(1, (availableU - (spacingU * (itemsPerLine - 1))) / itemsPerLine);
+            if (_model.ItemsStretch == DataGridUniformGridItemsStretch.Uniform)
+            {
+                cellV = Math.Max(1, baseV * (stretchedU / baseU));
+            }
+            cellU = stretchedU;
+        }
+
+        double lineAdvance = cellV + spacingV;
+        int lineCount = (itemCount + itemsPerLine - 1) / itemsPerLine;
+        double realizationStart = Math.Max(0, GetVStart(context.RealizationRect, flowOrientation));
+        double realizationEnd = Math.Max(realizationStart, GetVEnd(context.RealizationRect, flowOrientation));
+        int firstLine = Math.Min(lineCount - 1, Math.Max(0, (int)Math.Floor(realizationStart / lineAdvance)));
+        int lastLine = Math.Min(lineCount - 1, Math.Max(firstLine, (int)Math.Floor(Math.Max(0, realizationEnd - 0.001) / lineAdvance)));
+        int firstIndex = firstLine * itemsPerLine;
+        int lastIndex = Math.Min(itemCount - 1, ((lastLine + 1) * itemsPerLine) - 1);
+        Size measureSize = ToSize(cellU, cellV, flowOrientation);
+
+        for (int line = firstLine; line <= lastLine; line++)
+        {
+            int lineStartIndex = line * itemsPerLine;
+            int lineItemCount = Math.Min(itemsPerLine, itemCount - lineStartIndex);
+            GetLineAlignment(availableU, cellU, spacingU, lineItemCount, out double lineStartU, out double effectiveSpacingU);
+            double v = line * lineAdvance;
+
+            for (int lineIndex = 0; lineIndex < lineItemCount; lineIndex++)
+            {
+                int itemIndex = lineStartIndex + lineIndex;
+                Control element = context.GetOrCreateElementAt(itemIndex);
+                element.Measure(measureSize);
+                double u = lineStartU + (lineIndex * (cellU + effectiveSpacingU));
+                context.SetLayoutBounds(itemIndex, ToRect(u, v, cellU, cellV, flowOrientation));
+            }
+        }
+
+        RecycleOutsideRange(context, firstIndex, lastIndex);
+        context.LayoutOrigin = default;
+        state.CellSize = ToSize(cellU, cellV, flowOrientation);
+        state.ItemsPerLine = itemsPerLine;
+
+        double extentU = IsFinitePositive(availableU)
+            ? availableU
+            : (Math.Min(itemsPerLine, itemCount) * cellU) + (Math.Max(0, Math.Min(itemsPerLine, itemCount) - 1) * spacingU);
+        double extentV = (lineCount * cellV) + (Math.Max(0, lineCount - 1) * spacingV);
+        return ToSize(extentU, extentV, flowOrientation);
+    }
+
+    public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+    {
+        Vector offset = context.ScrollOffset;
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = 0; index < realized.Count; index++)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex >= 0 && context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+            {
+                element.Arrange(new Rect(bounds.X - offset.X, bounds.Y - offset.Y, bounds.Width, bounds.Height));
+            }
+        }
+        return finalSize;
+    }
+
+    public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+    {
+        context.LayoutState = new State();
+    }
+
+    public void Uninitialize(IDataGridLayoutContext context)
+    {
+    }
+
+    private Size ResolveBaseCellSize(IDataGridLayoutContext context, Size availableSize, State state)
+    {
+        bool needsWidth = !IsFinitePositive(_model.MinItemWidth);
+        bool needsHeight = !IsFinitePositive(_model.MinItemHeight);
+        Size measured = state.NaturalCellSize;
+
+        if ((needsWidth || needsHeight) && (measured.Width <= 0 || measured.Height <= 0))
+        {
+            Control first = context.GetOrCreateElementAt(0);
+            first.Measure(availableSize);
+            measured = first.DesiredSize;
+            state.NaturalCellSize = measured;
+        }
+
+        double width = needsWidth ? Math.Max(1, measured.Width) : _model.MinItemWidth;
+        double height = needsHeight ? Math.Max(1, measured.Height) : _model.MinItemHeight;
+        return new Size(width, height);
+    }
+
+    private void GetLineAlignment(
+        double availableU,
+        double cellU,
+        double minimumSpacing,
+        int itemCount,
+        out double start,
+        out double spacing)
+    {
+        spacing = minimumSpacing;
+        start = 0;
+        if (!IsFinitePositive(availableU) || itemCount <= 0)
+        {
+            return;
+        }
+
+        double used = (itemCount * cellU) + (Math.Max(0, itemCount - 1) * minimumSpacing);
+        double remaining = Math.Max(0, availableU - used);
+        switch (_model.ItemsJustification)
+        {
+            case DataGridUniformGridItemsJustification.Center:
+                start = remaining / 2;
+                break;
+            case DataGridUniformGridItemsJustification.End:
+                start = remaining;
+                break;
+            case DataGridUniformGridItemsJustification.SpaceAround:
+                spacing += remaining / itemCount;
+                start = (spacing - minimumSpacing) / 2;
+                break;
+            case DataGridUniformGridItemsJustification.SpaceBetween when itemCount > 1:
+                spacing += remaining / (itemCount - 1);
+                break;
+            case DataGridUniformGridItemsJustification.SpaceEvenly:
+                double addition = remaining / (itemCount + 1);
+                spacing += addition;
+                start = addition;
+                break;
+        }
+    }
+
+    private double GetSpacingU(DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Horizontal ? _model.MinColumnSpacing : _model.MinRowSpacing;
+    }
+
+    private double GetSpacingV(DataGridLayoutOrientation orientation)
+    {
+        return orientation == DataGridLayoutOrientation.Horizontal ? _model.MinRowSpacing : _model.MinColumnSpacing;
+    }
+
+    private static State GetState(IDataGridLayoutContext context)
+    {
+        if (context.LayoutState is State state)
+        {
+            return state;
+        }
+        state = new State();
+        context.LayoutState = state;
+        return state;
+    }
+
+    private static void RecycleOutsideRange(IDataGridLayoutContext context, int firstIndex, int lastIndex)
+    {
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = realized.Count - 1; index >= 0; index--)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex < firstIndex || itemIndex > lastIndex)
+            {
+                context.RecycleElement(element);
+            }
+        }
+    }
+
+    private static double GetU(Size size, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? size.Width : size.Height;
+
+    private static double GetV(Size size, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? size.Height : size.Width;
+
+    private static double GetVStart(Rect rect, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? rect.Y : rect.X;
+
+    private static double GetVEnd(Rect rect, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? rect.Bottom : rect.Right;
+
+    private static Size ToSize(double u, double v, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? new Size(u, v) : new Size(v, u);
+
+    private static Rect ToRect(double u, double v, double sizeU, double sizeV, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal
+            ? new Rect(u, v, sizeU, sizeV)
+            : new Rect(v, u, sizeV, sizeU);
+
+    private static bool IsFinitePositive(double value) =>
+        !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
+
+    private sealed class State
+    {
+        public Size NaturalCellSize { get; set; }
+        public Size CellSize { get; set; }
+        public int ItemsPerLine { get; set; }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
@@ -18,7 +18,7 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
 
     public void Initialize(IDataGridLayoutContext context)
     {
-        context.LayoutState = new State();
+        context.LayoutState ??= new State();
     }
 
     public Size Measure(IDataGridLayoutContext context, Size availableSize)
@@ -66,8 +66,13 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
         int lineCount = (itemCount + itemsPerLine - 1) / itemsPerLine;
         double realizationStart = Math.Max(0, GetVStart(context.RealizationRect, flowOrientation));
         double realizationEnd = Math.Max(realizationStart, GetVEnd(context.RealizationRect, flowOrientation));
-        int firstLine = Math.Min(lineCount - 1, Math.Max(0, (int)Math.Floor(realizationStart / lineAdvance)));
-        int lastLine = Math.Min(lineCount - 1, Math.Max(firstLine, (int)Math.Floor(Math.Max(0, realizationEnd - 0.001) / lineAdvance)));
+        int recommendedAnchor = context.RecommendedAnchorIndex;
+        int firstLine = recommendedAnchor >= 0
+            ? Math.Min(lineCount - 1, recommendedAnchor / itemsPerLine)
+            : Math.Min(lineCount - 1, Math.Max(0, (int)Math.Floor(realizationStart / lineAdvance)));
+        int lastLine = recommendedAnchor >= 0
+            ? Math.Min(lineCount - 1, firstLine + Math.Max(0, (int)Math.Ceiling(GetV(context.RealizationRect.Size, flowOrientation) / lineAdvance)))
+            : Math.Min(lineCount - 1, Math.Max(firstLine, (int)Math.Floor(Math.Max(0, realizationEnd - 0.001) / lineAdvance)));
         int firstIndex = firstLine * itemsPerLine;
         int lastIndex = Math.Min(itemCount - 1, ((lastLine + 1) * itemsPerLine) - 1);
         Size measureSize = ToSize(cellU, cellV, flowOrientation);

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.DataGridLayouts;
 
-internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgorithm
+internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgorithm, IDataGridLayoutNavigation
 {
     private readonly DataGridUniformGridLayoutModel _model;
 
@@ -98,6 +98,9 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
         context.LayoutOrigin = default;
         state.CellSize = ToSize(cellU, cellV, flowOrientation);
         state.ItemsPerLine = itemsPerLine;
+        state.AvailableU = availableU;
+        state.SpacingU = spacingU;
+        state.SpacingV = spacingV;
 
         double extentU = IsFinitePositive(availableU)
             ? availableU
@@ -130,6 +133,155 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
     public void Uninitialize(IDataGridLayoutContext context)
     {
     }
+
+    public bool TryResolveNavigation(
+        IDataGridLayoutContext context,
+        in DataGridLayoutNavigationRequest request,
+        out DataGridLayoutNavigationResult result)
+    {
+        result = default;
+        int itemCount = context.ItemCount;
+        int current = request.CurrentItemIndex;
+        if (current < 0 || current >= itemCount)
+        {
+            return false;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = _model.Orientation;
+        int itemsPerLine = ResolveItemsPerLine(context, request.Viewport, state, orientation);
+        int line = current / itemsPerLine;
+        int lineIndex = current % itemsPerLine;
+        int target;
+
+        switch (request.Direction)
+        {
+            case DataGridLayoutNavigationDirection.Left when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Up when orientation == DataGridLayoutOrientation.Vertical:
+                target = lineIndex > 0 ? current - 1 : -1;
+                break;
+            case DataGridLayoutNavigationDirection.Right when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Down when orientation == DataGridLayoutOrientation.Vertical:
+                target = lineIndex + 1 < itemsPerLine && current + 1 < itemCount ? current + 1 : -1;
+                break;
+            case DataGridLayoutNavigationDirection.Up when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Left when orientation == DataGridLayoutOrientation.Vertical:
+                target = current - itemsPerLine;
+                break;
+            case DataGridLayoutNavigationDirection.Down when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Right when orientation == DataGridLayoutOrientation.Vertical:
+                target = current + itemsPerLine;
+                if (target >= itemCount)
+                {
+                    int lastLineStart = ((itemCount - 1) / itemsPerLine) * itemsPerLine;
+                    target = lastLineStart <= current ? -1 : itemCount - 1;
+                }
+                break;
+            case DataGridLayoutNavigationDirection.LineStart:
+                target = line * itemsPerLine;
+                break;
+            case DataGridLayoutNavigationDirection.LineEnd:
+                target = Math.Min(itemCount - 1, ((line + 1) * itemsPerLine) - 1);
+                break;
+            case DataGridLayoutNavigationDirection.PageUp:
+            case DataGridLayoutNavigationDirection.PageDown:
+                double cellV = Math.Max(1, GetV(ResolveCellSize(context, state, orientation), orientation));
+                double spacingV = ResolveSpacingV(state, orientation);
+                double viewportV = Math.Max(1, GetV(request.Viewport.Size, orientation));
+                int pageLines = Math.Max(1, (int)Math.Floor(viewportV / Math.Max(1, cellV + spacingV)));
+                target = current + (request.Direction == DataGridLayoutNavigationDirection.PageDown
+                    ? pageLines * itemsPerLine
+                    : -pageLines * itemsPerLine);
+                target = Math.Max(0, Math.Min(itemCount - 1, target));
+                break;
+            case DataGridLayoutNavigationDirection.First:
+                target = 0;
+                break;
+            case DataGridLayoutNavigationDirection.Last:
+                target = itemCount - 1;
+                break;
+            default:
+                return false;
+        }
+
+        if (target < 0 || target >= itemCount || target == current)
+        {
+            return false;
+        }
+
+        result = new DataGridLayoutNavigationResult(
+            target,
+            GetEstimatedBounds(context, request.Viewport, state, orientation, itemsPerLine, target));
+        return true;
+    }
+
+    private int ResolveItemsPerLine(
+        IDataGridLayoutContext context,
+        Rect viewport,
+        State state,
+        DataGridLayoutOrientation orientation)
+    {
+        if (state.ItemsPerLine > 0)
+        {
+            return state.ItemsPerLine;
+        }
+
+        Size cellSize = ResolveCellSize(context, state, orientation);
+        double cellU = Math.Max(1, GetU(cellSize, orientation));
+        double spacingU = Math.Max(0, GetSpacingU(orientation));
+        double availableU = Math.Max(1, GetU(viewport.Size, orientation));
+        int maximum = _model.MaximumRowsOrColumns <= 0 ? int.MaxValue : _model.MaximumRowsOrColumns;
+        return Math.Min(maximum, Math.Max(1, (int)Math.Floor((availableU + spacingU) / (cellU + spacingU))));
+    }
+
+    private Size ResolveCellSize(
+        IDataGridLayoutContext context,
+        State state,
+        DataGridLayoutOrientation orientation)
+    {
+        if (state.CellSize.Width > 0 && state.CellSize.Height > 0)
+        {
+            return state.CellSize;
+        }
+
+        Size estimate = context.GetEstimatedItemSize(0);
+        double width = IsFinitePositive(_model.MinItemWidth) ? _model.MinItemWidth : Math.Max(1, estimate.Width);
+        double height = IsFinitePositive(_model.MinItemHeight) ? _model.MinItemHeight : Math.Max(1, estimate.Height);
+        return new Size(width, height);
+    }
+
+    private Rect GetEstimatedBounds(
+        IDataGridLayoutContext context,
+        Rect viewport,
+        State state,
+        DataGridLayoutOrientation orientation,
+        int itemsPerLine,
+        int index)
+    {
+        if (context.TryGetLayoutBounds(index, out Rect bounds))
+        {
+            return bounds;
+        }
+
+        Size cellSize = ResolveCellSize(context, state, orientation);
+        double cellU = Math.Max(1, GetU(cellSize, orientation));
+        double cellV = Math.Max(1, GetV(cellSize, orientation));
+        double spacingU = state.SpacingU >= 0 ? state.SpacingU : Math.Max(0, GetSpacingU(orientation));
+        double spacingV = ResolveSpacingV(state, orientation);
+        double availableU = IsFinitePositive(state.AvailableU)
+            ? state.AvailableU
+            : Math.Max(1, GetU(viewport.Size, orientation));
+        int line = index / itemsPerLine;
+        int lineStart = line * itemsPerLine;
+        int lineItemCount = Math.Min(itemsPerLine, context.ItemCount - lineStart);
+        GetLineAlignment(availableU, cellU, spacingU, lineItemCount, out double startU, out double effectiveSpacingU);
+        double u = startU + ((index - lineStart) * (cellU + effectiveSpacingU));
+        double v = line * (cellV + spacingV);
+        return ToRect(u, v, cellU, cellV, orientation);
+    }
+
+    private double ResolveSpacingV(State state, DataGridLayoutOrientation orientation) =>
+        state.SpacingV >= 0 ? state.SpacingV : Math.Max(0, GetSpacingV(orientation));
 
     private Size ResolveBaseCellSize(IDataGridLayoutContext context, Size availableSize, State state)
     {
@@ -253,5 +405,8 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
         public Size NaturalCellSize { get; set; }
         public Size CellSize { get; set; }
         public int ItemsPerLine { get; set; }
+        public double AvailableU { get; set; } = double.NaN;
+        public double SpacingU { get; set; } = -1;
+        public double SpacingV { get; set; } = -1;
     }
 }

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutAlgorithm.cs
@@ -134,6 +134,27 @@ internal sealed class DataGridUniformGridLayoutAlgorithm : IDataGridLayoutAlgori
     {
     }
 
+    public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) => true;
+
+    public bool TryGetNavigationBounds(
+        IDataGridLayoutContext context,
+        int itemIndex,
+        Rect viewport,
+        out Rect bounds)
+    {
+        if (itemIndex < 0 || itemIndex >= context.ItemCount)
+        {
+            bounds = default;
+            return false;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = _model.Orientation;
+        int itemsPerLine = ResolveItemsPerLine(context, viewport, state, orientation);
+        bounds = GetEstimatedBounds(context, viewport, state, orientation, itemsPerLine, itemIndex);
+        return true;
+    }
+
     public bool TryResolveNavigation(
         IDataGridLayoutContext context,
         in DataGridLayoutNavigationRequest request,

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutModel.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Arranges DataGrid rows in a virtualized, wrapping grid of equally sized cells.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridUniformGridLayoutModel : DataGridLayoutModelBase
+{
+    private DataGridLayoutOrientation _orientation = DataGridLayoutOrientation.Horizontal;
+    private double _minItemWidth = double.NaN;
+    private double _minItemHeight = double.NaN;
+    private double _minRowSpacing;
+    private double _minColumnSpacing;
+    private int _maximumRowsOrColumns = int.MaxValue;
+    private DataGridUniformGridItemsJustification _itemsJustification;
+    private DataGridUniformGridItemsStretch _itemsStretch;
+
+    /// <summary>
+    /// Gets or sets the direction in which items fill each line before wrapping.
+    /// </summary>
+    public DataGridLayoutOrientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum item width. The default is <see cref="double.NaN"/>, which uses
+    /// the first measured item width.
+    /// </summary>
+    public double MinItemWidth
+    {
+        get => _minItemWidth;
+        set => SetProperty(ref _minItemWidth, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum item height. The default is <see cref="double.NaN"/>, which uses
+    /// the first measured item height.
+    /// </summary>
+    public double MinItemHeight
+    {
+        get => _minItemHeight;
+        set => SetProperty(ref _minItemHeight, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum vertical distance between cells.
+    /// </summary>
+    public double MinRowSpacing
+    {
+        get => _minRowSpacing;
+        set => SetProperty(ref _minRowSpacing, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum horizontal distance between cells.
+    /// </summary>
+    public double MinColumnSpacing
+    {
+        get => _minColumnSpacing;
+        set => SetProperty(ref _minColumnSpacing, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of items in a row or column.
+    /// </summary>
+    public int MaximumRowsOrColumns
+    {
+        get => _maximumRowsOrColumns;
+        set => SetProperty(ref _maximumRowsOrColumns, value);
+    }
+
+    /// <summary>
+    /// Gets or sets how unused space is distributed on the non-scrolling axis.
+    /// </summary>
+    public DataGridUniformGridItemsJustification ItemsJustification
+    {
+        get => _itemsJustification;
+        set => SetProperty(ref _itemsJustification, value, DataGridLayoutInvalidationKind.Arrange);
+    }
+
+    /// <summary>
+    /// Gets or sets how cells consume unused space on the non-scrolling axis.
+    /// </summary>
+    public DataGridUniformGridItemsStretch ItemsStretch
+    {
+        get => _itemsStretch;
+        set => SetProperty(ref _itemsStretch, value);
+    }
+
+    /// <inheritdoc/>
+    public override IDataGridLayoutAlgorithm CreateAlgorithm()
+    {
+        return new DataGridUniformGridLayoutAlgorithm(this);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutModel.cs
@@ -84,7 +84,7 @@ sealed class DataGridUniformGridLayoutModel : DataGridLayoutModelBase
     public DataGridUniformGridItemsJustification ItemsJustification
     {
         get => _itemsJustification;
-        set => SetProperty(ref _itemsJustification, value, DataGridLayoutInvalidationKind.Arrange);
+        set => SetProperty(ref _itemsJustification, value);
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutOptions.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridUniformGridLayoutOptions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Defines how uniform-grid items are aligned on the non-scrolling axis.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridUniformGridItemsJustification
+{
+    /// <summary>Places unused space after the items.</summary>
+    Start,
+    /// <summary>Splits unused space equally before and after the items.</summary>
+    Center,
+    /// <summary>Places unused space before the items.</summary>
+    End,
+    /// <summary>Distributes unused space evenly around each item.</summary>
+    SpaceAround,
+    /// <summary>Distributes unused space between adjacent items.</summary>
+    SpaceBetween,
+    /// <summary>Distributes unused space before, between, and after items.</summary>
+    SpaceEvenly
+}
+
+/// <summary>
+/// Defines how uniform-grid items consume unused space on the non-scrolling axis.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridUniformGridItemsStretch
+{
+    /// <summary>Retains the configured or measured item size.</summary>
+    None,
+    /// <summary>Stretches items on the non-scrolling axis.</summary>
+    Fill,
+    /// <summary>Stretches items while retaining their aspect ratio.</summary>
+    Uniform
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
@@ -162,6 +162,43 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm, ID
     {
     }
 
+    public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) => true;
+
+    public bool TryGetNavigationBounds(
+        IDataGridLayoutContext context,
+        int itemIndex,
+        Rect viewport,
+        out Rect bounds)
+    {
+        if (itemIndex < 0 || itemIndex >= context.ItemCount)
+        {
+            bounds = default;
+            return false;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = _model.Orientation;
+        double spacingU = Math.Max(0, GetSpacingU(orientation));
+        double spacingV = Math.Max(0, GetSpacingV(orientation));
+        double availableU = IsFinitePositive(state.AvailableU)
+            ? state.AvailableU
+            : Math.Max(1, GetU(viewport.Size, orientation));
+        state.EnsureEstimates(context.GetEstimatedItemSize(itemIndex), orientation);
+        int itemsPerLine = Math.Max(
+            1,
+            (int)Math.Floor((availableU + spacingU) / (Math.Max(1, state.AverageItemU) + spacingU)));
+        bounds = GetEstimatedBounds(
+            context,
+            state,
+            itemIndex,
+            orientation,
+            itemsPerLine,
+            context.ItemCount,
+            spacingU,
+            spacingV);
+        return true;
+    }
+
     public bool TryResolveNavigation(
         IDataGridLayoutContext context,
         in DataGridLayoutNavigationRequest request,

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.DataGridLayouts;
 
-internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
+internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm, IDataGridLayoutNavigation
 {
     private readonly DataGridWrapLayoutModel _model;
 
@@ -162,6 +162,264 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
     {
     }
 
+    public bool TryResolveNavigation(
+        IDataGridLayoutContext context,
+        in DataGridLayoutNavigationRequest request,
+        out DataGridLayoutNavigationResult result)
+    {
+        result = default;
+        int itemCount = context.ItemCount;
+        int current = request.CurrentItemIndex;
+        if (current < 0 || current >= itemCount)
+        {
+            return false;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = _model.Orientation;
+        double spacingU = Math.Max(0, GetSpacingU(orientation));
+        double spacingV = Math.Max(0, GetSpacingV(orientation));
+        double availableU = IsFinitePositive(state.AvailableU)
+            ? state.AvailableU
+            : Math.Max(1, GetU(request.Viewport.Size, orientation));
+        state.EnsureEstimates(context.GetEstimatedItemSize(current), orientation);
+        int estimatedItemsPerLine = Math.Max(
+            1,
+            (int)Math.Floor((availableU + spacingU) / (Math.Max(1, state.AverageItemU) + spacingU)));
+
+        LineInfo currentLine = state.TryFindLineForItem(current, out LineInfo cachedCurrentLine)
+            ? cachedCurrentLine
+            : EstimateLine(current, itemCount, estimatedItemsPerLine, state, spacingV);
+        int target;
+
+        switch (request.Direction)
+        {
+            case DataGridLayoutNavigationDirection.Left when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Up when orientation == DataGridLayoutOrientation.Vertical:
+                target = current > currentLine.FirstIndex ? current - 1 : -1;
+                break;
+            case DataGridLayoutNavigationDirection.Right when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Down when orientation == DataGridLayoutOrientation.Vertical:
+                target = current < currentLine.LastIndex ? current + 1 : -1;
+                break;
+            case DataGridLayoutNavigationDirection.Up when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Left when orientation == DataGridLayoutOrientation.Vertical:
+                target = FindCrossLineTarget(
+                    context,
+                    state,
+                    currentLine,
+                    previous: true,
+                    request.NavigationAnchor,
+                    orientation,
+                    estimatedItemsPerLine,
+                    itemCount,
+                    spacingU,
+                    spacingV);
+                break;
+            case DataGridLayoutNavigationDirection.Down when orientation == DataGridLayoutOrientation.Horizontal:
+            case DataGridLayoutNavigationDirection.Right when orientation == DataGridLayoutOrientation.Vertical:
+                target = FindCrossLineTarget(
+                    context,
+                    state,
+                    currentLine,
+                    previous: false,
+                    request.NavigationAnchor,
+                    orientation,
+                    estimatedItemsPerLine,
+                    itemCount,
+                    spacingU,
+                    spacingV);
+                break;
+            case DataGridLayoutNavigationDirection.LineStart:
+                target = currentLine.FirstIndex;
+                break;
+            case DataGridLayoutNavigationDirection.LineEnd:
+                target = currentLine.LastIndex;
+                break;
+            case DataGridLayoutNavigationDirection.PageUp:
+            case DataGridLayoutNavigationDirection.PageDown:
+                target = FindPageTarget(
+                    context,
+                    state,
+                    currentLine,
+                    request,
+                    orientation,
+                    estimatedItemsPerLine,
+                    itemCount,
+                    spacingU,
+                    spacingV);
+                break;
+            case DataGridLayoutNavigationDirection.First:
+                target = 0;
+                break;
+            case DataGridLayoutNavigationDirection.Last:
+                target = itemCount - 1;
+                break;
+            default:
+                return false;
+        }
+
+        if (target < 0 || target >= itemCount || target == current)
+        {
+            return false;
+        }
+
+        result = new DataGridLayoutNavigationResult(
+            target,
+            GetEstimatedBounds(
+                context,
+                state,
+                target,
+                orientation,
+                estimatedItemsPerLine,
+                itemCount,
+                spacingU,
+                spacingV));
+        return true;
+    }
+
+    private static int FindCrossLineTarget(
+        IDataGridLayoutContext context,
+        State state,
+        LineInfo currentLine,
+        bool previous,
+        Point navigationAnchor,
+        DataGridLayoutOrientation orientation,
+        int estimatedItemsPerLine,
+        int itemCount,
+        double spacingU,
+        double spacingV)
+    {
+        LineInfo targetLine;
+        if (!state.TryFindAdjacentLine(currentLine, previous, out targetLine))
+        {
+            int lineNumber = currentLine.FirstIndex / estimatedItemsPerLine + (previous ? -1 : 1);
+            if (lineNumber < 0 || lineNumber * estimatedItemsPerLine >= itemCount)
+            {
+                return -1;
+            }
+            targetLine = EstimateLine(lineNumber * estimatedItemsPerLine, itemCount, estimatedItemsPerLine, state, spacingV);
+        }
+
+        return FindClosestItemOnLine(
+            context,
+            state,
+            targetLine,
+            navigationAnchor,
+            orientation,
+            spacingU);
+    }
+
+    private static int FindPageTarget(
+        IDataGridLayoutContext context,
+        State state,
+        LineInfo currentLine,
+        in DataGridLayoutNavigationRequest request,
+        DataGridLayoutOrientation orientation,
+        int estimatedItemsPerLine,
+        int itemCount,
+        double spacingU,
+        double spacingV)
+    {
+        bool forward = request.Direction == DataGridLayoutNavigationDirection.PageDown;
+        double viewportV = Math.Max(1, GetV(request.Viewport.Size, orientation));
+        double desiredV = Math.Max(0, currentLine.V + (forward ? viewportV : -viewportV));
+        LineInfo targetLine;
+        if (!state.TryFindLineAt(desiredV, out targetLine))
+        {
+            double lineAdvance = Math.Max(1, state.AverageLineV) + spacingV;
+            int lineDelta = Math.Max(1, (int)Math.Round(viewportV / lineAdvance));
+            int currentLineNumber = currentLine.FirstIndex / estimatedItemsPerLine;
+            int targetLineNumber = Math.Max(0, currentLineNumber + (forward ? lineDelta : -lineDelta));
+            int firstIndex = Math.Min(itemCount - 1, targetLineNumber * estimatedItemsPerLine);
+            targetLine = EstimateLine(firstIndex, itemCount, estimatedItemsPerLine, state, spacingV);
+        }
+
+        return FindClosestItemOnLine(
+            context,
+            state,
+            targetLine,
+            request.NavigationAnchor,
+            orientation,
+            spacingU);
+    }
+
+    private static int FindClosestItemOnLine(
+        IDataGridLayoutContext context,
+        State state,
+        LineInfo line,
+        Point navigationAnchor,
+        DataGridLayoutOrientation orientation,
+        double spacingU)
+    {
+        double anchorU = orientation == DataGridLayoutOrientation.Horizontal
+            ? navigationAnchor.X
+            : navigationAnchor.Y;
+        int bestIndex = line.FirstIndex;
+        double bestDistance = double.PositiveInfinity;
+        for (int index = line.FirstIndex; index <= line.LastIndex; index++)
+        {
+            double centerU;
+            if (context.TryGetLayoutBounds(index, out Rect bounds))
+            {
+                centerU = orientation == DataGridLayoutOrientation.Horizontal
+                    ? bounds.Center.X
+                    : bounds.Center.Y;
+            }
+            else
+            {
+                centerU = ((index - line.FirstIndex) * (Math.Max(1, state.AverageItemU) + spacingU)) +
+                    (Math.Max(1, state.AverageItemU) / 2);
+            }
+
+            double distance = Math.Abs(centerU - anchorU);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                bestIndex = index;
+            }
+        }
+        return bestIndex;
+    }
+
+    private static LineInfo EstimateLine(
+        int itemIndex,
+        int itemCount,
+        int itemsPerLine,
+        State state,
+        double spacingV)
+    {
+        int lineNumber = Math.Max(0, itemIndex / itemsPerLine);
+        int first = lineNumber * itemsPerLine;
+        int last = Math.Min(itemCount - 1, first + itemsPerLine - 1);
+        double lineV = Math.Max(1, state.AverageLineV);
+        return new LineInfo(first, last, lineNumber * (lineV + spacingV), lineV, last - first + 1);
+    }
+
+    private static Rect GetEstimatedBounds(
+        IDataGridLayoutContext context,
+        State state,
+        int itemIndex,
+        DataGridLayoutOrientation orientation,
+        int estimatedItemsPerLine,
+        int itemCount,
+        double spacingU,
+        double spacingV)
+    {
+        if (context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+        {
+            return bounds;
+        }
+
+        LineInfo line = state.TryFindLineForItem(itemIndex, out LineInfo cachedLine)
+            ? cachedLine
+            : EstimateLine(itemIndex, itemCount, estimatedItemsPerLine, state, spacingV);
+        double sizeU = Math.Max(1, state.AverageItemU);
+        double sizeV = Math.Max(1, state.AverageItemV);
+        double u = (itemIndex - line.FirstIndex) * (sizeU + spacingU);
+        return ToRect(u, line.V, sizeU, sizeV, orientation);
+    }
+
     private double GetSpacingU(DataGridLayoutOrientation orientation) =>
         orientation == DataGridLayoutOrientation.Horizontal ? _model.HorizontalSpacing : _model.VerticalSpacing;
 
@@ -263,6 +521,56 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
         public double AverageLineV { get; private set; }
         public double AverageItemsPerLine { get; private set; }
         public double MaximumUsedU { get; set; }
+        public double AvailableU => _availableU;
+
+        public bool TryFindLineForItem(int itemIndex, out LineInfo line)
+        {
+            for (int index = 0; index < _lines.Count; index++)
+            {
+                LineInfo candidate = _lines[index];
+                if (itemIndex >= candidate.FirstIndex && itemIndex <= candidate.LastIndex)
+                {
+                    line = candidate;
+                    return true;
+                }
+            }
+            line = default;
+            return false;
+        }
+
+        public bool TryFindAdjacentLine(LineInfo current, bool previous, out LineInfo line)
+        {
+            LineInfo? best = null;
+            for (int index = 0; index < _lines.Count; index++)
+            {
+                LineInfo candidate = _lines[index];
+                if (previous ? candidate.LastIndex < current.FirstIndex : candidate.FirstIndex > current.LastIndex)
+                {
+                    if (!best.HasValue ||
+                        (previous ? candidate.LastIndex > best.Value.LastIndex : candidate.FirstIndex < best.Value.FirstIndex))
+                    {
+                        best = candidate;
+                    }
+                }
+            }
+            line = best.GetValueOrDefault();
+            return best.HasValue;
+        }
+
+        public bool TryFindLineAt(double v, out LineInfo line)
+        {
+            for (int index = 0; index < _lines.Count; index++)
+            {
+                LineInfo candidate = _lines[index];
+                if (v >= candidate.V && v <= candidate.V + candidate.SizeV)
+                {
+                    line = candidate;
+                    return true;
+                }
+            }
+            line = default;
+            return false;
+        }
 
         public void EnsureParameters(
             DataGridLayoutOrientation orientation,

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
@@ -18,7 +18,7 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
 
     public void Initialize(IDataGridLayoutContext context)
     {
-        context.LayoutState = new State();
+        context.LayoutState ??= new State();
     }
 
     public Size Measure(IDataGridLayoutContext context, Size availableSize)
@@ -54,7 +54,13 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
         Anchor anchor = state.FindAnchor(realizationStart, context.RecommendedAnchorIndex);
         if (!anchor.IsValid)
         {
-            anchor = state.EstimateAnchor(realizationStart, itemCount, availableU, spacingU, spacingV);
+            anchor = context.RecommendedAnchorIndex >= 0
+                ? state.EstimateAnchorForIndex(context.RecommendedAnchorIndex, itemCount, availableU, spacingU, spacingV)
+                : state.EstimateAnchor(realizationStart, itemCount, availableU, spacingU, spacingV);
+        }
+        if (context.RecommendedAnchorIndex >= 0)
+        {
+            realizationEnd = anchor.V + Math.Max(1, GetV(context.RealizationRect.Size, orientation));
         }
 
         int firstIndex = Math.Max(0, Math.Min(itemCount - 1, anchor.ItemIndex));
@@ -329,6 +335,18 @@ internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
             int line = Math.Max(0, (int)Math.Floor(realizationStart / lineAdvance));
             int itemIndex = Math.Min(itemCount - 1, line * itemsPerLine);
             return new Anchor(itemIndex, line * lineAdvance);
+        }
+
+        public Anchor EstimateAnchorForIndex(
+            int recommendedIndex,
+            int itemCount,
+            double availableU,
+            double spacingU,
+            double spacingV)
+        {
+            int itemsPerLine = Math.Max(1, (int)Math.Floor((availableU + spacingU) / (Math.Max(1, AverageItemU) + spacingU)));
+            int line = Math.Max(0, Math.Min(itemCount - 1, recommendedIndex)) / itemsPerLine;
+            return new Anchor(line * itemsPerLine, line * (Math.Max(1, AverageLineV) + spacingV));
         }
 
         public void RecordItem(double u, double v)

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutAlgorithm.cs
@@ -1,0 +1,372 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+internal sealed class DataGridWrapLayoutAlgorithm : IDataGridLayoutAlgorithm
+{
+    private readonly DataGridWrapLayoutModel _model;
+
+    public DataGridWrapLayoutAlgorithm(DataGridWrapLayoutModel model)
+    {
+        _model = model;
+    }
+
+    public void Initialize(IDataGridLayoutContext context)
+    {
+        context.LayoutState = new State();
+    }
+
+    public Size Measure(IDataGridLayoutContext context, Size availableSize)
+    {
+        int itemCount = context.ItemCount;
+        if (itemCount <= 0)
+        {
+            RecycleOutsideRange(context, 0, -1);
+            context.LayoutOrigin = default;
+            return default;
+        }
+
+        State state = GetState(context);
+        DataGridLayoutOrientation orientation = _model.Orientation;
+        double spacingU = Math.Max(0, GetSpacingU(orientation));
+        double spacingV = Math.Max(0, GetSpacingV(orientation));
+        double availableU = GetU(availableSize, orientation);
+        if (!IsFinitePositive(availableU))
+        {
+            availableU = GetU(context.RealizationRect.Size, orientation);
+        }
+        if (!IsFinitePositive(availableU))
+        {
+            availableU = Math.Max(1, GetU(context.GetEstimatedItemSize(0), orientation));
+        }
+
+        state.EnsureParameters(orientation, availableU, spacingU, spacingV);
+        int estimateIndex = Math.Max(0, Math.Min(itemCount - 1, context.RecommendedAnchorIndex));
+        state.EnsureEstimates(context.GetEstimatedItemSize(estimateIndex), orientation);
+
+        double realizationStart = Math.Max(0, GetVStart(context.RealizationRect, orientation));
+        double realizationEnd = Math.Max(realizationStart, GetVEnd(context.RealizationRect, orientation));
+        Anchor anchor = state.FindAnchor(realizationStart, context.RecommendedAnchorIndex);
+        if (!anchor.IsValid)
+        {
+            anchor = state.EstimateAnchor(realizationStart, itemCount, availableU, spacingU, spacingV);
+        }
+
+        int firstIndex = Math.Max(0, Math.Min(itemCount - 1, anchor.ItemIndex));
+        int index = firstIndex;
+        int lastIndex = firstIndex - 1;
+        double v = Math.Max(0, anchor.V);
+        double measuredEndV = v;
+        double maximumUsedU = state.MaximumUsedU;
+        Size measureConstraint = ToSize(availableU, double.PositiveInfinity, orientation);
+
+        while (index < itemCount)
+        {
+            int lineStartIndex = index;
+            double u = 0;
+            double lineV = 0;
+            int lineItemCount = 0;
+
+            while (index < itemCount)
+            {
+                Control element = context.GetOrCreateElementAt(index);
+                element.Measure(measureConstraint);
+                Size desired = element.DesiredSize;
+                double itemU = Math.Max(1, GetU(desired, orientation));
+                double itemV = Math.Max(1, GetV(desired, orientation));
+
+                if (lineItemCount > 0 && u + itemU > availableU)
+                {
+                    break;
+                }
+
+                context.SetLayoutBounds(index, ToRect(u, v, itemU, itemV, orientation));
+                state.RecordItem(itemU, itemV);
+                lineV = Math.Max(lineV, itemV);
+                u += itemU;
+                lineItemCount++;
+                lastIndex = index;
+                index++;
+
+                if (index < itemCount)
+                {
+                    u += spacingU;
+                }
+            }
+
+            maximumUsedU = Math.Max(maximumUsedU, Math.Max(0, u - (index < itemCount ? spacingU : 0)));
+            state.RecordLine(new LineInfo(lineStartIndex, lastIndex, v, lineV, lineItemCount), Math.Max(1, _model.MaximumCachedLines));
+            measuredEndV = v + lineV;
+            if (measuredEndV >= realizationEnd || index >= itemCount)
+            {
+                break;
+            }
+
+            v = measuredEndV + spacingV;
+        }
+
+        state.MaximumUsedU = maximumUsedU;
+        RecycleOutsideRange(context, firstIndex, lastIndex);
+        context.LayoutOrigin = default;
+
+        double extentV;
+        if (lastIndex >= itemCount - 1)
+        {
+            extentV = measuredEndV;
+        }
+        else
+        {
+            double averageItemsPerLine = Math.Max(1, state.AverageItemsPerLine);
+            int estimatedLineCount = Math.Max(1, (int)Math.Ceiling(itemCount / averageItemsPerLine));
+            extentV = (estimatedLineCount * Math.Max(1, state.AverageLineV)) +
+                (Math.Max(0, estimatedLineCount - 1) * spacingV);
+            extentV = Math.Max(extentV, measuredEndV);
+        }
+
+        return ToSize(Math.Max(availableU, maximumUsedU), extentV, orientation);
+    }
+
+    public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+    {
+        Vector offset = context.ScrollOffset;
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = 0; index < realized.Count; index++)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex >= 0 && context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+            {
+                element.Arrange(new Rect(bounds.X - offset.X, bounds.Y - offset.Y, bounds.Width, bounds.Height));
+            }
+        }
+        return finalSize;
+    }
+
+    public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+    {
+        context.LayoutState = new State();
+    }
+
+    public void Uninitialize(IDataGridLayoutContext context)
+    {
+    }
+
+    private double GetSpacingU(DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? _model.HorizontalSpacing : _model.VerticalSpacing;
+
+    private double GetSpacingV(DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? _model.VerticalSpacing : _model.HorizontalSpacing;
+
+    private static State GetState(IDataGridLayoutContext context)
+    {
+        if (context.LayoutState is State state)
+        {
+            return state;
+        }
+        state = new State();
+        context.LayoutState = state;
+        return state;
+    }
+
+    private static void RecycleOutsideRange(IDataGridLayoutContext context, int firstIndex, int lastIndex)
+    {
+        IReadOnlyList<Control> realized = context.RealizedElements;
+        for (int index = realized.Count - 1; index >= 0; index--)
+        {
+            Control element = realized[index];
+            int itemIndex = context.GetElementIndex(element);
+            if (itemIndex < firstIndex || itemIndex > lastIndex)
+            {
+                context.RecycleElement(element);
+            }
+        }
+    }
+
+    private static double GetU(Size size, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? size.Width : size.Height;
+
+    private static double GetV(Size size, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? size.Height : size.Width;
+
+    private static double GetVStart(Rect rect, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? rect.Y : rect.X;
+
+    private static double GetVEnd(Rect rect, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? rect.Bottom : rect.Right;
+
+    private static Size ToSize(double u, double v, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal ? new Size(u, v) : new Size(v, u);
+
+    private static Rect ToRect(double u, double v, double sizeU, double sizeV, DataGridLayoutOrientation orientation) =>
+        orientation == DataGridLayoutOrientation.Horizontal
+            ? new Rect(u, v, sizeU, sizeV)
+            : new Rect(v, u, sizeV, sizeU);
+
+    private static bool IsFinitePositive(double value) =>
+        !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
+
+    private readonly struct Anchor
+    {
+        public Anchor(int itemIndex, double v)
+        {
+            ItemIndex = itemIndex;
+            V = v;
+            IsValid = itemIndex >= 0 && !double.IsNaN(v);
+        }
+
+        public int ItemIndex { get; }
+        public double V { get; }
+        public bool IsValid { get; }
+    }
+
+    private readonly struct LineInfo
+    {
+        public LineInfo(int firstIndex, int lastIndex, double v, double sizeV, int itemCount)
+        {
+            FirstIndex = firstIndex;
+            LastIndex = lastIndex;
+            V = v;
+            SizeV = sizeV;
+            ItemCount = itemCount;
+        }
+
+        public int FirstIndex { get; }
+        public int LastIndex { get; }
+        public double V { get; }
+        public double SizeV { get; }
+        public int ItemCount { get; }
+    }
+
+    private sealed class State
+    {
+        private readonly List<LineInfo> _lines = new();
+        private DataGridLayoutOrientation _orientation;
+        private double _availableU = double.NaN;
+        private double _spacingU = double.NaN;
+        private double _spacingV = double.NaN;
+        private int _itemSamples;
+        private int _lineSamples;
+
+        public double AverageItemU { get; private set; }
+        public double AverageItemV { get; private set; }
+        public double AverageLineV { get; private set; }
+        public double AverageItemsPerLine { get; private set; }
+        public double MaximumUsedU { get; set; }
+
+        public void EnsureParameters(
+            DataGridLayoutOrientation orientation,
+            double availableU,
+            double spacingU,
+            double spacingV)
+        {
+            if (_orientation != orientation ||
+                !AreClose(_availableU, availableU) ||
+                !AreClose(_spacingU, spacingU) ||
+                !AreClose(_spacingV, spacingV))
+            {
+                _lines.Clear();
+                MaximumUsedU = 0;
+                _orientation = orientation;
+                _availableU = availableU;
+                _spacingU = spacingU;
+                _spacingV = spacingV;
+            }
+        }
+
+        public void EnsureEstimates(Size estimate, DataGridLayoutOrientation orientation)
+        {
+            if (AverageItemU <= 0)
+            {
+                AverageItemU = Math.Max(1, GetU(estimate, orientation));
+            }
+            if (AverageItemV <= 0)
+            {
+                AverageItemV = Math.Max(1, GetV(estimate, orientation));
+            }
+            if (AverageLineV <= 0)
+            {
+                AverageLineV = AverageItemV;
+            }
+        }
+
+        public Anchor FindAnchor(double realizationStart, int recommendedAnchorIndex)
+        {
+            LineInfo? best = null;
+            for (int index = 0; index < _lines.Count; index++)
+            {
+                LineInfo line = _lines[index];
+                if (recommendedAnchorIndex >= line.FirstIndex && recommendedAnchorIndex <= line.LastIndex)
+                {
+                    best = line;
+                    break;
+                }
+                if (line.V <= realizationStart && (!best.HasValue || line.V > best.Value.V))
+                {
+                    best = line;
+                }
+                else if (!best.HasValue && line.V > realizationStart)
+                {
+                    best = line;
+                }
+            }
+            return best.HasValue ? new Anchor(best.Value.FirstIndex, best.Value.V) : default;
+        }
+
+        public Anchor EstimateAnchor(
+            double realizationStart,
+            int itemCount,
+            double availableU,
+            double spacingU,
+            double spacingV)
+        {
+            int itemsPerLine = Math.Max(1, (int)Math.Floor((availableU + spacingU) / (Math.Max(1, AverageItemU) + spacingU)));
+            double lineAdvance = Math.Max(1, AverageLineV) + spacingV;
+            int line = Math.Max(0, (int)Math.Floor(realizationStart / lineAdvance));
+            int itemIndex = Math.Min(itemCount - 1, line * itemsPerLine);
+            return new Anchor(itemIndex, line * lineAdvance);
+        }
+
+        public void RecordItem(double u, double v)
+        {
+            _itemSamples++;
+            double weight = _itemSamples <= 256 ? 1d / _itemSamples : 1d / 256;
+            AverageItemU += (u - AverageItemU) * weight;
+            AverageItemV += (v - AverageItemV) * weight;
+        }
+
+        public void RecordLine(LineInfo line, int maximumCachedLines)
+        {
+            for (int index = 0; index < _lines.Count; index++)
+            {
+                if (_lines[index].FirstIndex == line.FirstIndex)
+                {
+                    _lines[index] = line;
+                    UpdateLineAverages(line);
+                    return;
+                }
+            }
+
+            _lines.Add(line);
+            while (_lines.Count > maximumCachedLines)
+            {
+                _lines.RemoveAt(0);
+            }
+            UpdateLineAverages(line);
+        }
+
+        private void UpdateLineAverages(LineInfo line)
+        {
+            _lineSamples++;
+            double weight = _lineSamples <= 256 ? 1d / _lineSamples : 1d / 256;
+            AverageLineV += (line.SizeV - AverageLineV) * weight;
+            AverageItemsPerLine += (line.ItemCount - AverageItemsPerLine) * weight;
+        }
+
+        private static bool AreClose(double first, double second) => Math.Abs(first - second) < 0.01;
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/DataGridWrapLayoutModel.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Arranges variable-size DataGrid rows in virtualized wrapping rows or columns.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+sealed class DataGridWrapLayoutModel : DataGridLayoutModelBase
+{
+    private DataGridLayoutOrientation _orientation = DataGridLayoutOrientation.Horizontal;
+    private double _horizontalSpacing;
+    private double _verticalSpacing;
+    private int _maximumCachedLines = 256;
+
+    /// <summary>
+    /// Gets or sets the direction in which items fill each line before wrapping.
+    /// </summary>
+    public DataGridLayoutOrientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value, DataGridLayoutInvalidationKind.Reset);
+    }
+
+    /// <summary>
+    /// Gets or sets the horizontal distance between items or columns.
+    /// </summary>
+    public double HorizontalSpacing
+    {
+        get => _horizontalSpacing;
+        set => SetProperty(ref _horizontalSpacing, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the vertical distance between items or rows.
+    /// </summary>
+    public double VerticalSpacing
+    {
+        get => _verticalSpacing;
+        set => SetProperty(ref _verticalSpacing, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of recently measured line records retained for anchoring.
+    /// </summary>
+    /// <remarks>
+    /// Values less than one use a single cached line. The default is 256 and does not grow with the
+    /// item count.
+    /// </remarks>
+    public int MaximumCachedLines
+    {
+        get => _maximumCachedLines;
+        set => SetProperty(ref _maximumCachedLines, value);
+    }
+
+    /// <inheritdoc/>
+    public override IDataGridLayoutAlgorithm CreateAlgorithm()
+    {
+        return new DataGridWrapLayoutAlgorithm(this);
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutAlgorithm.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutAlgorithm.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System.Collections.Specialized;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Computes row realization, measurement, and arrangement for a DataGrid layout model.
+/// </summary>
+/// <remarks>
+/// Implementations request and recycle row containers through <see cref="IDataGridLayoutContext"/>.
+/// The DataGrid remains responsible for container creation, preparation, selection, editing, and recycling.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IDataGridLayoutAlgorithm
+{
+    /// <summary>
+    /// Initializes the algorithm for a layout context.
+    /// </summary>
+    /// <param name="context">The owning grid layout context.</param>
+    void Initialize(IDataGridLayoutContext context);
+
+    /// <summary>
+    /// Measures the layout and realizes the rows needed by the realization window.
+    /// </summary>
+    /// <param name="context">The owning grid layout context.</param>
+    /// <param name="availableSize">The available layout size.</param>
+    /// <returns>The estimated extent required by the layout.</returns>
+    Size Measure(IDataGridLayoutContext context, Size availableSize);
+
+    /// <summary>
+    /// Arranges realized rows using bounds recorded in the layout context.
+    /// </summary>
+    /// <param name="context">The owning grid layout context.</param>
+    /// <param name="finalSize">The final viewport size.</param>
+    /// <returns>The arranged size.</returns>
+    Size Arrange(IDataGridLayoutContext context, Size finalSize);
+
+    /// <summary>
+    /// Notifies the algorithm that the items collection changed.
+    /// </summary>
+    /// <param name="context">The owning grid layout context.</param>
+    /// <param name="change">The collection change.</param>
+    void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change);
+
+    /// <summary>
+    /// Releases context-specific resources before the algorithm is detached.
+    /// </summary>
+    /// <param name="context">The owning grid layout context.</param>
+    void Uninitialize(IDataGridLayoutContext context);
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using System.Collections.Generic;
+
 namespace Avalonia.Controls.DataGridLayouts;
 
 /// <summary>
@@ -24,6 +26,11 @@ interface IDataGridLayoutContext
     Rect RealizationRect { get; }
 
     /// <summary>
+    /// Gets the current logical scroll offset in layout coordinates.
+    /// </summary>
+    Vector ScrollOffset { get; }
+
+    /// <summary>
     /// Gets the preferred anchor index, or <c>-1</c> when no anchor is available.
     /// </summary>
     int RecommendedAnchorIndex { get; }
@@ -37,6 +44,11 @@ interface IDataGridLayoutContext
     /// Gets or sets per-grid state owned by the active layout algorithm.
     /// </summary>
     object? LayoutState { get; set; }
+
+    /// <summary>
+    /// Gets a live, allocation-free view of the currently realized containers.
+    /// </summary>
+    IReadOnlyList<Control> RealizedElements { get; }
 
     /// <summary>
     /// Gets or creates the row container for an item index.
@@ -64,6 +76,17 @@ interface IDataGridLayoutContext
     /// <param name="index">The zero-based layout item index.</param>
     /// <returns>The measured size when cached; otherwise the current estimate.</returns>
     Size GetEstimatedItemSize(int index);
+
+    /// <summary>
+    /// Gets the estimated major-axis offset to an item without forcing realization.
+    /// </summary>
+    /// <param name="index">
+    /// The zero-based item index. A value equal to <see cref="ItemCount"/> requests the estimated
+    /// end offset of the collection.
+    /// </param>
+    /// <param name="orientation">The stack orientation that selects the major axis.</param>
+    /// <returns>The estimated offset in device-independent pixels.</returns>
+    double GetEstimatedItemOffset(int index, DataGridLayoutOrientation orientation);
 
     /// <summary>
     /// Records layout bounds for a realized item.

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Provides DataGrid realization services and per-grid state to a layout algorithm.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IDataGridLayoutContext
+{
+    /// <summary>
+    /// Gets the number of layout items, including visible group rows when grouping is active.
+    /// </summary>
+    int ItemCount { get; }
+
+    /// <summary>
+    /// Gets the viewport plus the configured realization cache in layout coordinates.
+    /// </summary>
+    Rect RealizationRect { get; }
+
+    /// <summary>
+    /// Gets the preferred anchor index, or <c>-1</c> when no anchor is available.
+    /// </summary>
+    int RecommendedAnchorIndex { get; }
+
+    /// <summary>
+    /// Gets or sets the estimated origin of the layout extent.
+    /// </summary>
+    Point LayoutOrigin { get; set; }
+
+    /// <summary>
+    /// Gets or sets per-grid state owned by the active layout algorithm.
+    /// </summary>
+    object? LayoutState { get; set; }
+
+    /// <summary>
+    /// Gets or creates the row container for an item index.
+    /// </summary>
+    /// <param name="index">The zero-based layout item index.</param>
+    /// <returns>The prepared row or group container.</returns>
+    Control GetOrCreateElementAt(int index);
+
+    /// <summary>
+    /// Recycles a realized container that is no longer required.
+    /// </summary>
+    /// <param name="element">The container to recycle.</param>
+    void RecycleElement(Control element);
+
+    /// <summary>
+    /// Gets the layout item index represented by a realized container.
+    /// </summary>
+    /// <param name="element">The realized container.</param>
+    /// <returns>The item index, or <c>-1</c> when the element is not realized by this context.</returns>
+    int GetElementIndex(Control element);
+
+    /// <summary>
+    /// Gets the best known item size without forcing realization.
+    /// </summary>
+    /// <param name="index">The zero-based layout item index.</param>
+    /// <returns>The measured size when cached; otherwise the current estimate.</returns>
+    Size GetEstimatedItemSize(int index);
+
+    /// <summary>
+    /// Records layout bounds for a realized item.
+    /// </summary>
+    /// <param name="index">The zero-based layout item index.</param>
+    /// <param name="bounds">The item bounds in layout coordinates.</param>
+    void SetLayoutBounds(int index, Rect bounds);
+
+    /// <summary>
+    /// Attempts to get previously recorded layout bounds for an item.
+    /// </summary>
+    /// <param name="index">The zero-based layout item index.</param>
+    /// <param name="bounds">Receives the item bounds when available.</param>
+    /// <returns><c>true</c> when bounds were found.</returns>
+    bool TryGetLayoutBounds(int index, out Rect bounds);
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutContext.cs
@@ -21,7 +21,7 @@ interface IDataGridLayoutContext
     int ItemCount { get; }
 
     /// <summary>
-    /// Gets the viewport plus the configured realization cache in layout coordinates.
+    /// Gets the current realization window in layout coordinates.
     /// </summary>
     Rect RealizationRect { get; }
 
@@ -58,8 +58,13 @@ interface IDataGridLayoutContext
     Control GetOrCreateElementAt(int index);
 
     /// <summary>
-    /// Recycles a realized container that is no longer required.
+    /// Marks a realized container as no longer required by the algorithm.
     /// </summary>
+    /// <remarks>
+    /// DataGrid performs the actual container lifecycle work after measurement. Because its display
+    /// store is range-based, a marked container can remain realized when it lies between the lowest
+    /// and highest item indexes requested during the same measure pass.
+    /// </remarks>
     /// <param name="element">The container to recycle.</param>
     void RecycleElement(Control element);
 

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutModel.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.ComponentModel;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Describes a model-driven row layout and creates the algorithm that executes it.
+/// </summary>
+/// <remarks>
+/// Layout models are safe to keep in a view model. Per-control realization state is stored by
+/// <see cref="IDataGridLayoutContext"/>, so the same model can be assigned to more than one grid.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IDataGridLayoutModel : INotifyPropertyChanged
+{
+    /// <summary>
+    /// Raised when a model change requires the owning grid to run layout again.
+    /// </summary>
+    event EventHandler<DataGridLayoutInvalidatedEventArgs>? LayoutInvalidated;
+
+    /// <summary>
+    /// Creates an algorithm instance for one DataGrid layout context.
+    /// </summary>
+    /// <returns>A new layout algorithm instance.</returns>
+    IDataGridLayoutAlgorithm CreateAlgorithm();
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutNavigation.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Identifies a spatial navigation operation understood by a DataGrid layout algorithm.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+enum DataGridLayoutNavigationDirection
+{
+    /// <summary>Moves to the nearest item above the current item.</summary>
+    Up,
+    /// <summary>Moves to the nearest item below the current item.</summary>
+    Down,
+    /// <summary>Moves to the nearest item to the left of the current item.</summary>
+    Left,
+    /// <summary>Moves to the nearest item to the right of the current item.</summary>
+    Right,
+    /// <summary>Moves toward the start by approximately one viewport.</summary>
+    PageUp,
+    /// <summary>Moves toward the end by approximately one viewport.</summary>
+    PageDown,
+    /// <summary>Moves to the first item on the current layout line.</summary>
+    LineStart,
+    /// <summary>Moves to the last item on the current layout line.</summary>
+    LineEnd,
+    /// <summary>Moves to the first layout item.</summary>
+    First,
+    /// <summary>Moves to the last layout item.</summary>
+    Last
+}
+
+/// <summary>
+/// Describes a geometry-based navigation request for the active DataGrid layout.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+readonly struct DataGridLayoutNavigationRequest : IEquatable<DataGridLayoutNavigationRequest>
+{
+    /// <summary>
+    /// Initializes a layout navigation request.
+    /// </summary>
+    /// <param name="currentItemIndex">The zero-based layout item index.</param>
+    /// <param name="direction">The requested spatial direction.</param>
+    /// <param name="viewport">The visible viewport in layout coordinates.</param>
+    /// <param name="navigationAnchor">
+    /// The layout-coordinate point whose cross-axis position should be preserved.
+    /// </param>
+    public DataGridLayoutNavigationRequest(
+        int currentItemIndex,
+        DataGridLayoutNavigationDirection direction,
+        Rect viewport,
+        Point navigationAnchor)
+    {
+        CurrentItemIndex = currentItemIndex;
+        Direction = direction;
+        Viewport = viewport;
+        NavigationAnchor = navigationAnchor;
+    }
+
+    /// <summary>Gets the zero-based current layout item index.</summary>
+    public int CurrentItemIndex { get; }
+
+    /// <summary>Gets the requested spatial direction.</summary>
+    public DataGridLayoutNavigationDirection Direction { get; }
+
+    /// <summary>Gets the visible viewport in layout coordinates.</summary>
+    public Rect Viewport { get; }
+
+    /// <summary>Gets the layout-coordinate navigation anchor.</summary>
+    public Point NavigationAnchor { get; }
+
+    /// <inheritdoc/>
+    public bool Equals(DataGridLayoutNavigationRequest other) =>
+        CurrentItemIndex == other.CurrentItemIndex &&
+        Direction == other.Direction &&
+        Viewport == other.Viewport &&
+        NavigationAnchor == other.NavigationAnchor;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DataGridLayoutNavigationRequest other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(CurrentItemIndex, Direction, Viewport, NavigationAnchor);
+
+    /// <summary>Compares two requests for equality.</summary>
+    public static bool operator ==(DataGridLayoutNavigationRequest left, DataGridLayoutNavigationRequest right) => left.Equals(right);
+
+    /// <summary>Compares two requests for inequality.</summary>
+    public static bool operator !=(DataGridLayoutNavigationRequest left, DataGridLayoutNavigationRequest right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Contains the target selected by a layout navigation algorithm.
+/// </summary>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+readonly struct DataGridLayoutNavigationResult : IEquatable<DataGridLayoutNavigationResult>
+{
+    /// <summary>Initializes a layout navigation result.</summary>
+    /// <param name="itemIndex">The zero-based target layout item index.</param>
+    /// <param name="estimatedBounds">The exact or estimated target bounds in layout coordinates.</param>
+    public DataGridLayoutNavigationResult(int itemIndex, Rect estimatedBounds)
+    {
+        ItemIndex = itemIndex;
+        EstimatedBounds = estimatedBounds;
+    }
+
+    /// <summary>Gets the zero-based target layout item index.</summary>
+    public int ItemIndex { get; }
+
+    /// <summary>
+    /// Gets the exact or estimated target bounds. The item does not need to be realized.
+    /// </summary>
+    public Rect EstimatedBounds { get; }
+
+    /// <inheritdoc/>
+    public bool Equals(DataGridLayoutNavigationResult other) =>
+        ItemIndex == other.ItemIndex && EstimatedBounds == other.EstimatedBounds;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DataGridLayoutNavigationResult other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(ItemIndex, EstimatedBounds);
+
+    /// <summary>Compares two results for equality.</summary>
+    public static bool operator ==(DataGridLayoutNavigationResult left, DataGridLayoutNavigationResult right) => left.Equals(right);
+
+    /// <summary>Compares two results for inequality.</summary>
+    public static bool operator !=(DataGridLayoutNavigationResult left, DataGridLayoutNavigationResult right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Optionally supplies geometry-aware item navigation for a DataGrid layout algorithm.
+/// </summary>
+/// <remarks>
+/// Implement this interface together with <see cref="IDataGridLayoutAlgorithm"/> to make a
+/// custom layout participate in keyboard, controller, and programmatic spatial navigation.
+/// Semantic policies such as wrapping, boundary exit, editing, and selection remain the
+/// responsibility of the DataGrid navigation model.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IDataGridLayoutNavigation
+{
+    /// <summary>Attempts to resolve a spatial target without forcing item realization.</summary>
+    /// <param name="context">The active per-grid layout context.</param>
+    /// <param name="request">The spatial request.</param>
+    /// <param name="result">Receives the target index and its estimated bounds.</param>
+    /// <returns><c>true</c> when the layout found a different target item.</returns>
+    bool TryResolveNavigation(
+        IDataGridLayoutContext context,
+        in DataGridLayoutNavigationRequest request,
+        out DataGridLayoutNavigationResult result);
+}

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutNavigation.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutNavigation.cs
@@ -160,6 +160,26 @@ internal
 #endif
 interface IDataGridLayoutNavigation
 {
+    /// <summary>Gets whether this algorithm owns the specified spatial direction.</summary>
+    /// <param name="direction">The direction to query.</param>
+    /// <returns>
+    /// <c>true</c> when the algorithm owns the direction. If resolution then returns
+    /// <c>false</c>, the request is at a layout boundary and must not fall back to linear navigation.
+    /// </returns>
+    bool SupportsNavigation(DataGridLayoutNavigationDirection direction);
+
+    /// <summary>Attempts to get exact or estimated item bounds without forcing realization.</summary>
+    /// <param name="context">The active per-grid layout context.</param>
+    /// <param name="itemIndex">The zero-based layout item index.</param>
+    /// <param name="viewport">The visible viewport in layout-content coordinates.</param>
+    /// <param name="bounds">Receives bounds in layout-content coordinates.</param>
+    /// <returns><c>true</c> when the index is valid and bounds can be estimated.</returns>
+    bool TryGetNavigationBounds(
+        IDataGridLayoutContext context,
+        int itemIndex,
+        Rect viewport,
+        out Rect bounds);
+
     /// <summary>Attempts to resolve a spatial target without forcing item realization.</summary>
     /// <param name="context">The active per-grid layout context.</param>
     /// <param name="request">The spatial request.</param>

--- a/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutPresentationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Layouts/IDataGridLayoutPresentationModel.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Avalonia.Controls.DataGridLayouts;
+
+/// <summary>
+/// Optionally describes how a layout model presents data items and estimates unrealized item sizes.
+/// </summary>
+/// <remarks>
+/// Custom layout models implement this focused capability to opt into item-template presentation.
+/// Models that do not implement it retain conventional row and cell presentation.
+/// </remarks>
+#if !DATAGRID_INTERNAL
+public
+#else
+internal
+#endif
+interface IDataGridLayoutPresentationModel
+{
+    /// <summary>
+    /// Gets the visual presentation used for data items.
+    /// </summary>
+    DataGridLayoutPresentationMode PresentationMode { get; }
+
+    /// <summary>
+    /// Gets the fallback size used for an item that has not been measured yet.
+    /// </summary>
+    Size ItemSizeEstimate { get; }
+}

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -285,39 +285,6 @@ namespace Avalonia.Controls.DataGridNavigation
             int lastRowIndex,
             int firstColumnDisplayIndex,
             int lastColumnDisplayIndex)
-            : this(
-                command,
-                origin,
-                currentPosition,
-                proposedPosition,
-                modifiers,
-                isEditing,
-                selectionMode,
-                selectionUnit,
-                flowDirection,
-                firstRowIndex,
-                lastRowIndex,
-                firstColumnDisplayIndex,
-                lastColumnDisplayIndex,
-                isLayoutNavigationOwned: false)
-        {
-        }
-
-        internal DataGridNavigationRequest(
-            DataGridNavigationCommand command,
-            DataGridNavigationOrigin origin,
-            DataGridNavigationPosition currentPosition,
-            DataGridNavigationPosition? proposedPosition,
-            KeyModifiers modifiers,
-            bool isEditing,
-            DataGridSelectionMode selectionMode,
-            DataGridSelectionUnit selectionUnit,
-            FlowDirection flowDirection,
-            int firstRowIndex,
-            int lastRowIndex,
-            int firstColumnDisplayIndex,
-            int lastColumnDisplayIndex,
-            bool isLayoutNavigationOwned)
         {
             Command = command;
             Origin = origin;
@@ -332,7 +299,6 @@ namespace Avalonia.Controls.DataGridNavigation
             LastRowIndex = lastRowIndex;
             FirstColumnDisplayIndex = firstColumnDisplayIndex;
             LastColumnDisplayIndex = lastColumnDisplayIndex;
-            IsLayoutNavigationOwned = isLayoutNavigationOwned;
         }
 
         /// <summary>Gets the semantic operation.</summary>
@@ -373,8 +339,6 @@ namespace Avalonia.Controls.DataGridNavigation
 
         /// <summary>Gets the last navigable column display index.</summary>
         public int LastColumnDisplayIndex { get; }
-
-        internal bool IsLayoutNavigationOwned { get; }
 
         /// <summary>Gets whether the request describes at least one navigable row.</summary>
         public bool HasRows => FirstRowIndex >= 0 && LastRowIndex >= FirstRowIndex;
@@ -971,9 +935,6 @@ namespace Avalonia.Controls.DataGridNavigation
         {
             return HorizontalBoundaryMode switch
             {
-                DataGridNavigationBoundaryMode.Wrap when request.IsLayoutNavigationOwned =>
-                    DataGridNavigationResult.RedirectTo(
-                        moveToEnd ? DataGridNavigationCommand.RowEnd : DataGridNavigationCommand.RowStart),
                 DataGridNavigationBoundaryMode.Wrap when request.HasColumns =>
                     DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
                         request.CurrentPosition.RowIndex,
@@ -989,9 +950,6 @@ namespace Avalonia.Controls.DataGridNavigation
         {
             return VerticalBoundaryMode switch
             {
-                DataGridNavigationBoundaryMode.Wrap when request.IsLayoutNavigationOwned =>
-                    DataGridNavigationResult.RedirectTo(
-                        moveToEnd ? DataGridNavigationCommand.ColumnEnd : DataGridNavigationCommand.ColumnStart),
                 DataGridNavigationBoundaryMode.Wrap when request.HasRows =>
                     DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
                         moveToEnd ? request.LastRowIndex : request.FirstRowIndex,

--- a/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Navigation/DataGridNavigationModel.cs
@@ -285,6 +285,39 @@ namespace Avalonia.Controls.DataGridNavigation
             int lastRowIndex,
             int firstColumnDisplayIndex,
             int lastColumnDisplayIndex)
+            : this(
+                command,
+                origin,
+                currentPosition,
+                proposedPosition,
+                modifiers,
+                isEditing,
+                selectionMode,
+                selectionUnit,
+                flowDirection,
+                firstRowIndex,
+                lastRowIndex,
+                firstColumnDisplayIndex,
+                lastColumnDisplayIndex,
+                isLayoutNavigationOwned: false)
+        {
+        }
+
+        internal DataGridNavigationRequest(
+            DataGridNavigationCommand command,
+            DataGridNavigationOrigin origin,
+            DataGridNavigationPosition currentPosition,
+            DataGridNavigationPosition? proposedPosition,
+            KeyModifiers modifiers,
+            bool isEditing,
+            DataGridSelectionMode selectionMode,
+            DataGridSelectionUnit selectionUnit,
+            FlowDirection flowDirection,
+            int firstRowIndex,
+            int lastRowIndex,
+            int firstColumnDisplayIndex,
+            int lastColumnDisplayIndex,
+            bool isLayoutNavigationOwned)
         {
             Command = command;
             Origin = origin;
@@ -299,6 +332,7 @@ namespace Avalonia.Controls.DataGridNavigation
             LastRowIndex = lastRowIndex;
             FirstColumnDisplayIndex = firstColumnDisplayIndex;
             LastColumnDisplayIndex = lastColumnDisplayIndex;
+            IsLayoutNavigationOwned = isLayoutNavigationOwned;
         }
 
         /// <summary>Gets the semantic operation.</summary>
@@ -339,6 +373,8 @@ namespace Avalonia.Controls.DataGridNavigation
 
         /// <summary>Gets the last navigable column display index.</summary>
         public int LastColumnDisplayIndex { get; }
+
+        internal bool IsLayoutNavigationOwned { get; }
 
         /// <summary>Gets whether the request describes at least one navigable row.</summary>
         public bool HasRows => FirstRowIndex >= 0 && LastRowIndex >= FirstRowIndex;
@@ -935,6 +971,9 @@ namespace Avalonia.Controls.DataGridNavigation
         {
             return HorizontalBoundaryMode switch
             {
+                DataGridNavigationBoundaryMode.Wrap when request.IsLayoutNavigationOwned =>
+                    DataGridNavigationResult.RedirectTo(
+                        moveToEnd ? DataGridNavigationCommand.RowEnd : DataGridNavigationCommand.RowStart),
                 DataGridNavigationBoundaryMode.Wrap when request.HasColumns =>
                     DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
                         request.CurrentPosition.RowIndex,
@@ -950,6 +989,9 @@ namespace Avalonia.Controls.DataGridNavigation
         {
             return VerticalBoundaryMode switch
             {
+                DataGridNavigationBoundaryMode.Wrap when request.IsLayoutNavigationOwned =>
+                    DataGridNavigationResult.RedirectTo(
+                        moveToEnd ? DataGridNavigationCommand.ColumnEnd : DataGridNavigationCommand.ColumnStart),
                 DataGridNavigationBoundaryMode.Wrap when request.HasRows =>
                     DataGridNavigationResult.MoveTo(new DataGridNavigationPosition(
                         moveToEnd ? request.LastRowIndex : request.FirstRowIndex,

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
@@ -1,0 +1,354 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls.DataGridLayouts;
+using Avalonia.Media;
+
+namespace Avalonia.Controls.Primitives
+{
+    #if !DATAGRID_INTERNAL
+    public
+    #else
+    internal
+    #endif
+    sealed partial class DataGridRowsPresenter
+    {
+        private readonly ConditionalWeakTable<IDataGridLayoutModel, LayoutSession> _layoutSessions = new();
+        private LayoutSession? _activeLayoutSession;
+        private int _requestedLayoutAnchorIndex = -1;
+
+        internal bool UsesLayoutModel => OwningGrid?.LayoutModel != null;
+
+        internal void OnLayoutModelChanged(IDataGridLayoutModel? oldModel, IDataGridLayoutModel? newModel)
+        {
+            if (_activeLayoutSession != null && ReferenceEquals(_activeLayoutSession.Model, oldModel))
+            {
+                _activeLayoutSession.Algorithm.Uninitialize(_activeLayoutSession.Context);
+                _activeLayoutSession.IsInitialized = false;
+                _activeLayoutSession = null;
+            }
+
+            CancelPrefetch();
+            InvalidateMeasure();
+            InvalidateArrange();
+        }
+
+        internal void OnLayoutModelInvalidated(IDataGridLayoutModel model, DataGridLayoutInvalidationKind kind)
+        {
+            if (kind == DataGridLayoutInvalidationKind.Reset && _layoutSessions.TryGetValue(model, out LayoutSession? session))
+            {
+                session.State = null;
+                session.Bounds.Clear();
+                session.LastItemCount = -1;
+            }
+        }
+
+        internal bool ScrollLayoutIndexIntoView(int layoutIndex)
+        {
+            if (!UsesLayoutModel || OwningGrid == null || layoutIndex < 0 || layoutIndex >= OwningGrid.LayoutItemCount)
+            {
+                return false;
+            }
+
+            _requestedLayoutAnchorIndex = layoutIndex;
+            InvalidateMeasure();
+            return true;
+        }
+
+        private Size MeasureLayoutModel(Size availableSize)
+        {
+            DataGrid grid = OwningGrid!;
+            IDataGridLayoutModel model = grid.LayoutModel!;
+            LayoutSession session = GetLayoutSession(model);
+            Size viewport = NormalizeViewport(availableSize);
+
+            session.Context.BeginMeasure(viewport, _offset);
+            if (session.LastItemCount != grid.LayoutItemCount)
+            {
+                session.Algorithm.OnItemsChanged(
+                    session.Context,
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                session.LastItemCount = grid.LayoutItemCount;
+            }
+
+            Size extent = session.Algorithm.Measure(session.Context, viewport);
+            session.Context.CompleteMeasure();
+            if (_requestedLayoutAnchorIndex >= 0 &&
+                session.Bounds.TryGetValue(_requestedLayoutAnchorIndex, out Rect anchorBounds))
+            {
+                _offset = BringBoundsIntoViewport(_offset, viewport, anchorBounds);
+                session.Context.SetViewport(viewport, _offset);
+                _requestedLayoutAnchorIndex = -1;
+            }
+            UpdateMeasuredLayoutMetadata(grid);
+
+            extent = new Size(
+                NormalizeExtent(extent.Width, viewport.Width),
+                NormalizeExtent(extent.Height, viewport.Height));
+            UpdateScrollInfo(extent, viewport);
+
+            grid.AvailableSlotElementRoom = Math.Max(0, viewport.Height - GetRealizedDesiredHeight(grid));
+            return new Size(
+                Math.Min(extent.Width, viewport.Width),
+                Math.Min(extent.Height, viewport.Height));
+        }
+
+        private static Vector BringBoundsIntoViewport(Vector offset, Size viewport, Rect bounds)
+        {
+            double x = offset.X;
+            double y = offset.Y;
+            if (bounds.X < x)
+            {
+                x = bounds.X;
+            }
+            else if (bounds.Right > x + viewport.Width)
+            {
+                x = bounds.Right - viewport.Width;
+            }
+            if (bounds.Y < y)
+            {
+                y = bounds.Y;
+            }
+            else if (bounds.Bottom > y + viewport.Height)
+            {
+                y = bounds.Bottom - viewport.Height;
+            }
+            return new Vector(Math.Max(0, x), Math.Max(0, y));
+        }
+
+        private Size ArrangeLayoutModel(Size finalSize)
+        {
+            DataGrid grid = OwningGrid!;
+            LayoutSession session = GetLayoutSession(grid.LayoutModel!);
+            Size viewport = NormalizeViewport(finalSize);
+            if (!AreClose(_viewport, viewport))
+            {
+                UpdateScrollInfo(_extent, viewport);
+            }
+
+            foreach (Control element in grid.DisplayData.GetScrollingElements())
+            {
+                if (element is DataGridRow row)
+                {
+                    row.EnsureFillerVisibility();
+                }
+            }
+
+            session.Context.SetViewport(viewport, _offset);
+            Size arranged = session.Algorithm.Arrange(session.Context, viewport);
+            _lastArrangeHeight = viewport.Height;
+            _lastArrangeMatchesDesired = true;
+
+            Rect clipRect = new(0, 0, viewport.Width, viewport.Height);
+            if (!AreClose(_clipRectGeometry.Rect, clipRect))
+            {
+                _clipRectGeometry.Rect = clipRect;
+            }
+            if (!ReferenceEquals(Clip, _clipRectGeometry))
+            {
+                Clip = _clipRectGeometry;
+            }
+
+            return new Size(
+                Math.Max(viewport.Width, arranged.Width),
+                Math.Max(viewport.Height, arranged.Height));
+        }
+
+        private LayoutSession GetLayoutSession(IDataGridLayoutModel model)
+        {
+            LayoutSession session = _layoutSessions.GetValue(model, key => new LayoutSession(this, key));
+            if (!ReferenceEquals(_activeLayoutSession, session))
+            {
+                if (_activeLayoutSession != null)
+                {
+                    _activeLayoutSession.Algorithm.Uninitialize(_activeLayoutSession.Context);
+                    _activeLayoutSession.IsInitialized = false;
+                }
+                _activeLayoutSession = session;
+            }
+
+            if (!session.IsInitialized)
+            {
+                session.Algorithm.Initialize(session.Context);
+                session.IsInitialized = true;
+            }
+            return session;
+        }
+
+        private static Size NormalizeViewport(Size size)
+        {
+            double width = double.IsNaN(size.Width) || double.IsInfinity(size.Width) ? 0 : Math.Max(0, size.Width);
+            double height = double.IsNaN(size.Height) || double.IsInfinity(size.Height) ? 0 : Math.Max(0, size.Height);
+            return new Size(width, height);
+        }
+
+        private static double NormalizeExtent(double extent, double viewport)
+        {
+            return double.IsNaN(extent) || double.IsInfinity(extent) ? viewport : Math.Max(viewport, extent);
+        }
+
+        private static double GetRealizedDesiredHeight(DataGrid grid)
+        {
+            double height = 0;
+            foreach (Control element in grid.DisplayData.GetScrollingElements())
+            {
+                height += element.DesiredSize.Height;
+            }
+            return height;
+        }
+
+        private static void UpdateMeasuredLayoutMetadata(DataGrid grid)
+        {
+            double headerWidth = 0;
+            foreach (Control element in grid.DisplayData.GetScrollingElements())
+            {
+                int layoutIndex = grid.GetLayoutIndex(element);
+                int slot = grid.GetLayoutSlot(layoutIndex);
+                if (slot >= 0)
+                {
+                    grid.UpdateScrollHeightEstimate(slot, element.DesiredSize.Height);
+                }
+
+                if (element is DataGridRow { HeaderCell: { } rowHeader })
+                {
+                    headerWidth = Math.Max(headerWidth, rowHeader.DesiredSize.Width);
+                }
+                else if (element is DataGridRowGroupHeader { HeaderCell: { } groupHeader })
+                {
+                    headerWidth = Math.Max(headerWidth, groupHeader.DesiredSize.Width);
+                }
+            }
+            grid.RowHeadersDesiredWidth = headerWidth;
+        }
+
+        private sealed class LayoutSession
+        {
+            public LayoutSession(DataGridRowsPresenter presenter, IDataGridLayoutModel model)
+            {
+                Model = model;
+                Algorithm = model.CreateAlgorithm() ??
+                    throw new InvalidOperationException("A DataGrid layout model returned a null algorithm.");
+                Context = new LayoutContext(presenter, this);
+            }
+
+            public IDataGridLayoutModel Model { get; }
+            public IDataGridLayoutAlgorithm Algorithm { get; }
+            public LayoutContext Context { get; }
+            public Dictionary<int, Rect> Bounds { get; } = new();
+            public object? State { get; set; }
+            public Point Origin { get; set; }
+            public int LastItemCount { get; set; } = -1;
+            public bool IsInitialized { get; set; }
+        }
+
+        private sealed class LayoutContext : IDataGridLayoutContext
+        {
+            private readonly DataGridRowsPresenter _presenter;
+            private readonly LayoutSession _session;
+            private readonly RealizedElementList _realizedElements;
+            private int _firstRequestedIndex;
+            private int _lastRequestedIndex;
+
+            public LayoutContext(DataGridRowsPresenter presenter, LayoutSession session)
+            {
+                _presenter = presenter;
+                _session = session;
+                _realizedElements = new RealizedElementList(presenter);
+            }
+
+            private DataGrid Grid => _presenter.OwningGrid!;
+
+            public int ItemCount => Grid.LayoutItemCount;
+            public Rect RealizationRect { get; private set; }
+            public Vector ScrollOffset { get; private set; }
+            public int RecommendedAnchorIndex => _presenter._requestedLayoutAnchorIndex;
+            public Point LayoutOrigin
+            {
+                get => _session.Origin;
+                set => _session.Origin = value;
+            }
+            public object? LayoutState
+            {
+                get => _session.State;
+                set => _session.State = value;
+            }
+            public IReadOnlyList<Control> RealizedElements => _realizedElements;
+
+            public void BeginMeasure(Size viewport, Vector offset)
+            {
+                _firstRequestedIndex = int.MaxValue;
+                _lastRequestedIndex = -1;
+                _session.Bounds.Clear();
+                SetViewport(viewport, offset);
+            }
+
+            public void SetViewport(Size viewport, Vector offset)
+            {
+                ScrollOffset = offset;
+                RealizationRect = new Rect(offset.X, offset.Y, viewport.Width, viewport.Height);
+            }
+
+            public void CompleteMeasure()
+            {
+                Grid.CompleteLayoutRealization(
+                    _lastRequestedIndex < 0 ? -1 : _firstRequestedIndex,
+                    _lastRequestedIndex);
+            }
+
+            public Control GetOrCreateElementAt(int index)
+            {
+                if (index < 0 || index >= ItemCount)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                _firstRequestedIndex = Math.Min(_firstRequestedIndex, index);
+                _lastRequestedIndex = Math.Max(_lastRequestedIndex, index);
+                return Grid.GetOrCreateLayoutElement(index);
+            }
+
+            public void RecycleElement(Control element)
+            {
+                int index = GetElementIndex(element);
+                if (index >= 0)
+                {
+                    _session.Bounds.Remove(index);
+                }
+            }
+
+            public int GetElementIndex(Control element) => Grid.GetLayoutIndex(element);
+            public Size GetEstimatedItemSize(int index) => Grid.GetEstimatedLayoutItemSize(index);
+            public double GetEstimatedItemOffset(int index, DataGridLayoutOrientation orientation) =>
+                Grid.GetEstimatedLayoutItemOffset(index, orientation);
+            public void SetLayoutBounds(int index, Rect bounds) => _session.Bounds[index] = bounds;
+            public bool TryGetLayoutBounds(int index, out Rect bounds) => _session.Bounds.TryGetValue(index, out bounds);
+        }
+
+        private sealed class RealizedElementList : IReadOnlyList<Control>
+        {
+            private readonly DataGridRowsPresenter _presenter;
+
+            public RealizedElementList(DataGridRowsPresenter presenter)
+            {
+                _presenter = presenter;
+            }
+
+            public int Count => _presenter.OwningGrid?.DisplayData.ScrollingElementCount ?? 0;
+            public Control this[int index] => _presenter.OwningGrid!.DisplayData.GetLogicalScrollingElement(index);
+
+            public IEnumerator<Control> GetEnumerator()
+            {
+                for (int index = 0; index < Count; index++)
+                {
+                    yield return this[index];
+                }
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
@@ -74,6 +74,36 @@ namespace Avalonia.Controls.Primitives
                 navigation.TryResolveNavigation(session.Context, request, out result);
         }
 
+        internal bool SupportsLayoutNavigation(DataGridLayoutNavigationDirection direction)
+        {
+            if (OwningGrid?.LayoutModel is not IDataGridLayoutModel model)
+            {
+                return false;
+            }
+
+            LayoutSession session = GetLayoutSession(model);
+            return session.Algorithm is IDataGridLayoutNavigation navigation &&
+                navigation.SupportsNavigation(direction);
+        }
+
+        internal bool TryGetLayoutNavigationBounds(int layoutIndex, out Rect bounds)
+        {
+            bounds = default;
+            if (OwningGrid?.LayoutModel is not IDataGridLayoutModel model)
+            {
+                return false;
+            }
+
+            LayoutSession session = GetLayoutSession(model);
+            Rect viewport = new(
+                Offset.X,
+                Offset.Y,
+                Viewport.Width,
+                Viewport.Height);
+            return session.Algorithm is IDataGridLayoutNavigation navigation &&
+                navigation.TryGetNavigationBounds(session.Context, layoutIndex, viewport, out bounds);
+        }
+
         internal bool TryGetLayoutBounds(int layoutIndex, out Rect bounds)
         {
             bounds = default;

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Layouts.cs
@@ -59,6 +59,40 @@ namespace Avalonia.Controls.Primitives
             return true;
         }
 
+        internal bool TryResolveLayoutNavigation(
+            in DataGridLayoutNavigationRequest request,
+            out DataGridLayoutNavigationResult result)
+        {
+            result = default;
+            if (OwningGrid?.LayoutModel is not IDataGridLayoutModel model)
+            {
+                return false;
+            }
+
+            LayoutSession session = GetLayoutSession(model);
+            return session.Algorithm is IDataGridLayoutNavigation navigation &&
+                navigation.TryResolveNavigation(session.Context, request, out result);
+        }
+
+        internal bool TryGetLayoutBounds(int layoutIndex, out Rect bounds)
+        {
+            bounds = default;
+            return _activeLayoutSession != null &&
+                _activeLayoutSession.Bounds.TryGetValue(layoutIndex, out bounds);
+        }
+
+        internal void OnLayoutPresenterDetached()
+        {
+            if (_activeLayoutSession == null)
+            {
+                return;
+            }
+
+            _activeLayoutSession.Algorithm.Uninitialize(_activeLayoutSession.Context);
+            _activeLayoutSession.IsInitialized = false;
+            _activeLayoutSession = null;
+        }
+
         private Size MeasureLayoutModel(Size availableSize)
         {
             DataGrid grid = OwningGrid!;

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Scrollable.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.Scrollable.cs
@@ -404,6 +404,14 @@ internal
             if (OwningGrid == null)
                 return;
 
+            if (UsesLayoutModel)
+            {
+                CancelPrefetch();
+                InvalidateMeasure();
+                InvalidateArrange();
+                return;
+            }
+
             // Calculate the delta and delegate to the DataGrid's scroll handling
             var deltaY = newOffset.Y - oldOffset.Y;
             var deltaX = newOffset.X - oldOffset.X;

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
@@ -94,6 +94,7 @@ internal
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            OnLayoutPresenterDetached();
             UnhookTopLevel();
             _measureConstraints.Clear();
             base.OnDetachedFromVisualTree(e);

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
@@ -166,6 +166,11 @@ internal
                 return base.ArrangeOverride(finalSize);
             }
 
+            if (UsesLayoutModel)
+            {
+                return ArrangeLayoutModel(finalSize);
+            }
+
             if (finalSize.Height <= 0)
             {
                 var viewportHeight = Math.Max(0, finalSize.Height);
@@ -550,6 +555,11 @@ internal
             // The DataGrid uses the RowsPresenter available size in order to autogrow
             // and calculate the scrollbars
             OwningGrid.RowsPresenterAvailableSize = availableSize;
+
+            if (UsesLayoutModel)
+            {
+                return MeasureLayoutModel(availableSize);
+            }
 
             OwningGrid.OnRowsMeasure();
 

--- a/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Generic.xaml
@@ -1427,6 +1427,40 @@
         </Setter>
       </ControlTheme>
 
+      <!-- DataGrid item-template container -->
+      <ControlTheme x:Key="{x:Type DataGridItemContainer}" TargetType="DataGridItemContainer">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+          <ControlTemplate>
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    Padding="{TemplateBinding Padding}">
+              <ContentPresenter Content="{TemplateBinding Content}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </Border>
+          </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover">
+          <Setter Property="Background" Value="{DynamicResource DataGridRowHoveredBackgroundBrush}" />
+        </Style>
+        <Style Selector="^:selected">
+          <Setter Property="Background" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}" />
+        </Style>
+        <Style Selector="^:selected:pointerover">
+          <Setter Property="Background" Value="{DynamicResource DataGridRowSelectedHoveredBackgroundBrush}" />
+        </Style>
+        <Style Selector="^:current">
+          <Setter Property="BorderBrush" Value="{DynamicResource DataGridSelectionOutlineBrush}" />
+        </Style>
+      </ControlTheme>
+
       <!-- DataGrid -->
       <ControlTheme x:Key="{x:Type DataGrid}" TargetType="DataGrid">
         <Setter Property="RowBackground" Value="{DynamicResource DataGridRowBackgroundBrush}" />

--- a/src/DataGridSample.UnitTests/LayoutGalleryPageTests.cs
+++ b/src/DataGridSample.UnitTests/LayoutGalleryPageTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using Xunit;
+
+namespace DataGridSample.Tests;
+
+public sealed class LayoutGalleryPageTests
+{
+    [AvaloniaFact]
+    public void Gallery_switches_between_table_and_templated_card_realization()
+    {
+        var viewModel = new LayoutGalleryViewModel();
+        viewModel.SelectedLayout = viewModel.Layouts[3];
+        var page = new LayoutGalleryPage { DataContext = viewModel };
+        var window = new Window { Width = 1120, Height = 720, Content = page };
+        window.ApplySampleTheme();
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            DataGrid grid = page.GetVisualDescendants().OfType<DataGrid>().Single();
+            DataGridColumnHeadersPresenter headers = page.GetVisualDescendants()
+                .OfType<DataGridColumnHeadersPresenter>()
+                .Single();
+            Assert.Contains(page.GetVisualDescendants().OfType<DataGridItemContainer>(),
+                static item => item.Index >= 0);
+            Assert.DoesNotContain(page.GetVisualDescendants().OfType<DataGridRow>(),
+                static row => row.Index >= 0);
+            Assert.Empty(page.GetVisualDescendants().OfType<DataGridCell>());
+            Assert.False(headers.IsVisible);
+            SaveScreenshot(window, "layout-gallery-item-cards.png");
+
+            viewModel.SelectedLayout = viewModel.Layouts[0];
+            PumpLayout(window);
+
+            Assert.Contains(page.GetVisualDescendants().OfType<DataGridRow>(),
+                static row => row.Index >= 0);
+            Assert.DoesNotContain(page.GetVisualDescendants().OfType<DataGridItemContainer>(),
+                static item => item.Index >= 0);
+            Assert.NotEmpty(page.GetVisualDescendants().OfType<DataGridCell>());
+            Assert.True(headers.IsVisible);
+            Assert.Same(viewModel.LayoutModel, grid.LayoutModel);
+            SaveScreenshot(window, "layout-gallery-table-rows.png");
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static void PumpLayout(Window window)
+    {
+        for (int pass = 0; pass < 3; pass++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static void SaveScreenshot(Window window, string fileName)
+    {
+        string? directory = Environment.GetEnvironmentVariable("AVALONIA_SCREENSHOT_DIR");
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+
+        using var frame = window.CaptureRenderedFrame();
+        Assert.NotNull(frame);
+        Directory.CreateDirectory(directory);
+        string path = Path.GetFullPath(Path.Combine(directory, fileName));
+        using var stream = File.Create(path);
+        frame.Save(stream, new PngBitmapEncoderOptions());
+        Assert.True(new FileInfo(path).Length > 0);
+    }
+}

--- a/src/DataGridSample/Layouts/IndentedStackLayoutModel.cs
+++ b/src/DataGridSample/Layouts/IndentedStackLayoutModel.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridLayouts;
+
+namespace DataGridSample.Layouts;
+
+/// <summary>
+/// Sample custom layout that virtualizes a vertical stack and alternates its horizontal indent.
+/// </summary>
+public sealed class IndentedStackLayoutModel : DataGridLayoutModelBase
+{
+    private double _indent = 36;
+    private double _spacing = 6;
+
+    public double Indent
+    {
+        get => _indent;
+        set => SetProperty(ref _indent, value);
+    }
+
+    public double Spacing
+    {
+        get => _spacing;
+        set => SetProperty(ref _spacing, value);
+    }
+
+    public override IDataGridLayoutAlgorithm CreateAlgorithm() => new Algorithm(this);
+
+    private sealed class Algorithm : IDataGridLayoutAlgorithm, IDataGridLayoutNavigation
+    {
+        private readonly IndentedStackLayoutModel _model;
+
+        public Algorithm(IndentedStackLayoutModel model)
+        {
+            _model = model;
+        }
+
+        public void Initialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public Size Measure(IDataGridLayoutContext context, Size availableSize)
+        {
+            int itemCount = context.ItemCount;
+            if (itemCount == 0)
+            {
+                RecycleOutsideRange(context, 0, -1);
+                return default;
+            }
+
+            double spacing = Math.Max(0, _model.Spacing);
+            double start = Math.Max(0, context.RealizationRect.Y);
+            double end = Math.Max(start, context.RealizationRect.Bottom);
+            int firstIndex = FindFirstIndex(context, itemCount, start, spacing);
+            double y = GetOffset(context, firstIndex, spacing);
+            int lastIndex = firstIndex - 1;
+            double width = IsFinite(availableSize.Width) ? Math.Max(0, availableSize.Width) : 0;
+            double indent = Math.Max(0, _model.Indent);
+
+            for (int index = firstIndex; index < itemCount && y <= end; index++)
+            {
+                double x = (index & 1) == 0 ? 0 : indent;
+                double itemWidth = Math.Max(1, width - x);
+                Control element = context.GetOrCreateElementAt(index);
+                element.Measure(new Size(itemWidth, double.PositiveInfinity));
+                double height = Math.Max(1, element.DesiredSize.Height);
+                context.SetLayoutBounds(index, new Rect(x, y, itemWidth, height));
+                y += height + spacing;
+                lastIndex = index;
+            }
+
+            RecycleOutsideRange(context, firstIndex, lastIndex);
+            double extentHeight = Math.Max(y - spacing, GetOffset(context, itemCount, spacing) - spacing);
+            return new Size(width, Math.Max(0, extentHeight));
+        }
+
+        public Size Arrange(IDataGridLayoutContext context, Size finalSize)
+        {
+            Vector offset = context.ScrollOffset;
+            IReadOnlyList<Control> realized = context.RealizedElements;
+            for (int index = 0; index < realized.Count; index++)
+            {
+                Control element = realized[index];
+                int itemIndex = context.GetElementIndex(element);
+                if (itemIndex >= 0 && context.TryGetLayoutBounds(itemIndex, out Rect bounds))
+                {
+                    element.Arrange(new Rect(
+                        bounds.X - offset.X,
+                        bounds.Y - offset.Y,
+                        bounds.Width,
+                        bounds.Height));
+                }
+            }
+            return finalSize;
+        }
+
+        public void OnItemsChanged(IDataGridLayoutContext context, NotifyCollectionChangedEventArgs change)
+        {
+        }
+
+        public void Uninitialize(IDataGridLayoutContext context)
+        {
+        }
+
+        public bool SupportsNavigation(DataGridLayoutNavigationDirection direction) =>
+            direction is DataGridLayoutNavigationDirection.Up or
+                DataGridLayoutNavigationDirection.Down or
+                DataGridLayoutNavigationDirection.PageUp or
+                DataGridLayoutNavigationDirection.PageDown or
+                DataGridLayoutNavigationDirection.First or
+                DataGridLayoutNavigationDirection.Last;
+
+        public bool TryGetNavigationBounds(
+            IDataGridLayoutContext context,
+            int itemIndex,
+            Rect viewport,
+            out Rect bounds)
+        {
+            if (itemIndex < 0 || itemIndex >= context.ItemCount)
+            {
+                bounds = default;
+                return false;
+            }
+
+            double spacing = Math.Max(0, _model.Spacing);
+            Size estimate = context.GetEstimatedItemSize(itemIndex);
+            double x = (itemIndex & 1) == 0 ? 0 : Math.Max(0, _model.Indent);
+            bounds = new Rect(
+                x,
+                GetOffset(context, itemIndex, spacing),
+                Math.Max(1, estimate.Width - x),
+                Math.Max(1, estimate.Height));
+            return true;
+        }
+
+        public bool TryResolveNavigation(
+            IDataGridLayoutContext context,
+            in DataGridLayoutNavigationRequest request,
+            out DataGridLayoutNavigationResult result)
+        {
+            if (!SupportsNavigation(request.Direction))
+            {
+                result = default;
+                return false;
+            }
+
+            int target = request.Direction switch
+            {
+                DataGridLayoutNavigationDirection.Up => request.CurrentItemIndex - 1,
+                DataGridLayoutNavigationDirection.Down => request.CurrentItemIndex + 1,
+                DataGridLayoutNavigationDirection.PageUp => FindPageTarget(context, request, forward: false),
+                DataGridLayoutNavigationDirection.PageDown => FindPageTarget(context, request, forward: true),
+                DataGridLayoutNavigationDirection.First => 0,
+                DataGridLayoutNavigationDirection.Last => context.ItemCount - 1,
+                _ => -1
+            };
+            if (target < 0 || target >= context.ItemCount || target == request.CurrentItemIndex)
+            {
+                result = default;
+                return false;
+            }
+
+            TryGetNavigationBounds(context, target, request.Viewport, out Rect bounds);
+            result = new DataGridLayoutNavigationResult(target, bounds);
+            return true;
+        }
+
+        private static int FindPageTarget(
+            IDataGridLayoutContext context,
+            in DataGridLayoutNavigationRequest request,
+            bool forward)
+        {
+            double rowHeight = Math.Max(1, context.GetEstimatedItemSize(request.CurrentItemIndex).Height);
+            int rows = Math.Max(1, (int)Math.Floor(request.Viewport.Height / rowHeight));
+            return request.CurrentItemIndex + (forward ? rows : -rows);
+        }
+
+        private static int FindFirstIndex(
+            IDataGridLayoutContext context,
+            int itemCount,
+            double realizationStart,
+            double spacing)
+        {
+            int low = 0;
+            int high = itemCount;
+            while (low < high)
+            {
+                int middle = low + ((high - low) / 2);
+                double end = GetOffset(context, middle, spacing) +
+                    Math.Max(1, context.GetEstimatedItemSize(middle).Height);
+                if (end <= realizationStart)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+            return Math.Max(0, Math.Min(itemCount - 1, low));
+        }
+
+        private static double GetOffset(IDataGridLayoutContext context, int index, double spacing) =>
+            Math.Max(0, context.GetEstimatedItemOffset(index, DataGridLayoutOrientation.Vertical)) + (spacing * index);
+
+        private static void RecycleOutsideRange(IDataGridLayoutContext context, int firstIndex, int lastIndex)
+        {
+            IReadOnlyList<Control> realized = context.RealizedElements;
+            for (int index = realized.Count - 1; index >= 0; index--)
+            {
+                Control element = realized[index];
+                int itemIndex = context.GetElementIndex(element);
+                if (itemIndex < firstIndex || itemIndex > lastIndex)
+                {
+                    context.RecycleElement(element);
+                }
+            }
+        }
+
+        private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+}

--- a/src/DataGridSample/MainWindow.axaml
+++ b/src/DataGridSample/MainWindow.axaml
@@ -424,6 +424,13 @@
     <TabItem Header="Logical Scroll Performance">
       <pages:LogicalScrollPerformancePage />
     </TabItem>
+    <TabItem Header="Layout Gallery">
+      <pages:LayoutGalleryPage>
+        <pages:LayoutGalleryPage.DataContext>
+          <viewModels:LayoutGalleryViewModel />
+        </pages:LayoutGalleryPage.DataContext>
+      </pages:LayoutGalleryPage>
+    </TabItem>
     <TabItem Header="Routed events">
       <pages:RoutedEventsPage />
     </TabItem>

--- a/src/DataGridSample/Models/LayoutGalleryRow.cs
+++ b/src/DataGridSample/Models/LayoutGalleryRow.cs
@@ -12,4 +12,6 @@ public sealed class LayoutGalleryRow
     public string Title { get; init; } = string.Empty;
 
     public string Notes { get; init; } = string.Empty;
+
+    public double CardWidth { get; init; }
 }

--- a/src/DataGridSample/Models/LayoutGalleryRow.cs
+++ b/src/DataGridSample/Models/LayoutGalleryRow.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace DataGridSample.Models;
+
+public sealed class LayoutGalleryRow
+{
+    public int Id { get; init; }
+
+    public string Category { get; init; } = string.Empty;
+
+    public string Title { get; init; } = string.Empty;
+
+    public string Notes { get; init; } = string.Empty;
+}

--- a/src/DataGridSample/Pages/LayoutGalleryPage.axaml
+++ b/src/DataGridSample/Pages/LayoutGalleryPage.axaml
@@ -1,0 +1,78 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:models="clr-namespace:DataGridSample.Models"
+             xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
+             x:Class="DataGridSample.Pages.LayoutGalleryPage"
+             x:DataType="viewModels:LayoutGalleryViewModel">
+  <Grid RowDefinitions="Auto,Auto,*"
+        RowSpacing="10"
+        Margin="12">
+    <StackPanel Spacing="4">
+      <TextBlock Classes="h2" Text="Model-based row layouts" />
+      <TextBlock TextWrapping="Wrap"
+                 Text="Switch among every built-in layout and an application-defined layout. Model instances and their bounded sessions are retained, while row containers, selection, editing, filtering, and columns stay owned by the same DataGrid." />
+    </StackPanel>
+
+    <Grid Grid.Row="1"
+          ColumnDefinitions="Auto,280,Auto,Auto,*"
+          ColumnSpacing="8">
+      <TextBlock VerticalAlignment="Center" Text="Layout:" />
+      <ComboBox Grid.Column="1"
+                ItemsSource="{CompiledBinding Layouts}"
+                SelectedItem="{CompiledBinding SelectedLayout, Mode=TwoWay}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="viewModels:DataGridLayoutChoice">
+            <TextBlock Text="{CompiledBinding Name}" />
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+      <Button Grid.Column="2"
+              Command="{CompiledBinding NextLayoutCommand}"
+              Content="Next layout" />
+      <TextBlock Grid.Column="3"
+                 VerticalAlignment="Center"
+                 Text="{CompiledBinding SwitchCount, StringFormat='Switches: {0}'}" />
+      <TextBlock Grid.Column="4"
+                 VerticalAlignment="Center"
+                 TextWrapping="Wrap"
+                 Text="{CompiledBinding Description}" />
+    </Grid>
+
+    <DataGrid Grid.Row="2"
+              ItemsSource="{CompiledBinding Rows}"
+              LayoutModel="{CompiledBinding LayoutModel}"
+              UseLogicalScrollable="True"
+              AutoGenerateColumns="False"
+              IsReadOnly="True"
+              CanUserSortColumns="True"
+              HeadersVisibility="All"
+              GridLinesVisibility="All"
+              SelectionMode="Extended"
+              SelectionUnit="CellOrRowHeader">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Id"
+                            Width="54"
+                            Binding="{CompiledBinding Id}"
+                            x:DataType="models:LayoutGalleryRow" />
+        <DataGridTextColumn Header="Category"
+                            Width="88"
+                            Binding="{CompiledBinding Category}"
+                            x:DataType="models:LayoutGalleryRow" />
+        <DataGridTextColumn Header="Title"
+                            Width="118"
+                            Binding="{CompiledBinding Title}"
+                            x:DataType="models:LayoutGalleryRow" />
+        <DataGridTemplateColumn Header="Notes" Width="190">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate x:DataType="models:LayoutGalleryRow">
+              <TextBlock Margin="4,2"
+                         MaxWidth="180"
+                         TextWrapping="Wrap"
+                         Text="{CompiledBinding Notes}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</UserControl>

--- a/src/DataGridSample/Pages/LayoutGalleryPage.axaml
+++ b/src/DataGridSample/Pages/LayoutGalleryPage.axaml
@@ -8,13 +8,13 @@
         RowSpacing="10"
         Margin="12">
     <StackPanel Spacing="4">
-      <TextBlock Classes="h2" Text="Model-based row layouts" />
+      <TextBlock Classes="h2" Text="Model-based layouts and item views" />
       <TextBlock TextWrapping="Wrap"
-                 Text="Switch among every built-in layout and an application-defined layout. Model instances and their bounded sessions are retained, while row containers, selection, editing, filtering, and columns stay owned by the same DataGrid." />
+                 Text="The table layout uses DataGrid rows, cells, and headers. Card layouts use one compiled item template with lightweight recyclable containers; headers and cell visuals are not realized. Selection, navigation, filtering, sorting, and retained layout sessions stay on the same DataGrid while switching at runtime." />
     </StackPanel>
 
     <Grid Grid.Row="1"
-          ColumnDefinitions="Auto,280,Auto,Auto,*"
+          ColumnDefinitions="Auto,280,Auto,Auto,Auto,*"
           ColumnSpacing="8">
       <TextBlock VerticalAlignment="Center" Text="Layout:" />
       <ComboBox Grid.Column="1"
@@ -34,6 +34,9 @@
                  Text="{CompiledBinding SwitchCount, StringFormat='Switches: {0}'}" />
       <TextBlock Grid.Column="4"
                  VerticalAlignment="Center"
+                 Text="{CompiledBinding SelectedLayout.Presentation}" />
+      <TextBlock Grid.Column="5"
+                 VerticalAlignment="Center"
                  TextWrapping="Wrap"
                  Text="{CompiledBinding Description}" />
     </Grid>
@@ -48,7 +51,51 @@
               HeadersVisibility="All"
               GridLinesVisibility="All"
               SelectionMode="Extended"
-              SelectionUnit="CellOrRowHeader">
+              SelectionUnit="FullRow">
+      <DataGrid.ItemTemplate>
+        <DataTemplate x:DataType="models:LayoutGalleryRow">
+          <Border Width="{CompiledBinding CardWidth}"
+                  Height="88"
+                  Margin="4"
+                  Padding="10,8"
+                  CornerRadius="5"
+                  Background="{DynamicResource ThemeControlLowBrush}"
+                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                  BorderThickness="1"
+                  AutomationProperties.Name="{CompiledBinding Title}">
+            <Grid RowDefinitions="Auto,Auto,*"
+                  ColumnDefinitions="Auto,*"
+                  ColumnSpacing="10">
+              <Border Grid.RowSpan="2"
+                      Width="32"
+                      Height="32"
+                      CornerRadius="16"
+                      Background="{DynamicResource SystemControlHighlightAccentBrush}">
+                <TextBlock HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="{CompiledBinding Id}" />
+              </Border>
+              <TextBlock Grid.Column="1"
+                         FontWeight="SemiBold"
+                         TextTrimming="CharacterEllipsis"
+                         Text="{CompiledBinding Title}" />
+              <TextBlock Grid.Row="1"
+                         Grid.Column="1"
+                         Opacity="0.72"
+                         Text="{CompiledBinding Category}" />
+              <TextBlock Grid.Row="2"
+                         Grid.ColumnSpan="2"
+                         Margin="0,5,0,0"
+                         MaxHeight="34"
+                         TextWrapping="Wrap"
+                         TextTrimming="CharacterEllipsis"
+                         Text="{CompiledBinding Notes}" />
+            </Grid>
+          </Border>
+        </DataTemplate>
+      </DataGrid.ItemTemplate>
       <DataGrid.Columns>
         <DataGridTextColumn Header="Id"
                             Width="54"

--- a/src/DataGridSample/Pages/LayoutGalleryPage.axaml.cs
+++ b/src/DataGridSample/Pages/LayoutGalleryPage.axaml.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DataGridSample.Pages;
+
+public partial class LayoutGalleryPage : UserControl
+{
+    public LayoutGalleryPage()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/DataGridSample/ViewModels/LayoutGalleryViewModel.cs
+++ b/src/DataGridSample/ViewModels/LayoutGalleryViewModel.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls.DataGridLayouts;
+using DataGridSample.Layouts;
+using DataGridSample.Models;
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
+
+namespace DataGridSample.ViewModels;
+
+public sealed partial class LayoutGalleryViewModel : ReactiveObject
+{
+    private DataGridLayoutChoice _selectedLayout;
+
+    [Reactive]
+    private IDataGridLayoutModel _layoutModel = null!;
+
+    [Reactive]
+    private string _description = string.Empty;
+
+    [Reactive]
+    private int _switchCount;
+
+    public LayoutGalleryViewModel()
+    {
+        Layouts =
+        [
+            new("Virtualizing stack", "Variable-height vertical list using the existing indexed row-height estimator.", new DataGridStackLayoutModel { Spacing = 2 }),
+            new("Horizontal stack", "Virtualized horizontal flow; width becomes the estimated major axis.", new DataGridStackLayoutModel { Orientation = DataGridLayoutOrientation.Horizontal, Spacing = 8 }),
+            new("Non-virtualizing stack", "Reference layout that realizes every item. Keep data sets intentionally small.", new DataGridNonVirtualizingStackLayoutModel { Spacing = 2 }),
+            new("Uniform grid", "Equal 260 × 74 cells with O(1) line and extent calculations.", new DataGridUniformGridLayoutModel { MinItemWidth = 260, MinItemHeight = 74, MinColumnSpacing = 8, MinRowSpacing = 8 }),
+            new("Vertical uniform grid", "Equal cells fill downward and virtualize columns horizontally.", new DataGridUniformGridLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, MinItemWidth = 260, MinItemHeight = 74, MinColumnSpacing = 8, MinRowSpacing = 8, MaximumRowsOrColumns = 4 }),
+            new("Variable wrap", "Rows keep their measured size and wrap into cached, bounded line records.", new DataGridWrapLayoutModel { HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
+            new("Vertical variable wrap", "Variable-size items fill downward before wrapping into columns.", new DataGridWrapLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
+            new("Custom indented stack", "Application-defined virtualizing layout with its own spatial navigation resolver.", new IndentedStackLayoutModel { Indent = 42, Spacing = 5 })
+        ];
+        Rows = CreateRows(500);
+        _selectedLayout = Layouts[0];
+        LayoutModel = _selectedLayout.Model;
+        Description = _selectedLayout.Description;
+        NextLayoutCommand = ReactiveCommand.Create(SelectNextLayout);
+    }
+
+    public IReadOnlyList<DataGridLayoutChoice> Layouts { get; }
+
+    public IReadOnlyList<LayoutGalleryRow> Rows { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> NextLayoutCommand { get; }
+
+    public DataGridLayoutChoice SelectedLayout
+    {
+        get => _selectedLayout;
+        set
+        {
+            if (value == null || ReferenceEquals(_selectedLayout, value))
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _selectedLayout, value);
+            LayoutModel = value.Model;
+            Description = value.Description;
+            SwitchCount++;
+        }
+    }
+
+    private void SelectNextLayout()
+    {
+        int index = 0;
+        for (int candidate = 0; candidate < Layouts.Count; candidate++)
+        {
+            if (ReferenceEquals(Layouts[candidate], SelectedLayout))
+            {
+                index = candidate;
+                break;
+            }
+        }
+        SelectedLayout = Layouts[(index + 1) % Layouts.Count];
+    }
+
+    private static IReadOnlyList<LayoutGalleryRow> CreateRows(int count)
+    {
+        var rows = new List<LayoutGalleryRow>(count);
+        for (int index = 0; index < count; index++)
+        {
+            string detail = (index % 5) switch
+            {
+                0 => "Short item.",
+                1 => "A medium description that demonstrates measured row content.",
+                2 => "Longer content: the same recycled DataGrid row containers are arranged by every model without rebuilding the item source or selection state.",
+                3 => "Navigation remains semantic while the active layout resolves spatial targets.",
+                _ => "Runtime switching retains one bounded algorithm session per model instance."
+            };
+            rows.Add(new LayoutGalleryRow
+            {
+                Id = index + 1,
+                Category = $"Group {index % 12 + 1:00}",
+                Title = $"Layout item {index + 1:n0}",
+                Notes = detail
+            });
+        }
+        return rows;
+    }
+}
+
+public sealed class DataGridLayoutChoice
+{
+    public DataGridLayoutChoice(string name, string description, IDataGridLayoutModel model)
+    {
+        Name = name;
+        Description = description;
+        Model = model;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public IDataGridLayoutModel Model { get; }
+}

--- a/src/DataGridSample/ViewModels/LayoutGalleryViewModel.cs
+++ b/src/DataGridSample/ViewModels/LayoutGalleryViewModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Avalonia;
 using Avalonia.Controls.DataGridLayouts;
 using DataGridSample.Layouts;
 using DataGridSample.Models;
@@ -29,14 +30,14 @@ public sealed partial class LayoutGalleryViewModel : ReactiveObject
     {
         Layouts =
         [
-            new("Virtualizing stack", "Variable-height vertical list using the existing indexed row-height estimator.", new DataGridStackLayoutModel { Spacing = 2 }),
-            new("Horizontal stack", "Virtualized horizontal flow; width becomes the estimated major axis.", new DataGridStackLayoutModel { Orientation = DataGridLayoutOrientation.Horizontal, Spacing = 8 }),
-            new("Non-virtualizing stack", "Reference layout that realizes every item. Keep data sets intentionally small.", new DataGridNonVirtualizingStackLayoutModel { Spacing = 2 }),
-            new("Uniform grid", "Equal 260 × 74 cells with O(1) line and extent calculations.", new DataGridUniformGridLayoutModel { MinItemWidth = 260, MinItemHeight = 74, MinColumnSpacing = 8, MinRowSpacing = 8 }),
-            new("Vertical uniform grid", "Equal cells fill downward and virtualize columns horizontally.", new DataGridUniformGridLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, MinItemWidth = 260, MinItemHeight = 74, MinColumnSpacing = 8, MinRowSpacing = 8, MaximumRowsOrColumns = 4 }),
-            new("Variable wrap", "Rows keep their measured size and wrap into cached, bounded line records.", new DataGridWrapLayoutModel { HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
-            new("Vertical variable wrap", "Variable-size items fill downward before wrapping into columns.", new DataGridWrapLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
-            new("Custom indented stack", "Application-defined virtualizing layout with its own spatial navigation resolver.", new IndentedStackLayoutModel { Indent = 42, Spacing = 5 })
+            new("Table list", "Classic variable-height DataGrid rows and cells, including column headers.", new DataGridStackLayoutModel { Spacing = 2 }),
+            new("Horizontal card stack", "Virtualized horizontal item flow using the gallery card template instead of rows or cells.", new DataGridStackLayoutModel { Orientation = DataGridLayoutOrientation.Horizontal, Spacing = 10, PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(280, 92) }),
+            new("Non-virtualizing cards", "Reference item layout that realizes every card. Keep production data sets intentionally small.", new DataGridNonVirtualizingStackLayoutModel { Spacing = 8, PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(280, 92) }),
+            new("Uniform card grid", "Equal 260 × 96 item slots with O(1) line and extent calculations.", new DataGridUniformGridLayoutModel { PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(260, 96), MinItemWidth = 260, MinItemHeight = 96, MinColumnSpacing = 8, MinRowSpacing = 8 }),
+            new("Vertical uniform cards", "Equal item slots fill downward and virtualize columns horizontally.", new DataGridUniformGridLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(260, 96), MinItemWidth = 260, MinItemHeight = 96, MinColumnSpacing = 8, MinRowSpacing = 8, MaximumRowsOrColumns = 4 }),
+            new("Variable card wrap", "Measured card widths wrap into cached, bounded horizontal line records.", new DataGridWrapLayoutModel { PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(240, 92), HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
+            new("Vertical card wrap", "Variable-size cards fill downward before wrapping into virtualized columns.", new DataGridWrapLayoutModel { Orientation = DataGridLayoutOrientation.Vertical, PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(240, 92), HorizontalSpacing = 8, VerticalSpacing = 8, MaximumCachedLines = 96 }),
+            new("Custom indented cards", "Application-defined item layout and spatial navigation resolver using the same recyclable template containers.", new IndentedStackLayoutModel { Indent = 42, Spacing = 8, PresentationMode = DataGridLayoutPresentationMode.Items, ItemSizeEstimate = new Size(280, 92) })
         ];
         Rows = CreateRows(500);
         _selectedLayout = Layouts[0];
@@ -91,7 +92,7 @@ public sealed partial class LayoutGalleryViewModel : ReactiveObject
             {
                 0 => "Short item.",
                 1 => "A medium description that demonstrates measured row content.",
-                2 => "Longer content: the same recycled DataGrid row containers are arranged by every model without rebuilding the item source or selection state.",
+                2 => "Longer content: recyclable item containers switch templates and geometry without rebuilding the item source or selection state.",
                 3 => "Navigation remains semantic while the active layout resolves spatial targets.",
                 _ => "Runtime switching retains one bounded algorithm session per model instance."
             };
@@ -100,7 +101,8 @@ public sealed partial class LayoutGalleryViewModel : ReactiveObject
                 Id = index + 1,
                 Category = $"Group {index % 12 + 1:00}",
                 Title = $"Layout item {index + 1:n0}",
-                Notes = detail
+                Notes = detail,
+                CardWidth = 200 + ((index % 3) * 24)
             });
         }
         return rows;
@@ -121,4 +123,9 @@ public sealed class DataGridLayoutChoice
     public string Description { get; }
 
     public IDataGridLayoutModel Model { get; }
+
+    public string Presentation =>
+        Model is IDataGridLayoutPresentationModel { PresentationMode: DataGridLayoutPresentationMode.Items }
+            ? "Item template"
+            : "Rows and cells";
 }

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -4989,6 +4989,43 @@ public sealed class ProDataGridGeneratorTests
     }
 
     [Fact]
+    public void Generated_view_binds_custom_item_layout_and_typed_template_reflection_free()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row
+            {
+                public int Value { get; set; }
+                public static Control CreateCard(Row item, Control existing) =>
+                    existing ?? new TextBlock { Text = item.Value.ToString() };
+            }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row),
+                LayoutModelPropertyName = nameof(Layout),
+                LayoutItemTemplateFactoryMethod = nameof(Row.CreateCard))]
+            public sealed partial class GridViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = System.Array.Empty<Row>();
+                public IDataGridLayoutModel Layout { get; } = new DataGridWrapLayoutModel
+                {
+                    PresentationMode = DataGridLayoutPresentationMode.Items,
+                    ItemSizeEstimate = new Avalonia.Size(180, 72)
+                };
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGrid.LayoutModelProperty", result.CombinedSource);
+        Assert.Contains("DataGridGeneratedFuncDataTemplate<global::Demo.Row>(global::Demo.Row.CreateCard)", result.CombinedSource);
+        Assert.DoesNotContain("new global::Avalonia.Controls.DataGridLayouts.DataGridWrapLayoutModel", result.CombinedSource);
+    }
+
+    [Fact]
     public void Generated_view_rejects_invalid_or_conflicting_layout_configuration()
     {
         GeneratorTestResult invalid = GeneratorTestHelper.Run("""

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -4893,6 +4893,83 @@ public sealed class ProDataGridGeneratorTests
     }
 
     [Fact]
+    public void Namespace_view_policy_creates_configured_builtin_layout()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System;
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            [assembly: GenerateDataGridViewsForNamespace(
+                "Demo.ViewModels",
+                IncludeNestedNamespaces = false,
+                Layout = DataGridGeneratedLayout.Wrap,
+                LayoutOrientation = DataGridGeneratedLayoutOrientation.Vertical,
+                LayoutHorizontalSpacing = 7,
+                LayoutVerticalSpacing = 9,
+                LayoutMaximumCachedLines = 32)]
+            namespace Demo.Models
+            {
+                public sealed class Row { public int Id { get; set; } }
+            }
+            namespace Demo.ViewModels
+            {
+                public sealed class RowsViewModel
+                {
+                    public IReadOnlyList<Demo.Models.Row> Items { get; } = Array.Empty<Demo.Models.Row>();
+                    public DataGridColumnDefinitionList ColumnDefinitions { get; } = new();
+                    public DataGridFastPathOptions FastPathOptions { get; } = new();
+                }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("class RowsView", result.CombinedSource);
+        Assert.Contains("new global::Avalonia.Controls.DataGridLayouts.DataGridWrapLayoutModel", result.CombinedSource);
+        Assert.Contains("Orientation = global::Avalonia.Controls.DataGridLayouts.DataGridLayoutOrientation.Vertical", result.CombinedSource);
+        Assert.Contains("HorizontalSpacing = 7", result.CombinedSource);
+        Assert.Contains("VerticalSpacing = 9", result.CombinedSource);
+        Assert.Contains("MaximumCachedLines = 32", result.CombinedSource);
+        Assert.Contains("dataGrid.UseLogicalScrollable = true", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Namespace_view_policy_binds_custom_layout_model_reflection_free()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System;
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            [assembly: GenerateDataGridViewsForNamespace(
+                "Demo.ViewModels",
+                IncludeNestedNamespaces = false,
+                LayoutModelPropertyName = nameof(Demo.ViewModels.RowsViewModel.LayoutModel))]
+            namespace Demo.Models
+            {
+                public sealed class Row { public int Id { get; set; } }
+            }
+            namespace Demo.ViewModels
+            {
+                public sealed class RowsViewModel
+                {
+                    public IReadOnlyList<Demo.Models.Row> Items { get; } = Array.Empty<Demo.Models.Row>();
+                    public DataGridColumnDefinitionList ColumnDefinitions { get; } = new();
+                    public DataGridFastPathOptions FastPathOptions { get; } = new();
+                    public IDataGridLayoutModel LayoutModel { get; } = new DataGridStackLayoutModel();
+                }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGrid.LayoutModelProperty", result.CombinedSource);
+        Assert.Contains("s_layoutModelProperty", result.CombinedSource);
+        Assert.Contains("dataGrid.UseLogicalScrollable = true", result.CombinedSource);
+    }
+
+    [Fact]
     public void Generated_view_binds_reflection_free_clipboard_and_fill_models()
     {
         GeneratorTestResult result = GeneratorTestHelper.Run("""

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -4804,6 +4804,95 @@ public sealed class ProDataGridGeneratorTests
     }
 
     [Fact]
+    public void Generated_views_create_all_builtin_layout_models()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Value { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(typeof(Row), ViewName = "StackView", Layout = DataGridGeneratedLayout.Stack,
+                LayoutOrientation = DataGridGeneratedLayoutOrientation.Horizontal, LayoutSpacing = 4, LayoutDisableVirtualization = true)]
+            [GenerateDataGridView(typeof(Row), ViewName = "NonVirtualView", Layout = DataGridGeneratedLayout.NonVirtualizingStack)]
+            [GenerateDataGridView(typeof(Row), ViewName = "UniformView", Layout = DataGridGeneratedLayout.UniformGrid,
+                LayoutMinItemWidth = 120, LayoutMinItemHeight = 36, LayoutMaximumRowsOrColumns = 3,
+                LayoutItemsJustification = DataGridUniformGridItemsJustification.Center,
+                LayoutItemsStretch = DataGridUniformGridItemsStretch.Fill)]
+            [GenerateDataGridView(typeof(Row), ViewName = "WrapView", Layout = DataGridGeneratedLayout.Wrap,
+                LayoutHorizontalSpacing = 8, LayoutVerticalSpacing = 6, LayoutMaximumCachedLines = 64)]
+            public sealed partial class GridViewModel
+            {
+                public System.Collections.Generic.IReadOnlyList<Row> Items { get; } = System.Array.Empty<Row>();
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("new global::Avalonia.Controls.DataGridLayouts.DataGridStackLayoutModel", result.CombinedSource);
+        Assert.Contains("new global::Avalonia.Controls.DataGridLayouts.DataGridNonVirtualizingStackLayoutModel", result.CombinedSource);
+        Assert.Contains("new global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridLayoutModel", result.CombinedSource);
+        Assert.Contains("new global::Avalonia.Controls.DataGridLayouts.DataGridWrapLayoutModel", result.CombinedSource);
+        Assert.Contains("DisableVirtualization = true", result.CombinedSource);
+        Assert.Contains("MaximumRowsOrColumns = 3", result.CombinedSource);
+        Assert.Contains("MaximumCachedLines = 64", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Generated_view_binds_custom_layout_model_reflection_free()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Value { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(typeof(Row), LayoutModelPropertyName = nameof(Layout))]
+            public sealed partial class GridViewModel
+            {
+                public System.Collections.Generic.IReadOnlyList<Row> Items { get; } = System.Array.Empty<Row>();
+                public IDataGridLayoutModel Layout { get; } = new DataGridWrapLayoutModel();
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGrid.LayoutModelProperty", result.CombinedSource);
+        Assert.Contains("s_layoutModelProperty", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Generated_view_rejects_invalid_or_conflicting_layout_configuration()
+    {
+        GeneratorTestResult invalid = GeneratorTestHelper.Run("""
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Value { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(typeof(Row), LayoutModelPropertyName = nameof(Layout))]
+            public sealed partial class GridViewModel
+            {
+                public System.Collections.Generic.IReadOnlyList<Row> Items { get; } = System.Array.Empty<Row>();
+                public object Layout { get; } = new();
+            }
+            """);
+        GeneratorTestResult conflicting = GeneratorTestHelper.Run("""
+            using Avalonia.Controls.DataGridLayouts;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Value { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(typeof(Row), Layout = DataGridGeneratedLayout.Stack, LayoutModelPropertyName = nameof(LayoutModel))]
+            public sealed partial class GridViewModel
+            {
+                public System.Collections.Generic.IReadOnlyList<Row> Items { get; } = System.Array.Empty<Row>();
+                public IDataGridLayoutModel LayoutModel { get; } = new DataGridStackLayoutModel();
+            }
+            """);
+
+        Assert.Contains(invalid.GeneratorDiagnostics, diagnostic => diagnostic.Id == "PDGSG125");
+        Assert.Contains(conflicting.GeneratorDiagnostics, diagnostic => diagnostic.Id == "PDGSG139");
+    }
+
+    [Fact]
     public void Generated_view_binds_reflection_free_clipboard_and_fill_models()
     {
         GeneratorTestResult result = GeneratorTestHelper.Run("""

--- a/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
+++ b/src/ProDataGrid.SourceGenerators.UnitTests/ProDataGridGeneratorTests.cs
@@ -4838,6 +4838,135 @@ public sealed class ProDataGridGeneratorTests
     }
 
     [Fact]
+    public void Generated_item_layout_emits_presentation_estimate_and_typed_factory()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row
+            {
+                public int Id { get; set; }
+                public static Control CreateCard(Row item, Control existing) =>
+                    existing ?? new TextBlock { Text = item.Id.ToString() };
+            }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row),
+                Layout = DataGridGeneratedLayout.UniformGrid,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemWidthEstimate = 180,
+                LayoutItemHeightEstimate = 72,
+                LayoutItemTemplateFactoryMethod = nameof(Row.CreateCard))]
+            public sealed partial class RowsViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = new List<Row>();
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("PresentationMode = global::Avalonia.Controls.DataGridLayouts.DataGridLayoutPresentationMode.Items", result.CombinedSource);
+        Assert.Contains("ItemSizeEstimate = new global::Avalonia.Size(180, 72)", result.CombinedSource);
+        Assert.Contains("DataGridGeneratedFuncDataTemplate<global::Demo.Row>(global::Demo.Row.CreateCard)", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Generated_item_layout_supports_resource_and_implementation_templates()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using Avalonia.Controls.Templates;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Id { get; set; } }
+            public sealed class CardTemplate : IDataTemplate
+            {
+                public Control Build(object data) => new TextBlock();
+                public bool Match(object data) => data is Row;
+            }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row), ViewName = "ResourceCards",
+                Layout = DataGridGeneratedLayout.Wrap,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemTemplateKey = "RowCard")]
+            [GenerateDataGridView(
+                typeof(Row), ViewName = "ImplementationCards",
+                Layout = DataGridGeneratedLayout.Stack,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemTemplateImplementationType = typeof(CardTemplate))]
+            public sealed partial class RowsViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = new List<Row>();
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGrid.ItemTemplateProperty, new global::Avalonia.Markup.Xaml.MarkupExtensions.DynamicResourceExtension(\"RowCard\")", result.CombinedSource);
+        Assert.Contains("dataGrid.ItemTemplate = new global::Demo.CardTemplate()", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Generated_item_layout_rejects_missing_conflicting_and_invalid_configuration()
+    {
+        GeneratorTestResult missing = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Id { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row),
+                Layout = DataGridGeneratedLayout.Wrap,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items)]
+            public sealed partial class RowsViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = new List<Row>();
+            }
+            """);
+        GeneratorTestResult conflicting = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Id { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row),
+                Layout = DataGridGeneratedLayout.Wrap,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemTemplateKey = "Card",
+                LayoutItemTemplateFactoryMethod = "CreateCard")]
+            public sealed partial class RowsViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = new List<Row>();
+            }
+            """);
+        GeneratorTestResult invalidEstimate = GeneratorTestHelper.Run("""
+            using System.Collections.Generic;
+            using ProDataGrid.SourceGeneration;
+            namespace Demo;
+            public sealed class Row { public int Id { get; set; } }
+            [GenerateDataGridViewModel(typeof(Row))]
+            [GenerateDataGridView(
+                typeof(Row),
+                Layout = DataGridGeneratedLayout.Wrap,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemWidthEstimate = 0,
+                LayoutItemTemplateKey = "Card")]
+            public sealed partial class RowsViewModel
+            {
+                public IReadOnlyList<Row> Items { get; } = new List<Row>();
+            }
+            """);
+
+        Assert.Contains(missing.GeneratorDiagnostics, static diagnostic => diagnostic.Id == "PDGSG139");
+        Assert.Contains(conflicting.GeneratorDiagnostics, static diagnostic => diagnostic.Id == "PDGSG139");
+        Assert.Contains(invalidEstimate.GeneratorDiagnostics, static diagnostic => diagnostic.Id == "PDGSG139");
+    }
+
+    [Fact]
     public void Generated_view_binds_custom_layout_model_reflection_free()
     {
         GeneratorTestResult result = GeneratorTestHelper.Run("""
@@ -4932,6 +5061,43 @@ public sealed class ProDataGridGeneratorTests
         Assert.Contains("VerticalSpacing = 9", result.CombinedSource);
         Assert.Contains("MaximumCachedLines = 32", result.CombinedSource);
         Assert.Contains("dataGrid.UseLogicalScrollable = true", result.CombinedSource);
+    }
+
+    [Fact]
+    public void Namespace_view_policy_creates_item_layout_with_resource_template()
+    {
+        GeneratorTestResult result = GeneratorTestHelper.Run("""
+            using System;
+            using System.Collections.Generic;
+            using Avalonia.Controls;
+            using ProDataGrid.SourceGeneration;
+            [assembly: GenerateDataGridViewsForNamespace(
+                "Demo.ViewModels",
+                IncludeNestedNamespaces = false,
+                Layout = DataGridGeneratedLayout.UniformGrid,
+                LayoutPresentation = DataGridGeneratedLayoutPresentation.Items,
+                LayoutItemWidthEstimate = 144,
+                LayoutItemHeightEstimate = 64,
+                LayoutItemTemplateKey = "GalleryCard")]
+            namespace Demo.Models
+            {
+                public sealed class Row { public int Id { get; set; } }
+            }
+            namespace Demo.ViewModels
+            {
+                public sealed class RowsViewModel
+                {
+                    public IReadOnlyList<Demo.Models.Row> Items { get; } = Array.Empty<Demo.Models.Row>();
+                    public DataGridColumnDefinitionList ColumnDefinitions { get; } = new();
+                    public DataGridFastPathOptions FastPathOptions { get; } = new();
+                }
+            }
+            """);
+
+        AssertNoErrors(result);
+        Assert.Contains("DataGridLayoutPresentationMode.Items", result.CombinedSource);
+        Assert.Contains("ItemSizeEstimate = new global::Avalonia.Size(144, 64)", result.CombinedSource);
+        Assert.Contains("DynamicResourceExtension(\"GalleryCard\")", result.CombinedSource);
     }
 
     [Fact]

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
@@ -116,6 +116,12 @@ public sealed partial class ProDataGridGenerator
                 Vertical
             }
 
+            internal enum DataGridGeneratedLayoutPresentation
+            {
+                Rows,
+                Items
+            }
+
             internal enum DataGridCondition
             {
                 Equals,
@@ -342,6 +348,12 @@ public sealed partial class ProDataGridGenerator
                 public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsStretch LayoutItemsStretch { get; set; }
                 public bool LayoutDisableVirtualization { get; set; }
                 public int LayoutMaximumCachedLines { get; set; } = 256;
+                public DataGridGeneratedLayoutPresentation LayoutPresentation { get; set; }
+                public double LayoutItemWidthEstimate { get; set; } = 100;
+                public double LayoutItemHeightEstimate { get; set; } = 32;
+                public string? LayoutItemTemplateKey { get; set; }
+                public Type? LayoutItemTemplateImplementationType { get; set; }
+                public string? LayoutItemTemplateFactoryMethod { get; set; }
                 public string? SortingModelPropertyName { get; set; }
                 public string? FilteringModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridFiltering.DataGridHierarchyFilterPolicy HierarchyFilterPolicy { get; set; } =
@@ -446,6 +458,12 @@ public sealed partial class ProDataGridGenerator
                 public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsStretch LayoutItemsStretch { get; set; }
                 public bool LayoutDisableVirtualization { get; set; }
                 public int LayoutMaximumCachedLines { get; set; } = 256;
+                public DataGridGeneratedLayoutPresentation LayoutPresentation { get; set; }
+                public double LayoutItemWidthEstimate { get; set; } = 100;
+                public double LayoutItemHeightEstimate { get; set; } = 32;
+                public string? LayoutItemTemplateKey { get; set; }
+                public Type? LayoutItemTemplateImplementationType { get; set; }
+                public string? LayoutItemTemplateFactoryMethod { get; set; }
                 public string? SortingModelPropertyName { get; set; }
                 public string? FilteringModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridFiltering.DataGridHierarchyFilterPolicy HierarchyFilterPolicy { get; set; } =

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.AttributeSources.cs
@@ -100,6 +100,22 @@ public sealed partial class ProDataGridGenerator
                 MasterDetail
             }
 
+            internal enum DataGridGeneratedLayout
+            {
+                None,
+                Stack,
+                NonVirtualizingStack,
+                UniformGrid,
+                Wrap
+            }
+
+            internal enum DataGridGeneratedLayoutOrientation
+            {
+                Default,
+                Horizontal,
+                Vertical
+            }
+
             internal enum DataGridCondition
             {
                 Equals,
@@ -313,6 +329,19 @@ public sealed partial class ProDataGridGenerator
                 public string ItemsPropertyName { get; set; } = "Items";
                 public string ColumnDefinitionsPropertyName { get; set; } = "ColumnDefinitions";
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+                public string? LayoutModelPropertyName { get; set; }
+                public DataGridGeneratedLayout Layout { get; set; }
+                public DataGridGeneratedLayoutOrientation LayoutOrientation { get; set; }
+                public double LayoutSpacing { get; set; }
+                public double LayoutHorizontalSpacing { get; set; }
+                public double LayoutVerticalSpacing { get; set; }
+                public double LayoutMinItemWidth { get; set; } = double.NaN;
+                public double LayoutMinItemHeight { get; set; } = double.NaN;
+                public int LayoutMaximumRowsOrColumns { get; set; } = int.MaxValue;
+                public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsJustification LayoutItemsJustification { get; set; }
+                public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsStretch LayoutItemsStretch { get; set; }
+                public bool LayoutDisableVirtualization { get; set; }
+                public int LayoutMaximumCachedLines { get; set; } = 256;
                 public string? SortingModelPropertyName { get; set; }
                 public string? FilteringModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridFiltering.DataGridHierarchyFilterPolicy HierarchyFilterPolicy { get; set; } =
@@ -404,6 +433,19 @@ public sealed partial class ProDataGridGenerator
                 public string ItemsPropertyName { get; set; } = "Items";
                 public string ColumnDefinitionsPropertyName { get; set; } = "ColumnDefinitions";
                 public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+                public string? LayoutModelPropertyName { get; set; }
+                public DataGridGeneratedLayout Layout { get; set; }
+                public DataGridGeneratedLayoutOrientation LayoutOrientation { get; set; }
+                public double LayoutSpacing { get; set; }
+                public double LayoutHorizontalSpacing { get; set; }
+                public double LayoutVerticalSpacing { get; set; }
+                public double LayoutMinItemWidth { get; set; } = double.NaN;
+                public double LayoutMinItemHeight { get; set; } = double.NaN;
+                public int LayoutMaximumRowsOrColumns { get; set; } = int.MaxValue;
+                public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsJustification LayoutItemsJustification { get; set; }
+                public global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsStretch LayoutItemsStretch { get; set; }
+                public bool LayoutDisableVirtualization { get; set; }
+                public int LayoutMaximumCachedLines { get; set; } = 256;
                 public string? SortingModelPropertyName { get; set; }
                 public string? FilteringModelPropertyName { get; set; }
                 public global::Avalonia.Controls.DataGridFiltering.DataGridHierarchyFilterPolicy HierarchyFilterPolicy { get; set; } =

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
@@ -3531,6 +3531,7 @@ internal static class Emitter
         {
             EmitGeneratedLayout(builder, model);
         }
+        EmitLayoutItemTemplateConfiguration(builder, model);
 
         EmitOptionalGridBinding(builder, model.SortingModel, "SortingModel", "s_sortingModelProperty");
         if (model.HierarchicalModel == null)
@@ -4829,6 +4830,13 @@ internal static class Emitter
         builder.Append("            dataGrid.LayoutModel = new global::Avalonia.Controls.DataGridLayouts.")
             .Append(typeName).AppendLine()
             .AppendLine("            {");
+        if (model.LayoutPresentation == 1)
+        {
+            builder.AppendLine("                PresentationMode = global::Avalonia.Controls.DataGridLayouts.DataGridLayoutPresentationMode.Items,")
+                .Append("                ItemSizeEstimate = new global::Avalonia.Size(")
+                .Append(GeneratorUtilities.FormatDouble(model.LayoutItemWidthEstimate)).Append(", ")
+                .Append(GeneratorUtilities.FormatDouble(model.LayoutItemHeightEstimate)).AppendLine("),");
+        }
         if (model.LayoutOrientation != 0)
         {
             builder.Append("                Orientation = global::Avalonia.Controls.DataGridLayouts.DataGridLayoutOrientation.")
@@ -4871,6 +4879,34 @@ internal static class Emitter
 
         builder.AppendLine("            };")
             .AppendLine("            dataGrid.UseLogicalScrollable = true;");
+    }
+
+    private static void EmitLayoutItemTemplateConfiguration(StringBuilder builder, ViewModelViewModel model)
+    {
+        LayoutItemTemplateViewModel? template = model.LayoutItemTemplate;
+        if (template == null)
+        {
+            return;
+        }
+
+        string itemType = model.ItemType.ToDisplayString(GeneratorUtilities.FullyQualifiedNullableFormat);
+        switch (template.Source)
+        {
+            case LayoutItemTemplateSourceModel.Resource:
+                builder.Append("            dataGrid.Bind(global::Avalonia.Controls.DataGrid.ItemTemplateProperty, new global::Avalonia.Markup.Xaml.MarkupExtensions.DynamicResourceExtension(")
+                    .Append(GeneratorUtilities.EscapeString(template.ResourceKey)).AppendLine("));");
+                break;
+            case LayoutItemTemplateSourceModel.Implementation:
+                builder.Append("            dataGrid.ItemTemplate = new ")
+                    .Append(template.ImplementationType!.ToDisplayString(GeneratorUtilities.FullyQualifiedNullableFormat))
+                    .AppendLine("();");
+                break;
+            case LayoutItemTemplateSourceModel.FactoryMethod:
+                builder.Append("            dataGrid.ItemTemplate = new global::Avalonia.Controls.DataGridGeneratedFuncDataTemplate<")
+                    .Append(itemType).Append(">(").Append(itemType).Append('.')
+                    .Append(GeneratorUtilities.EscapeIdentifier(template.FactoryMethod!)).AppendLine(");");
+                break;
+        }
     }
 
     private static void EmitStringAssignment(StringBuilder builder, ImmutableDictionary<string, TypedConstant> options, string propertyName)

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Emitter.cs
@@ -3238,6 +3238,10 @@ internal static class Emitter
         EmitViewPropertyInfo(builder, model.Items, viewModelType, "Items");
         EmitViewPropertyInfo(builder, model.ColumnDefinitions, viewModelType, "ColumnDefinitions");
         EmitViewPropertyInfo(builder, model.FastPathOptions, viewModelType, "FastPathOptions");
+        if (model.LayoutModel != null)
+        {
+            EmitViewPropertyInfo(builder, model.LayoutModel, viewModelType, "LayoutModel");
+        }
         if (model.SortingModel != null)
         {
             EmitViewPropertyInfo(builder, model.SortingModel, viewModelType, "SortingModel");
@@ -3517,6 +3521,16 @@ internal static class Emitter
         builder
             .AppendLine("            dataGrid[!global::Avalonia.Controls.DataGrid.ColumnDefinitionsSourceProperty] = CreateBinding(s_columnDefinitionsProperty, global::Avalonia.Data.BindingMode.OneWay);")
             .AppendLine("            dataGrid[!global::Avalonia.Controls.DataGrid.FastPathOptionsProperty] = CreateBinding(s_fastPathOptionsProperty, global::Avalonia.Data.BindingMode.OneWay);");
+
+        if (model.LayoutModel != null)
+        {
+            builder.AppendLine("            dataGrid.UseLogicalScrollable = true;");
+            EmitOptionalGridBinding(builder, model.LayoutModel, "LayoutModel", "s_layoutModelProperty");
+        }
+        else
+        {
+            EmitGeneratedLayout(builder, model);
+        }
 
         EmitOptionalGridBinding(builder, model.SortingModel, "SortingModel", "s_sortingModelProperty");
         if (model.HierarchicalModel == null)
@@ -4790,6 +4804,73 @@ internal static class Emitter
         builder.Append("            dataGrid[!global::Avalonia.Controls.DataGrid.").Append(propertyName)
             .Append("Property] = CreateBinding(").Append(fieldName)
             .AppendLine(", global::Avalonia.Data.BindingMode.OneWay);");
+    }
+
+    private static void EmitGeneratedLayout(StringBuilder builder, ViewModelViewModel model)
+    {
+        if (model.Layout == 0)
+        {
+            return;
+        }
+
+        string typeName = model.Layout switch
+        {
+            1 => "DataGridStackLayoutModel",
+            2 => "DataGridNonVirtualizingStackLayoutModel",
+            3 => "DataGridUniformGridLayoutModel",
+            4 => "DataGridWrapLayoutModel",
+            _ => string.Empty
+        };
+        if (typeName.Length == 0)
+        {
+            return;
+        }
+
+        builder.Append("            dataGrid.LayoutModel = new global::Avalonia.Controls.DataGridLayouts.")
+            .Append(typeName).AppendLine()
+            .AppendLine("            {");
+        if (model.LayoutOrientation != 0)
+        {
+            builder.Append("                Orientation = global::Avalonia.Controls.DataGridLayouts.DataGridLayoutOrientation.")
+                .Append(model.LayoutOrientation == 1 ? "Horizontal" : "Vertical").AppendLine(",");
+        }
+
+        if (model.Layout is 1 or 2)
+        {
+            builder.Append("                Spacing = ").Append(GeneratorUtilities.FormatDouble(model.LayoutSpacing)).AppendLine(",");
+            if (model.Layout == 1)
+            {
+                builder.Append("                DisableVirtualization = ").Append(model.LayoutDisableVirtualization ? "true" : "false").AppendLine(",");
+            }
+        }
+        else if (model.Layout == 3)
+        {
+            builder.Append("                MinColumnSpacing = ").Append(GeneratorUtilities.FormatDouble(model.LayoutHorizontalSpacing)).AppendLine(",")
+                .Append("                MinRowSpacing = ").Append(GeneratorUtilities.FormatDouble(model.LayoutVerticalSpacing)).AppendLine(",");
+        }
+        else
+        {
+            builder.Append("                HorizontalSpacing = ").Append(GeneratorUtilities.FormatDouble(model.LayoutHorizontalSpacing)).AppendLine(",")
+                .Append("                VerticalSpacing = ").Append(GeneratorUtilities.FormatDouble(model.LayoutVerticalSpacing)).AppendLine(",");
+        }
+
+        if (model.Layout == 3)
+        {
+            builder.Append("                MinItemWidth = ").Append(GeneratorUtilities.FormatDouble(model.LayoutMinItemWidth)).AppendLine(",")
+                .Append("                MinItemHeight = ").Append(GeneratorUtilities.FormatDouble(model.LayoutMinItemHeight)).AppendLine(",")
+                .Append("                MaximumRowsOrColumns = ").Append(model.LayoutMaximumRowsOrColumns.ToString(CultureInfo.InvariantCulture)).AppendLine(",")
+                .Append("                ItemsJustification = (global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsJustification)")
+                .Append(model.LayoutItemsJustification.ToString(CultureInfo.InvariantCulture)).AppendLine(",")
+                .Append("                ItemsStretch = (global::Avalonia.Controls.DataGridLayouts.DataGridUniformGridItemsStretch)")
+                .Append(model.LayoutItemsStretch.ToString(CultureInfo.InvariantCulture)).AppendLine(",");
+        }
+        else if (model.Layout == 4)
+        {
+            builder.Append("                MaximumCachedLines = ").Append(model.LayoutMaximumCachedLines.ToString(CultureInfo.InvariantCulture)).AppendLine(",");
+        }
+
+        builder.AppendLine("            };")
+            .AppendLine("            dataGrid.UseLogicalScrollable = true;");
     }
 
     private static void EmitStringAssignment(StringBuilder builder, ImmutableDictionary<string, TypedConstant> options, string propertyName)

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
@@ -105,6 +105,32 @@ internal sealed class ViewModelViewModel
 
     public ViewBindingModel FastPathOptions { get; set; } = null!;
 
+    public ViewBindingModel? LayoutModel { get; set; }
+
+    public int Layout { get; set; }
+
+    public int LayoutOrientation { get; set; }
+
+    public double LayoutSpacing { get; set; }
+
+    public double LayoutHorizontalSpacing { get; set; }
+
+    public double LayoutVerticalSpacing { get; set; }
+
+    public double LayoutMinItemWidth { get; set; } = double.NaN;
+
+    public double LayoutMinItemHeight { get; set; } = double.NaN;
+
+    public int LayoutMaximumRowsOrColumns { get; set; } = int.MaxValue;
+
+    public int LayoutItemsJustification { get; set; }
+
+    public int LayoutItemsStretch { get; set; }
+
+    public bool LayoutDisableVirtualization { get; set; }
+
+    public int LayoutMaximumCachedLines { get; set; } = 256;
+
     public ViewBindingModel? SortingModel { get; set; }
 
     public ViewBindingModel? FilteringModel { get; set; }

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Models.cs
@@ -131,6 +131,14 @@ internal sealed class ViewModelViewModel
 
     public int LayoutMaximumCachedLines { get; set; } = 256;
 
+    public int LayoutPresentation { get; set; }
+
+    public double LayoutItemWidthEstimate { get; set; } = 100;
+
+    public double LayoutItemHeightEstimate { get; set; } = 32;
+
+    public LayoutItemTemplateViewModel? LayoutItemTemplate { get; set; }
+
     public ViewBindingModel? SortingModel { get; set; }
 
     public ViewBindingModel? FilteringModel { get; set; }
@@ -252,6 +260,24 @@ internal enum RowDetailsTemplateSourceModel
     Implementation,
     FactoryMethod,
     NestedGrid
+}
+
+internal enum LayoutItemTemplateSourceModel
+{
+    Resource,
+    Implementation,
+    FactoryMethod
+}
+
+internal sealed class LayoutItemTemplateViewModel
+{
+    public LayoutItemTemplateSourceModel Source { get; set; }
+
+    public string? ResourceKey { get; set; }
+
+    public INamedTypeSymbol? ImplementationType { get; set; }
+
+    public string? FactoryMethod { get; set; }
 }
 
 internal sealed class RowDetailsViewModel

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Utilities.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.Utilities.cs
@@ -254,6 +254,11 @@ internal static class GeneratorUtilities
         return arguments.TryGetValue(name, out TypedConstant value) && value.Value is int number ? number : fallback;
     }
 
+    public static double GetDouble(Dictionary<string, TypedConstant> arguments, string name, double fallback)
+    {
+        return arguments.TryGetValue(name, out TypedConstant value) && value.Value is double number ? number : fallback;
+    }
+
     public static bool IsPartial(INamedTypeSymbol type)
     {
         foreach (SyntaxReference reference in type.DeclaringSyntaxReferences)

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
@@ -331,6 +331,19 @@ internal static partial class Discovery
             ItemsPropertyName = GeneratorUtilities.GetString(arguments, "ItemsPropertyName") ?? "Items",
             ColumnDefinitionsPropertyName = GeneratorUtilities.GetString(arguments, "ColumnDefinitionsPropertyName") ?? "ColumnDefinitions",
             FastPathOptionsPropertyName = GeneratorUtilities.GetString(arguments, "FastPathOptionsPropertyName") ?? "FastPathOptions",
+            LayoutModelPropertyName = GeneratorUtilities.GetString(arguments, "LayoutModelPropertyName"),
+            Layout = GetEnumValue(arguments, "Layout", 0),
+            LayoutOrientation = GetEnumValue(arguments, "LayoutOrientation", 0),
+            LayoutSpacing = GeneratorUtilities.GetDouble(arguments, "LayoutSpacing", 0),
+            LayoutHorizontalSpacing = GeneratorUtilities.GetDouble(arguments, "LayoutHorizontalSpacing", 0),
+            LayoutVerticalSpacing = GeneratorUtilities.GetDouble(arguments, "LayoutVerticalSpacing", 0),
+            LayoutMinItemWidth = GeneratorUtilities.GetDouble(arguments, "LayoutMinItemWidth", double.NaN),
+            LayoutMinItemHeight = GeneratorUtilities.GetDouble(arguments, "LayoutMinItemHeight", double.NaN),
+            LayoutMaximumRowsOrColumns = GeneratorUtilities.GetInt32(arguments, "LayoutMaximumRowsOrColumns", int.MaxValue),
+            LayoutItemsJustification = GetEnumValue(arguments, "LayoutItemsJustification", 0),
+            LayoutItemsStretch = GetEnumValue(arguments, "LayoutItemsStretch", 0),
+            LayoutDisableVirtualization = GeneratorUtilities.GetBoolean(arguments, "LayoutDisableVirtualization", false),
+            LayoutMaximumCachedLines = GeneratorUtilities.GetInt32(arguments, "LayoutMaximumCachedLines", 256),
             SortingModelPropertyName = GeneratorUtilities.GetString(arguments, "SortingModelPropertyName"),
             FilteringModelPropertyName = GeneratorUtilities.GetString(arguments, "FilteringModelPropertyName"),
             HierarchyFilterPolicy = GetEnumValue(arguments, "HierarchyFilterPolicy", 1),
@@ -509,6 +522,38 @@ internal static partial class Discovery
             diagnostics);
         if (items == null || columns == null || fastOptions == null)
         {
+            return null;
+        }
+
+        ViewBindingModel? layoutModel = null;
+        if (!string.IsNullOrWhiteSpace(request.LayoutModelPropertyName))
+        {
+            if (request.Layout != 0)
+            {
+                ReportInvalidViewPresentation(request, diagnostics, "Layout and LayoutModelPropertyName cannot be used together");
+                return null;
+            }
+            layoutModel = ResolveValidatedViewBinding(
+                request,
+                request.LayoutModelPropertyName!,
+                static type => ImplementsMetadataName(type, "Avalonia.Controls.DataGridLayouts.IDataGridLayoutModel"),
+                "must be an accessible readable IDataGridLayoutModel property",
+                diagnostics);
+            if (layoutModel == null)
+            {
+                return null;
+            }
+        }
+        else if (request.LayoutModelPropertyName != null)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "LayoutModelPropertyName cannot be empty or whitespace");
+            return null;
+        }
+
+        if (request.Layout < 0 || request.Layout > 4 || request.LayoutOrientation < 0 || request.LayoutOrientation > 2 ||
+            request.LayoutMaximumRowsOrColumns <= 0 || request.LayoutMaximumCachedLines <= 0)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "layout configuration contains an unsupported value");
             return null;
         }
 
@@ -736,6 +781,19 @@ internal static partial class Discovery
             Items = items,
             ColumnDefinitions = columns,
             FastPathOptions = fastOptions,
+            LayoutModel = layoutModel,
+            Layout = request.Layout,
+            LayoutOrientation = request.LayoutOrientation,
+            LayoutSpacing = request.LayoutSpacing,
+            LayoutHorizontalSpacing = request.LayoutHorizontalSpacing,
+            LayoutVerticalSpacing = request.LayoutVerticalSpacing,
+            LayoutMinItemWidth = request.LayoutMinItemWidth,
+            LayoutMinItemHeight = request.LayoutMinItemHeight,
+            LayoutMaximumRowsOrColumns = request.LayoutMaximumRowsOrColumns,
+            LayoutItemsJustification = request.LayoutItemsJustification,
+            LayoutItemsStretch = request.LayoutItemsStretch,
+            LayoutDisableVirtualization = request.LayoutDisableVirtualization,
+            LayoutMaximumCachedLines = request.LayoutMaximumCachedLines,
             SortingModel = ResolveOptionalViewBinding(request, request.SortingModelPropertyName, diagnostics),
             FilteringModel = ResolveOptionalViewBinding(request, request.FilteringModelPropertyName, diagnostics),
             HierarchyFilterPolicy = request.HierarchyFilterPolicy,
@@ -1790,6 +1848,19 @@ internal static partial class Discovery
         public string ItemsPropertyName { get; set; } = "Items";
         public string ColumnDefinitionsPropertyName { get; set; } = "ColumnDefinitions";
         public string FastPathOptionsPropertyName { get; set; } = "FastPathOptions";
+        public string? LayoutModelPropertyName { get; set; }
+        public int Layout { get; set; }
+        public int LayoutOrientation { get; set; }
+        public double LayoutSpacing { get; set; }
+        public double LayoutHorizontalSpacing { get; set; }
+        public double LayoutVerticalSpacing { get; set; }
+        public double LayoutMinItemWidth { get; set; } = double.NaN;
+        public double LayoutMinItemHeight { get; set; } = double.NaN;
+        public int LayoutMaximumRowsOrColumns { get; set; } = int.MaxValue;
+        public int LayoutItemsJustification { get; set; }
+        public int LayoutItemsStretch { get; set; }
+        public bool LayoutDisableVirtualization { get; set; }
+        public int LayoutMaximumCachedLines { get; set; } = 256;
         public string? SortingModelPropertyName { get; set; }
         public string? FilteringModelPropertyName { get; set; }
         public int HierarchyFilterPolicy { get; set; } = 1;

--- a/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
+++ b/src/ProDataGrid.SourceGenerators/ProDataGridGenerator.ViewDiscovery.cs
@@ -344,6 +344,10 @@ internal static partial class Discovery
             LayoutItemsStretch = GetEnumValue(arguments, "LayoutItemsStretch", 0),
             LayoutDisableVirtualization = GeneratorUtilities.GetBoolean(arguments, "LayoutDisableVirtualization", false),
             LayoutMaximumCachedLines = GeneratorUtilities.GetInt32(arguments, "LayoutMaximumCachedLines", 256),
+            LayoutPresentation = GetEnumValue(arguments, "LayoutPresentation", 0),
+            LayoutItemWidthEstimate = GeneratorUtilities.GetDouble(arguments, "LayoutItemWidthEstimate", 100),
+            LayoutItemHeightEstimate = GeneratorUtilities.GetDouble(arguments, "LayoutItemHeightEstimate", 32),
+            LayoutItemTemplateArguments = arguments,
             SortingModelPropertyName = GeneratorUtilities.GetString(arguments, "SortingModelPropertyName"),
             FilteringModelPropertyName = GeneratorUtilities.GetString(arguments, "FilteringModelPropertyName"),
             HierarchyFilterPolicy = GetEnumValue(arguments, "HierarchyFilterPolicy", 1),
@@ -551,9 +555,32 @@ internal static partial class Discovery
         }
 
         if (request.Layout < 0 || request.Layout > 4 || request.LayoutOrientation < 0 || request.LayoutOrientation > 2 ||
-            request.LayoutMaximumRowsOrColumns <= 0 || request.LayoutMaximumCachedLines <= 0)
+            request.LayoutPresentation < 0 || request.LayoutPresentation > 1 ||
+            request.LayoutMaximumRowsOrColumns <= 0 || request.LayoutMaximumCachedLines <= 0 ||
+            !IsPositiveFinite(request.LayoutItemWidthEstimate) || !IsPositiveFinite(request.LayoutItemHeightEstimate))
         {
             ReportInvalidViewPresentation(request, diagnostics, "layout configuration contains an unsupported value");
+            return null;
+        }
+
+        LayoutItemTemplateViewModel? layoutItemTemplate = ResolveLayoutItemTemplate(request, diagnostics);
+        if (request.HasLayoutItemTemplateConfiguration && layoutItemTemplate == null)
+        {
+            return null;
+        }
+        if (request.LayoutPresentation == 1 && request.Layout == 0)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "LayoutPresentation.Items requires a generated built-in Layout");
+            return null;
+        }
+        if (request.LayoutPresentation == 1 && layoutItemTemplate == null)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "LayoutPresentation.Items requires one layout item template source");
+            return null;
+        }
+        if (layoutItemTemplate != null && request.LayoutPresentation == 0 && layoutModel == null)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "a layout item template requires LayoutPresentation.Items or LayoutModelPropertyName");
             return null;
         }
 
@@ -794,6 +821,10 @@ internal static partial class Discovery
             LayoutItemsStretch = request.LayoutItemsStretch,
             LayoutDisableVirtualization = request.LayoutDisableVirtualization,
             LayoutMaximumCachedLines = request.LayoutMaximumCachedLines,
+            LayoutPresentation = request.LayoutPresentation,
+            LayoutItemWidthEstimate = request.LayoutItemWidthEstimate,
+            LayoutItemHeightEstimate = request.LayoutItemHeightEstimate,
+            LayoutItemTemplate = layoutItemTemplate,
             SortingModel = ResolveOptionalViewBinding(request, request.SortingModelPropertyName, diagnostics),
             FilteringModel = ResolveOptionalViewBinding(request, request.FilteringModelPropertyName, diagnostics),
             HierarchyFilterPolicy = request.HierarchyFilterPolicy,
@@ -1078,6 +1109,75 @@ internal static partial class Discovery
             constructor.Parameters.Length == 0 && GeneratorUtilities.IsAccessibleFromGeneratedCode(constructor));
         return hasConstructor && ImplementsMetadataName(implementationType, interfaceMetadataName);
     }
+
+    private static LayoutItemTemplateViewModel? ResolveLayoutItemTemplate(
+        ViewRequest request,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        Dictionary<string, TypedConstant> arguments = request.LayoutItemTemplateArguments;
+        string? resourceKey = GeneratorUtilities.GetString(arguments, "LayoutItemTemplateKey");
+        INamedTypeSymbol? implementationType = GeneratorUtilities.GetType(arguments, "LayoutItemTemplateImplementationType");
+        string? factoryMethod = GeneratorUtilities.GetString(arguments, "LayoutItemTemplateFactoryMethod");
+        int sourceCount = (!string.IsNullOrWhiteSpace(resourceKey) ? 1 : 0) +
+                          (implementationType != null ? 1 : 0) +
+                          (!string.IsNullOrWhiteSpace(factoryMethod) ? 1 : 0);
+
+        if (sourceCount == 0)
+        {
+            if (request.HasLayoutItemTemplateConfiguration)
+            {
+                ReportInvalidViewPresentation(request, diagnostics, "a non-empty layout item template key, implementation type, or factory method is required");
+            }
+            return null;
+        }
+        if (sourceCount != 1)
+        {
+            ReportInvalidViewPresentation(request, diagnostics, "layout item template key, implementation type, and factory method are mutually exclusive");
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(resourceKey))
+        {
+            return new LayoutItemTemplateViewModel
+            {
+                Source = LayoutItemTemplateSourceModel.Resource,
+                ResourceKey = resourceKey
+            };
+        }
+        if (implementationType != null)
+        {
+            if (!ValidateRowDetailsImplementation(implementationType))
+            {
+                ReportInvalidViewPresentation(
+                    request,
+                    diagnostics,
+                    $"layout item template type '{implementationType.ToDisplayString()}' must be accessible, non-abstract, parameterless, and implement IDataTemplate");
+                return null;
+            }
+            return new LayoutItemTemplateViewModel
+            {
+                Source = LayoutItemTemplateSourceModel.Implementation,
+                ImplementationType = implementationType
+            };
+        }
+
+        if (!HasRowDetailsFactoryMethod(request.ItemType, factoryMethod!))
+        {
+            ReportInvalidViewPresentation(
+                request,
+                diagnostics,
+                $"layout item template factory '{factoryMethod}' must be accessible, static, non-generic, accept ({request.ItemType.Name}, Control), and return Control");
+            return null;
+        }
+        return new LayoutItemTemplateViewModel
+        {
+            Source = LayoutItemTemplateSourceModel.FactoryMethod,
+            FactoryMethod = factoryMethod
+        };
+    }
+
+    private static bool IsPositiveFinite(double value) =>
+        value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
 
     private static RowDetailsViewModel? ResolveRowDetails(
         ViewRequest request,
@@ -1861,6 +1961,12 @@ internal static partial class Discovery
         public int LayoutItemsStretch { get; set; }
         public bool LayoutDisableVirtualization { get; set; }
         public int LayoutMaximumCachedLines { get; set; } = 256;
+        public int LayoutPresentation { get; set; }
+        public double LayoutItemWidthEstimate { get; set; } = 100;
+        public double LayoutItemHeightEstimate { get; set; } = 32;
+        public Dictionary<string, TypedConstant> LayoutItemTemplateArguments { get; set; } = new(StringComparer.Ordinal);
+        public bool HasLayoutItemTemplateConfiguration =>
+            LayoutItemTemplateArguments.Keys.Any(static key => key.StartsWith("LayoutItemTemplate", StringComparison.Ordinal));
         public string? SortingModelPropertyName { get; set; }
         public string? FilteringModelPropertyName { get; set; }
         public int HierarchyFilterPolicy { get; set; } = 1;


### PR DESCRIPTION
## Summary

> **Stacked PR:** this PR is explicitly based on `agent/navigation-model` at clean navigation/input checkpoint `17317d3cb4a30879b1edd9a14938ecc5ea5701cf`. All layout implementation commits live in this PR and are visible in its diff.

Adds an extensible, model-based layout subsystem to ProDataGrid and integrates it with semantic navigation and normalized navigation input.

The implementation covers every concrete layout family currently provided by ProItemsRepeater:

- virtualizing stack (vertical or horizontal, fixed or variable item sizes)
- non-virtualizing stack
- uniform grid
- variable-size wrap

`DataGrid.LayoutModel == null` preserves the existing optimized vertical-list path. Assigning a model activates the presenter-owned layout session. Layouts use row/cell presentation by default, or opt into lightweight recyclable item-template containers that suppress row/cell and header realization while retaining selection, navigation, sorting, filtering, and virtualization.

## Architecture and extensibility

- Public `IDataGridLayoutModel`, `IDataGridLayoutAlgorithm`, and `IDataGridLayoutContext` contracts provide the custom-layout extension point.
- `DataGridLayoutModelBase` supplies batched, typed invalidation without reflection.
- Presenter sessions are retained per model instance for fast switches back to a prior layout; weak-key storage avoids retaining discarded models.
- Stack and uniform-grid geometry use allocation-light indexed/constant-time calculations.
- Wrap caches a configurable bounded number of exact lines and uses rolling estimates for far jumps, so state does not scale with the full item count.
- Existing realized row controls are reused across runtime layout switches.
- Optional `IDataGridLayoutPresentationModel` selects row/cell or custom item-template presentation without coupling Avalonia templates to geometry algorithms.
- Item presentation uses recyclable `DataGridItemContainer` instances and supports runtime layout/template switching without retaining discarded models or templates.
- Item size estimates seed off-screen virtualization before measurement; measured template sizes refine active geometry.
- `ScrollIntoView` and logical scrolling use active-layout geometry, including non-realized estimates.

## Navigation and input integration

The navigation model remains semantic policy while the active layout session owns geometry and realization:

- `IDataGridLayoutNavigation` advertises per-direction ownership, estimates non-realized bounds, and resolves spatial neighbors.
- One geometry plan is resolved per request; redirected commands resolve a fresh plan.
- Layout-owned unresolved directions are true boundaries, while unsupported directions preserve classic cell navigation.
- Cross-axis anchors persist through spatial/page movement and reset on layout switches or coordinate-space invalidation.
- Uniform-grid and wrap layouts own all spatial directions. Stack owns its major axis plus page/first/last, leaving its cross axis to DataGrid cell navigation.
- Layout-owned boundary wrapping stays spatial (line start/end or first/last); unsupported Stack cross-axis wrapping remains classic cell-axis policy.
- Normalized key, pointer, and wheel input first resolves to semantic navigation; layout geometry is consulted only afterward.
- Editing/focus validation, selection extension, hierarchy precedence, application routing, and completion reporting remain in the navigation pipeline.
- The integration adds no fields to the public navigation request struct, preserving its ABI and binary layout.

## Source generation

Both `GenerateDataGridView` and `GenerateDataGridViewsForNamespace` support:

- all built-in layout types and their complete option sets
- reflection-free binding to a custom `IDataGridLayoutModel` property
- automatic logical scrolling when a generated or bound layout is active
- compile-time diagnostics for invalid, inaccessible, wrong-typed, or conflicting configuration
- composition with generated navigation-input model properties and providers from the base PR
- generated item presentation, positive size estimates, and compile-time validated resource, implementation-type, or typed recycling-factory templates
- custom bound item-layout models with generated item templates

## Samples and documentation

- The Layout Gallery switches among eight retained models: classic table rows plus every built-in item-layout orientation/family and a public custom indented-stack algorithm.
- Card layouts use one compiled `DataGrid.ItemTemplate`; no row, cell, or header visuals are realized.
- A headless sample test switches card/table presentation, asserts the visual-tree contract, and captures both rendered states.
- The advanced navigation gallery demonstrates geometry-aware movement with the integrated navigation and input models.
- Guides cover model layouts, item-template presentation, custom algorithm authoring, navigation ownership/coordinates, accessibility/editing/recycling behavior, performance and memory guidance, and generated layouts.
- All new sample XAML uses compiled bindings and passive code-behind.

## Validation

- Exact stacked base / merge-base: `17317d3cb4a30879b1edd9a14938ecc5ea5701cf`
- Exact layout head: `ac7f97182ed47ba6a9e1a1cf4a5a2488b9b78f06`
- Solution build: 0 errors (existing warnings only)
- Focused layout + navigation + normalized-input + route + item-automation tests: 124/124
- Source-generator tests: 203/203
- Layout Gallery headless switch/screenshot test: 1/1
- DocFX metadata/build: 0 errors (existing warnings only)
- `git diff --check`: pass
- Exact-head [Build workflow](https://github.com/wieslawsoltes/ProDataGrid/actions/runs/31713070129): green (Build, Ubuntu/macOS/Windows, NativeAOT, Pack)
- Exact-head [Windows leak workflow](https://github.com/wieslawsoltes/ProDataGrid/actions/runs/31713070320): green
- Exact-head [native-source comparison](https://github.com/wieslawsoltes/ProDataGrid/actions/runs/31713068653): green

The PR remains draft for API and review.