### PR TITLE
Optimize virtual surface sorting and sample layout

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Collections/DataGridSortDescriptionTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Collections/DataGridSortDescriptionTests.cs
@@ -138,6 +138,56 @@ namespace Avalonia.Controls.DataGridTests.Collections
         }
 
         [Theory]
+        [InlineData(ListSortDirection.Ascending, "a", "b", "c")]
+        [InlineData(ListSortDirection.Descending, "c", "b", "a")]
+        public void FromAccessor_Extracts_Each_Sort_Key_Once(
+            ListSortDirection direction,
+            params string[] expected)
+        {
+            var items = new[]
+            {
+                new Item("b", "1"),
+                new Item("a", "2"),
+                new Item("c", "3"),
+            };
+            int getterCalls = 0;
+            var accessor = new DataGridColumnValueAccessor<Item, string>(item =>
+            {
+                getterCalls++;
+                return item.Prop1;
+            });
+            var sortDescription = DataGridSortDescription.FromAccessor(accessor, direction);
+
+            string?[] result = sortDescription.OrderBy(items).Cast<Item>().Select(item => item.Prop1).ToArray();
+
+            Assert.Equal(expected, result);
+            Assert.Equal(items.Length, getterCalls);
+        }
+
+        [Fact]
+        public void FromAccessor_ThenBy_Extracts_Each_Secondary_Key_Once()
+        {
+            var items = new[]
+            {
+                (object)new Item("a", "b"),
+                new Item("a", "a"),
+                new Item("a", "c"),
+            }.OrderBy(item => ((Item)item).Prop1);
+            int getterCalls = 0;
+            var accessor = new DataGridColumnValueAccessor<Item, string>(item =>
+            {
+                getterCalls++;
+                return item.Prop2;
+            });
+            var sortDescription = DataGridSortDescription.FromAccessor(accessor);
+
+            string?[] result = sortDescription.ThenBy(items).Cast<Item>().Select(item => item.Prop2).ToArray();
+
+            Assert.Equal(new[] { "a", "b", "c" }, result);
+            Assert.Equal(3, getterCalls);
+        }
+
+        [Theory]
         [InlineData(ListSortDirection.Ascending, "Alice", "Bob", "Charlie")]
         [InlineData(ListSortDirection.Descending, "Charlie", "Bob", "Alice")]
         public void FromPath_Orders_Explicit_Interface_Property(

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Layout/DataGridFlatVisualLayoutTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Layout/DataGridFlatVisualLayoutTests.cs
@@ -9,6 +9,7 @@ using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Automation.Peers;
 using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.DataGridSearching;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
@@ -1712,6 +1713,51 @@ public class DataGridFlatVisualLayoutTests
 
             Assert.True(grid.UsesVirtualCellSurfaceFallback);
             Assert.NotEmpty(GetRowsPresenter(grid).GetVisualDescendants().OfType<DataGridCell>());
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Virtualized_Search_Only_Uses_Retained_Fallback_When_Highlights_Are_Visible()
+    {
+        (Window window, DataGrid grid) = CreateGrid(DataGridTheme.SimpleFlat, useFlatTheme: true);
+        grid.VisualLayoutMode = DataGridVisualLayoutMode.Virtualized;
+        var searchModel = new SearchModel
+        {
+            HighlightMode = SearchHighlightMode.None,
+            HighlightCurrent = false,
+        };
+        grid.SearchModel = searchModel;
+        searchModel.HighlightMode = SearchHighlightMode.None;
+        searchModel.HighlightCurrent = false;
+
+        try
+        {
+            window.Show();
+            PumpLayout(grid);
+
+            searchModel.SetOrUpdate(new SearchDescriptor("Item 1", scope: SearchScope.VisibleColumns));
+            PumpLayout(grid);
+
+            Assert.NotEmpty(searchModel.Results);
+            Assert.Equal(SearchHighlightMode.None, searchModel.HighlightMode);
+            Assert.True(grid.UsesVirtualCellSurface);
+            Assert.Empty(GetRowsPresenter(grid).GetVisualDescendants().OfType<DataGridCell>());
+
+            searchModel.HighlightMode = SearchHighlightMode.TextAndCell;
+            PumpLayout(grid);
+
+            Assert.True(grid.UsesVirtualCellSurfaceFallback);
+            Assert.NotEmpty(GetRowsPresenter(grid).GetVisualDescendants().OfType<DataGridCell>());
+
+            searchModel.HighlightMode = SearchHighlightMode.None;
+            PumpLayout(grid);
+
+            Assert.True(grid.UsesVirtualCellSurface);
+            Assert.Empty(GetRowsPresenter(grid).GetVisualDescendants().OfType<DataGridCell>());
         }
         finally
         {

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridAccessorSearchAdapterTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Searching/DataGridAccessorSearchAdapterTests.cs
@@ -373,6 +373,73 @@ public class DataGridAccessorSearchAdapterTests
     }
 
     [AvaloniaFact]
+    public void AccessorAdapter_HighPerformanceSearch_Remaps_Results_For_Sort_Without_Rescanning_Text()
+    {
+        var items = new[]
+        {
+            new Person("Beta"),
+            new Person("Alpha"),
+            new Person("Beta")
+        };
+        var view = new DataGridCollectionView(items);
+        var model = new SearchModel();
+        var column = new DataGridTextColumn();
+        var textAccessor = new TextAccessor();
+        DataGridColumnMetadata.SetValueAccessor(column, textAccessor);
+        var options = new DataGridFastPathOptions
+        {
+            EnableHighPerformanceSearching = true,
+            HighPerformanceSearchTrackItemChanges = false
+        };
+        var adapter = new DataGridAccessorSearchAdapter(model, () => new[] { column }, options);
+        adapter.AttachView(view);
+
+        model.SetOrUpdate(new SearchDescriptor("Beta", comparison: StringComparison.OrdinalIgnoreCase));
+        int initialTextCalls = textAccessor.TextCalls;
+
+        view.SortDescriptions.Add(DataGridSortDescription.FromAccessor(
+            new DataGridColumnValueAccessor<Person, string>(person => person.Name),
+            ListSortDirection.Ascending));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(initialTextCalls, textAccessor.TextCalls);
+        Assert.Equal(new[] { 1, 2 }, model.Results.Select(result => result.RowIndex).ToArray());
+        Assert.All(model.Results, result => Assert.Equal("Beta", result.Text));
+    }
+
+    [AvaloniaFact]
+    public void AccessorAdapter_HighPerformanceSearch_Rescans_For_Filter_Reset()
+    {
+        var items = new[]
+        {
+            new Person("Beta"),
+            new Person("Alpha"),
+            new Person("Beta")
+        };
+        var view = new DataGridCollectionView(items);
+        var model = new SearchModel();
+        var column = new DataGridTextColumn();
+        var textAccessor = new TextAccessor();
+        DataGridColumnMetadata.SetValueAccessor(column, textAccessor);
+        var options = new DataGridFastPathOptions
+        {
+            EnableHighPerformanceSearching = true,
+            HighPerformanceSearchTrackItemChanges = false
+        };
+        var adapter = new DataGridAccessorSearchAdapter(model, () => new[] { column }, options);
+        adapter.AttachView(view);
+
+        model.SetOrUpdate(new SearchDescriptor("Beta", comparison: StringComparison.OrdinalIgnoreCase));
+        int initialTextCalls = textAccessor.TextCalls;
+
+        view.Filter = item => ((Person)item).Name == "Alpha";
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(textAccessor.TextCalls > initialTextCalls);
+        Assert.Empty(model.Results);
+    }
+
+    [AvaloniaFact]
     public void AccessorAdapter_HighPerformanceSearch_Tracks_Item_Changes_When_Enabled()
     {
         var items = new ObservableCollection<MutablePerson>

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.CollectionOps.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.CollectionOps.cs
@@ -26,6 +26,10 @@ namespace Avalonia.Collections
         private int _sourceMutationDepth;
         private DataGridCollectionViewSourceMutationEventArgs _sourceMutationEventArgs;
         private NotifyCollectionChangedEventArgs _pendingSourceReset;
+        private bool _pendingSortOnlyRefresh;
+        private bool _isReorderOnlyReset;
+
+        internal bool IsReorderOnlyReset => _isReorderOnlyReset;
 
         private SourceMutationScope BeginSourceMutation(NotifyCollectionChangedEventArgs change)
         {
@@ -1008,6 +1012,7 @@ namespace Avalonia.Collections
             finally
             {
                 viewProjectionMutation.Dispose();
+                _pendingSortOnlyRefresh = false;
             }
         }
 
@@ -1016,12 +1021,31 @@ namespace Avalonia.Collections
         /// </summary>
         private void RefreshOrDefer()
         {
+            _pendingSortOnlyRefresh = false;
             if (IsRefreshDeferred)
             {
                 SetFlag(CollectionViewFlags.NeedsRefresh, true);
             }
             else
             {
+                RefreshInternal();
+            }
+        }
+
+        private void RefreshOrDeferForSort()
+        {
+            if (IsRefreshDeferred)
+            {
+                if (!CheckFlag(CollectionViewFlags.NeedsRefresh))
+                {
+                    _pendingSortOnlyRefresh = true;
+                }
+
+                SetFlag(CollectionViewFlags.NeedsRefresh, true);
+            }
+            else
+            {
+                _pendingSortOnlyRefresh = true;
                 RefreshInternal();
             }
         }
@@ -1116,6 +1140,7 @@ namespace Avalonia.Collections
                 ? BeginViewProjectionMutation()
                 : default;
 
+            _isReorderOnlyReset = _pendingSortOnlyRefresh;
             try
             {
                 // reset currency values
@@ -1135,6 +1160,10 @@ namespace Avalonia.Collections
             {
                 viewProjectionMutation.Dispose();
                 throw;
+            }
+            finally
+            {
+                _isReorderOnlyReset = false;
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.Internal.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.Internal.cs
@@ -388,7 +388,12 @@ namespace Avalonia.Collections
             activity?.SetTag(DataGridDiagnostics.Tags.SortDescriptions, SortDescriptions?.Count ?? 0);
 
             // filter the collection's array into the local array
-            List<object> localList = new List<object>();
+            int capacity = Filter == null && enumerable is ICollection collection
+                ? collection.Count
+                : 0;
+            List<object> localList = capacity > 0
+                ? new List<object>(capacity)
+                : new List<object>();
 
             foreach (object item in enumerable)
             {
@@ -500,7 +505,7 @@ namespace Avalonia.Collections
 
             // we want to make sure that the data is refreshed before we try to move to a page
             // since the refresh would take care of the filtering, sorting, and grouping.
-            RefreshOrDefer();
+            RefreshOrDeferForSort();
 
             if (PageSize > 0)
             {

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -424,6 +424,27 @@ internal
             else
                 return result;
         }
+
+        public override IOrderedEnumerable<object> OrderBy(IEnumerable<object> seq)
+        {
+            if (_innerComparer is IDataGridColumnValueAccessorSorter accessorSorter)
+            {
+                return accessorSorter.OrderBy(seq, Direction);
+            }
+
+            return base.OrderBy(seq);
+        }
+
+        public override IOrderedEnumerable<object> ThenBy(IOrderedEnumerable<object> seq)
+        {
+            if (_innerComparer is IDataGridColumnValueAccessorSorter accessorSorter)
+            {
+                return accessorSorter.ThenBy(seq, Direction);
+            }
+
+            return base.ThenBy(seq);
+        }
+
         public override DataGridSortDescription SwitchSortDirection()
         {
             var newDirection = _direction == ListSortDirection.Ascending ? ListSortDirection.Descending : ListSortDirection.Ascending;

--- a/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnValueAccessor.cs
+++ b/src/Avalonia.Controls.DataGrid/ColumnDefinitions/DataGridColumnValueAccessor.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Avalonia.Controls.DataGridFiltering;
 using Avalonia.Data.Converters;
@@ -78,6 +80,17 @@ namespace Avalonia.Controls
     internal interface IDataGridColumnValueAccessorComparer
     {
         IDataGridColumnValueAccessor Accessor { get; }
+    }
+
+    internal interface IDataGridColumnValueAccessorSorter
+    {
+        IOrderedEnumerable<object> OrderBy(
+            IEnumerable<object> source,
+            ListSortDirection direction);
+
+        IOrderedEnumerable<object> ThenBy(
+            IOrderedEnumerable<object> source,
+            ListSortDirection direction);
     }
 
 #if !DATAGRID_INTERNAL
@@ -413,7 +426,7 @@ namespace Avalonia.Controls
 #else
     internal
 #endif
-    sealed class DataGridColumnValueAccessorComparer : IComparer, IDataGridColumnValueAccessorComparer
+    sealed class DataGridColumnValueAccessorComparer : IComparer, IDataGridColumnValueAccessorComparer, IDataGridColumnValueAccessorSorter
     {
         private static readonly ConditionalWeakTable<IDataGridColumnValueAccessor, AccessorComparerCache> s_comparerCache = new();
 
@@ -522,6 +535,24 @@ namespace Avalonia.Controls
 
         public IDataGridColumnValueAccessor Accessor => _accessor;
 
+        IOrderedEnumerable<object> IDataGridColumnValueAccessorSorter.OrderBy(
+            IEnumerable<object> source,
+            ListSortDirection direction)
+        {
+            return direction == ListSortDirection.Descending
+                ? source.OrderByDescending(GetSortValue, AccessorValueComparer.Instance(this))
+                : source.OrderBy(GetSortValue, AccessorValueComparer.Instance(this));
+        }
+
+        IOrderedEnumerable<object> IDataGridColumnValueAccessorSorter.ThenBy(
+            IOrderedEnumerable<object> source,
+            ListSortDirection direction)
+        {
+            return direction == ListSortDirection.Descending
+                ? source.ThenByDescending(GetSortValue, AccessorValueComparer.Instance(this))
+                : source.ThenBy(GetSortValue, AccessorValueComparer.Instance(this));
+        }
+
         public int Compare(object x, object y)
         {
             var left = _accessor.GetValue(x);
@@ -559,6 +590,54 @@ namespace Avalonia.Controls
 
             return Comparer.Default.Compare(left, right);
         }
+
+        private object GetSortValue(object item) => _accessor.GetValue(item);
+
+        private int CompareValues(object left, object right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return 0;
+            }
+
+            if (left == null)
+            {
+                return -1;
+            }
+
+            if (right == null)
+            {
+                return 1;
+            }
+
+            if (_valueComparer != null)
+            {
+                return _valueComparer.Compare(left, right);
+            }
+
+            if (left is string leftString && right is string rightString)
+            {
+                return _culture.CompareInfo.Compare(leftString, rightString);
+            }
+
+            if (left is IComparable comparable)
+            {
+                return comparable.CompareTo(right);
+            }
+
+            return Comparer.Default.Compare(left, right);
+        }
+
+        private sealed class AccessorValueComparer : IComparer<object>
+        {
+            private readonly DataGridColumnValueAccessorComparer _owner;
+
+            private AccessorValueComparer(DataGridColumnValueAccessorComparer owner) => _owner = owner;
+
+            public static AccessorValueComparer Instance(DataGridColumnValueAccessorComparer owner) => new(owner);
+
+            public int Compare(object x, object y) => _owner.CompareValues(x, y);
+        }
     }
 
 #if !DATAGRID_INTERNAL
@@ -566,7 +645,7 @@ namespace Avalonia.Controls
 #else
     internal
 #endif
-    sealed class DataGridColumnValueAccessorComparer<TItem, TValue> : IComparer, IDataGridColumnValueAccessorComparer
+    sealed class DataGridColumnValueAccessorComparer<TItem, TValue> : IComparer, IDataGridColumnValueAccessorComparer, IDataGridColumnValueAccessorSorter
     {
         private static readonly ConditionalWeakTable<IDataGridColumnValueAccessor<TItem, TValue>, TypedComparerCache> s_comparerCache = new();
 
@@ -668,6 +747,26 @@ namespace Avalonia.Controls
 
         public IDataGridColumnValueAccessor Accessor => _accessor;
 
+        IOrderedEnumerable<object> IDataGridColumnValueAccessorSorter.OrderBy(
+            IEnumerable<object> source,
+            ListSortDirection direction)
+        {
+            var comparer = new AccessorSortKeyComparer(_comparer);
+            return direction == ListSortDirection.Descending
+                ? source.OrderByDescending(GetSortKey, comparer)
+                : source.OrderBy(GetSortKey, comparer);
+        }
+
+        IOrderedEnumerable<object> IDataGridColumnValueAccessorSorter.ThenBy(
+            IOrderedEnumerable<object> source,
+            ListSortDirection direction)
+        {
+            var comparer = new AccessorSortKeyComparer(_comparer);
+            return direction == ListSortDirection.Descending
+                ? source.ThenByDescending(GetSortKey, comparer)
+                : source.ThenBy(GetSortKey, comparer);
+        }
+
         public int Compare(object x, object y)
         {
             if (ReferenceEquals(x, y))
@@ -724,6 +823,59 @@ namespace Avalonia.Controls
 
             value = default;
             return false;
+        }
+
+        private AccessorSortKey GetSortKey(object item)
+        {
+            bool hasValue = TryGetValue(item, out TValue value);
+            return new AccessorSortKey(hasValue, value);
+        }
+
+        private readonly struct AccessorSortKey
+        {
+            public AccessorSortKey(bool hasValue, TValue value)
+            {
+                HasValue = hasValue;
+                Value = value;
+            }
+
+            public bool HasValue { get; }
+
+            public TValue Value { get; }
+        }
+
+        private sealed class AccessorSortKeyComparer : IComparer<AccessorSortKey>
+        {
+            private readonly IComparer<TValue> _valueComparer;
+
+            public AccessorSortKeyComparer(IComparer<TValue> valueComparer) => _valueComparer = valueComparer;
+
+            public int Compare(AccessorSortKey left, AccessorSortKey right)
+            {
+                if (!left.HasValue)
+                {
+                    return right.HasValue ? -1 : 0;
+                }
+
+                if (!right.HasValue)
+                {
+                    return 1;
+                }
+
+                bool leftNull = left.Value is null;
+                bool rightNull = right.Value is null;
+                if (leftNull)
+                {
+                    return rightNull ? 0 : -1;
+                }
+
+                if (rightNull)
+                {
+                    return 1;
+                }
+
+                return _valueComparer.Compare(left.Value, right.Value);
+            }
         }
 
         private static IComparer<TValue> CreateComparer(CultureInfo culture)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.FlatVisualLayout.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.FlatVisualLayout.cs
@@ -181,7 +181,7 @@ partial class DataGrid
             RowGroupFootersTable.RangeCount != 0 ||
             !_collapsedSlotsTable.IsEmpty ||
             (_conditionalFormattingModel?.Descriptors.Count ?? 0) > 0 ||
-            (_searchModel?.Descriptors.Count ?? 0) > 0 ||
+            HasActiveSearchPresentation() ||
             HasLoadingRowHandlers() ||
             HasUnloadingRowHandlers() ||
             HasCellPreparedHandlers ||
@@ -317,7 +317,7 @@ partial class DataGrid
         if (!double.IsFinite(RowHeight) ||
             CellTheme is not null ||
             (_conditionalFormattingModel?.Descriptors.Count ?? 0) > 0 ||
-            (_searchModel?.Descriptors.Count ?? 0) > 0 ||
+            HasActiveSearchPresentation() ||
             HasCellPreparedHandlers ||
             HasCellClearingHandlers)
         {
@@ -345,6 +345,10 @@ partial class DataGrid
 
         return foundVisibleColumn;
     }
+
+    private bool HasActiveSearchPresentation() =>
+        (_searchModel?.Descriptors.Count ?? 0) > 0 &&
+        _searchModel!.HighlightMode != DataGridSearching.SearchHighlightMode.None;
 
     private void RefreshVirtualCellBackendAfterColumnsChanged()
     {

--- a/src/Avalonia.Controls.DataGrid/DataGrid.SelectionChanging.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.SelectionChanging.cs
@@ -398,7 +398,12 @@ namespace Avalonia.Controls
             object oldCurrentItem = ProjectSelectionItem(CurrentCell.Item);
             object oldCurrencyItem = ProjectSelectionItem(DataConnection?.CollectionView?.CurrentItem);
 
-            var prospectiveRows = new List<ProspectiveSelectionRow>();
+            int prospectiveCapacity = prospectiveSource is ICollection collection
+                ? collection.Count
+                : 0;
+            var prospectiveRows = prospectiveCapacity > 0
+                ? new List<ProspectiveSelectionRow>(prospectiveCapacity)
+                : new List<ProspectiveSelectionRow>();
             if (prospectiveSource != null)
             {
                 foreach (object rowDataContext in prospectiveSource)

--- a/src/Avalonia.Controls.DataGrid/Searching/DataGridAccessorSearchAdapter.cs
+++ b/src/Avalonia.Controls.DataGrid/Searching/DataGridAccessorSearchAdapter.cs
@@ -62,7 +62,9 @@ namespace Avalonia.Controls.DataGridSearching
                 return;
             }
 
-            _incrementalSearchService.RecordCollectionChange(e);
+            bool canRemapReset = e.Action == NotifyCollectionChangedAction.Reset &&
+                View is DataGridCollectionView { IsReorderOnlyReset: true };
+            _incrementalSearchService.RecordCollectionChange(e, canRemapReset);
         }
 
         protected override void OnViewItemPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -98,6 +100,7 @@ namespace Avalonia.Controls.DataGridSearching
                     descriptors,
                     BuildRowResults,
                     TryGetUniqueRowIndex,
+                    TryRemapReorderedResults,
                     out results))
             {
                 return true;
@@ -118,6 +121,89 @@ namespace Avalonia.Controls.DataGridSearching
                 }
             }
 
+            return true;
+        }
+
+        private bool TryRemapReorderedResults(
+            IReadOnlyList<SearchResult> currentResults,
+            out IReadOnlyList<SearchResult> remappedResults)
+        {
+            remappedResults = null;
+            if (currentResults == null || currentResults.Count == 0)
+            {
+                remappedResults = Array.Empty<SearchResult>();
+                return true;
+            }
+
+            var requiredIndexes = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+            for (int i = 0; i < currentResults.Count; i++)
+            {
+                object item = currentResults[i].Item;
+                if (item == null)
+                {
+                    return false;
+                }
+
+                requiredIndexes.TryAdd(item, -1);
+            }
+
+            int rowIndex = 0;
+            foreach (object item in View)
+            {
+                if (item != null && requiredIndexes.TryGetValue(item, out int existingIndex))
+                {
+                    if (existingIndex >= 0)
+                    {
+                        return false;
+                    }
+
+                    requiredIndexes[item] = rowIndex;
+                }
+
+                rowIndex++;
+            }
+
+            foreach (KeyValuePair<object, int> pair in requiredIndexes)
+            {
+                if (pair.Value < 0)
+                {
+                    return false;
+                }
+            }
+
+            var remapped = new List<SearchResult>(currentResults.Count);
+            for (int i = 0; i < currentResults.Count; i++)
+            {
+                SearchResult current = currentResults[i];
+                remapped.Add(new SearchResult(
+                    current.Item,
+                    requiredIndexes[current.Item],
+                    current.ColumnId,
+                    current.ColumnIndex,
+                    current.Text,
+                    current.Matches));
+            }
+
+            remapped.Sort(static (left, right) =>
+            {
+                int comparison = left.RowIndex.CompareTo(right.RowIndex);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                comparison = left.ColumnIndex.CompareTo(right.ColumnIndex);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                int leftStart = left.Matches.Count > 0 ? left.Matches[0].Start : 0;
+                int rightStart = right.Matches.Count > 0 ? right.Matches[0].Start : 0;
+                return leftStart.CompareTo(rightStart);
+            });
+
+            remappedResults = remapped;
             return true;
         }
 

--- a/src/Avalonia.Controls.DataGrid/Searching/IncrementalSearchResultService.cs
+++ b/src/Avalonia.Controls.DataGrid/Searching/IncrementalSearchResultService.cs
@@ -18,6 +18,9 @@ namespace Avalonia.Controls.DataGridSearching
     internal sealed class IncrementalSearchResultService
     {
         internal delegate bool TryResolveRowIndexDelegate(object item, out int rowIndex);
+        internal delegate bool TryRemapResetDelegate(
+            IReadOnlyList<SearchResult> currentResults,
+            out IReadOnlyList<SearchResult> remappedResults);
 
         private readonly bool _trackItemChanges;
         private readonly List<PendingCollectionChange> _pendingCollectionChanges = new();
@@ -31,14 +34,20 @@ namespace Avalonia.Controls.DataGridSearching
             _trackItemChanges = trackItemChanges;
         }
 
-        public void RecordCollectionChange(NotifyCollectionChangedEventArgs e)
+        public void RecordCollectionChange(
+            NotifyCollectionChangedEventArgs e,
+            bool canRemapReset = false)
         {
             if (e == null || _activeResults == null)
             {
                 return;
             }
 
-            _pendingCollectionChanges.Add(PendingCollectionChange.From(e));
+            _pendingCollectionChanges.Add(PendingCollectionChange.From(e, canRemapReset));
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                _hasPendingReset = true;
+            }
         }
 
         public void RecordItemChange(object item)
@@ -75,6 +84,7 @@ namespace Avalonia.Controls.DataGridSearching
             IReadOnlyList<SearchDescriptor> descriptors,
             Func<object, int, IReadOnlyList<SearchResult>> buildRowResults,
             TryResolveRowIndexDelegate tryResolveRowIndex,
+            TryRemapResetDelegate tryRemapReset,
             out IReadOnlyList<SearchResult> results)
         {
             if (buildRowResults == null)
@@ -85,6 +95,11 @@ namespace Avalonia.Controls.DataGridSearching
             if (tryResolveRowIndex == null)
             {
                 throw new ArgumentNullException(nameof(tryResolveRowIndex));
+            }
+
+            if (tryRemapReset == null)
+            {
+                throw new ArgumentNullException(nameof(tryRemapReset));
             }
 
             results = null;
@@ -110,6 +125,16 @@ namespace Avalonia.Controls.DataGridSearching
 
             if (_hasPendingReset)
             {
+                if (_pendingCollectionChanges.Count == 1 &&
+                    _pendingCollectionChanges[0].CanRemapReset &&
+                    tryRemapReset(_activeResults, out IReadOnlyList<SearchResult> remappedResults))
+                {
+                    _activeResults = remappedResults as List<SearchResult> ?? remappedResults.ToList();
+                    ClearPendingChanges();
+                    results = _activeResults;
+                    return true;
+                }
+
                 ClearPendingChanges();
                 return false;
             }
@@ -413,13 +438,15 @@ namespace Avalonia.Controls.DataGridSearching
                 int newStartingIndex,
                 int oldStartingIndex,
                 object[] newItems,
-                object[] oldItems)
+                object[] oldItems,
+                bool canRemapReset)
             {
                 Action = action;
                 NewStartingIndex = newStartingIndex;
                 OldStartingIndex = oldStartingIndex;
                 NewItems = newItems;
                 OldItems = oldItems;
+                CanRemapReset = canRemapReset;
             }
 
             public NotifyCollectionChangedAction Action { get; }
@@ -432,14 +459,19 @@ namespace Avalonia.Controls.DataGridSearching
 
             public object[] OldItems { get; }
 
-            public static PendingCollectionChange From(NotifyCollectionChangedEventArgs e)
+            public bool CanRemapReset { get; }
+
+            public static PendingCollectionChange From(
+                NotifyCollectionChangedEventArgs e,
+                bool canRemapReset)
             {
                 return new PendingCollectionChange(
                     e.Action,
                     e.NewStartingIndex,
                     e.OldStartingIndex,
                     ToArray(e.NewItems),
-                    ToArray(e.OldItems));
+                    ToArray(e.OldItems),
+                    canRemapReset);
             }
 
             private static object[] ToArray(IList items)

--- a/src/DataGridSample.UnitTests/FlatVisualLayoutSamplePageTests.cs
+++ b/src/DataGridSample.UnitTests/FlatVisualLayoutSamplePageTests.cs
@@ -1,7 +1,15 @@
+using System;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Windows.Input;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.DataGridFiltering;
 using Avalonia.Controls.DataGridHierarchical;
+using Avalonia.Controls.DataGridSorting;
 using Avalonia.Headless.XUnit;
+using Avalonia.Headless;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using DataGridSample.Models;
@@ -27,6 +35,13 @@ public sealed class FlatVisualLayoutSamplePageTests
         AssertMatchedHierarchyPage(new VirtualSurfaceHierarchyPage(), DataGridVisualLayoutMode.Virtualized);
         AssertMatchedHierarchyPage(new FlatSurfaceHierarchyPage(), DataGridVisualLayoutMode.Flat);
         AssertMatchedHierarchyPage(new NestedSurfaceHierarchyPage(), DataGridVisualLayoutMode.Nested);
+    }
+
+    [AvaloniaFact]
+    public void Virtual_Surface_Pages_Keep_The_Grid_Below_Status_Content_And_Inside_The_Viewport()
+    {
+        AssertVirtualSurfacePageLayout(new VirtualSurfaceFlatDataPage());
+        AssertVirtualSurfacePageLayout(new VirtualSurfaceHierarchyPage());
     }
 
     [AvaloniaFact]
@@ -134,6 +149,219 @@ public sealed class FlatVisualLayoutSamplePageTests
         }
     }
 
+    [AvaloniaFact]
+    public void Virtual_Flat_Data_Page_All_Columns_Have_Writable_Accessors_And_Remain_Rowless()
+    {
+        var page = new VirtualSurfaceFlatDataPage();
+        Window window = CreateHostWindow(page);
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<OptimizedFlatCellPathsViewModel>(page.DataContext);
+            DataGrid grid = Assert.Single(page.GetVisualDescendants().OfType<DataGrid>());
+            foreach (VirtualSurfaceModeOption mode in viewModel.VirtualModes)
+            {
+                viewModel.SelectedVirtualMode = mode;
+                PumpLayout(window);
+                AssertAllColumnsEditable(grid, viewModel.Items[0]);
+                AssertCellOwnership(
+                    grid,
+                    DataGridVisualLayoutMode.Virtualized,
+                    expectsRowlessSurface: true,
+                    context: mode.Key);
+            }
+
+            viewModel.SelectedVirtualMode = viewModel.VirtualModes.Single(mode => mode.Key == "virtual");
+            PumpLayout(window);
+            IDataGridColumnValueAccessor nameAccessor = Assert.IsAssignableFrom<IDataGridColumnValueAccessor>(
+                DataGridColumnMetadata.GetValueAccessor(grid.Columns[1]));
+            nameAccessor.SetValue(viewModel.Items[0], "Edited flat virtual cell");
+            Assert.Equal("Edited flat virtual cell", viewModel.Items[0].Name);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Virtual_Hierarchy_Page_All_Columns_Have_Writable_Accessors_And_Remain_Rowless()
+    {
+        var page = new VirtualSurfaceHierarchyPage();
+        Window window = CreateHostWindow(page);
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<OptimizedHierarchyCellPathsViewModel>(page.DataContext);
+            DataGrid grid = Assert.Single(page.GetVisualDescendants().OfType<DataGrid>());
+            IHierarchicalModel untypedModel = viewModel.Model;
+            foreach (VirtualSurfaceModeOption mode in viewModel.VirtualModes)
+            {
+                viewModel.SelectedVirtualMode = mode;
+                PumpLayout(window);
+                AssertAllColumnsEditable(grid, untypedModel.Flattened[0]);
+                AssertCellOwnership(
+                    grid,
+                    DataGridVisualLayoutMode.Virtualized,
+                    expectsRowlessSurface: true,
+                    context: mode.Key);
+            }
+
+            viewModel.SelectedVirtualMode = viewModel.VirtualModes.Single(mode => mode.Key == "virtual");
+            PumpLayout(window);
+            HierarchicalNode node = untypedModel.Flattened[0];
+            IDataGridColumnValueAccessor nameAccessor = Assert.IsAssignableFrom<IDataGridColumnValueAccessor>(
+                DataGridColumnMetadata.GetValueAccessor(grid.Columns[0]));
+            nameAccessor.SetValue(node, "Edited hierarchy virtual cell");
+            Assert.Equal(
+                "Edited hierarchy virtual cell",
+                Assert.IsType<OptimizedHierarchyCellSampleNode>(node.Item).Name);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Virtual_Flat_Data_Page_Integrates_Sorting_Filtering_And_Search()
+    {
+        var page = new VirtualSurfaceFlatDataPage();
+        Window window = CreateHostWindow(page);
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<OptimizedFlatCellPathsViewModel>(page.DataContext);
+            DataGrid grid = Assert.Single(page.GetVisualDescendants().OfType<DataGrid>());
+            VirtualSurfaceDataOperationsViewModel operations = viewModel.Operations;
+
+            Assert.Same(operations.SortingModel, grid.SortingModel);
+            Assert.Same(operations.FilteringModel, grid.FilteringModel);
+            Assert.Same(operations.SearchModel, grid.SearchModel);
+            Assert.Same(operations.FastPathOptions, grid.FastPathOptions);
+            Assert.True(grid.CanUserSortColumns);
+
+            operations.SortingModel.SetOrUpdate(new SortingDescriptor(
+                nameof(OptimizedCellSampleRow.Name),
+                ListSortDirection.Descending,
+                nameof(OptimizedCellSampleRow.Name)));
+            PumpLayout(window);
+
+            OptimizedCellSampleRow[] sorted = grid.CollectionView.Cast<OptimizedCellSampleRow>().ToArray();
+            Assert.Equal("Work item 0001000", sorted[0].Name);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "flat-sort");
+
+            operations.OwnerFilterText = "Atlas";
+            Execute(operations.ApplyOwnerFilterCommand);
+            PumpLayout(window);
+
+            OptimizedCellSampleRow[] filtered = grid.CollectionView.Cast<OptimizedCellSampleRow>().ToArray();
+            Assert.NotEmpty(filtered);
+            Assert.True(filtered.Length < viewModel.Items.Count);
+            Assert.All(filtered, item => Assert.Equal("Atlas", item.Owner));
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "flat-filter");
+
+            Execute(operations.ClearOwnerFilterCommand);
+            operations.SearchQuery = "Work item 00000";
+            Execute(operations.ApplySearchCommand);
+            PumpLayout(window);
+
+            Assert.NotEmpty(operations.SearchModel.Results);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "flat-search");
+
+            Execute(operations.NextSearchResultCommand);
+            PumpLayout(window);
+            Assert.Same(operations.SearchModel.CurrentResult!.Item, grid.SelectedItem);
+
+            operations.SearchHighlightingEnabled = true;
+            PumpLayout(window);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, false, "flat-search-highlights");
+
+            operations.SearchHighlightingEnabled = false;
+            PumpLayout(window);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "flat-search-no-highlights");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Virtual_Hierarchy_Page_Integrates_Sibling_Sorting_Ancestor_Filtering_And_Search()
+    {
+        var page = new VirtualSurfaceHierarchyPage();
+        Window window = CreateHostWindow(page);
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            var viewModel = Assert.IsType<OptimizedHierarchyCellPathsViewModel>(page.DataContext);
+            DataGrid grid = Assert.Single(page.GetVisualDescendants().OfType<DataGrid>());
+            VirtualSurfaceDataOperationsViewModel operations = viewModel.Operations;
+
+            Assert.Same(operations.SortingModel, grid.SortingModel);
+            Assert.Same(operations.FilteringModel, grid.FilteringModel);
+            Assert.Same(operations.SearchModel, grid.SearchModel);
+            Assert.Same(operations.FastPathOptions, grid.FastPathOptions);
+            Assert.IsType<DataGridHierarchicalFilteringAdapterFactory>(grid.FilteringAdapterFactory);
+            Assert.True(grid.CanUserSortColumns);
+
+            operations.SortingModel.SetOrUpdate(new SortingDescriptor(
+                nameof(OptimizedHierarchyCellSampleNode.Name),
+                ListSortDirection.Descending,
+                nameof(OptimizedHierarchyCellSampleNode.Name)));
+            PumpLayout(window);
+
+            OptimizedHierarchyCellSampleNode first = viewModel.Model.GetTypedNode(0).Item;
+            OptimizedHierarchyCellSampleNode lastRoot = viewModel.Model.Root!.Value.Children[^1].Item;
+            Assert.True(string.CompareOrdinal(first.Name, lastRoot.Name) > 0);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "hierarchy-sort");
+
+            int unfilteredCount = grid.CollectionView.Cast<object>().Count();
+            operations.OwnerFilterText = "Atlas";
+            Execute(operations.ApplyOwnerFilterCommand);
+            PumpLayout(window);
+
+            int filteredCount = grid.CollectionView.Cast<object>().Count();
+            Assert.InRange(filteredCount, 1, unfilteredCount - 1);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "hierarchy-filter");
+
+            Execute(operations.ClearOwnerFilterCommand);
+            operations.SearchQuery = "Portfolio";
+            Execute(operations.ApplySearchCommand);
+            PumpLayout(window);
+
+            Assert.NotEmpty(operations.SearchModel.Results);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "hierarchy-search");
+
+            Execute(operations.NextSearchResultCommand);
+            PumpLayout(window);
+            Assert.Same(
+                Assert.IsType<HierarchicalNode>(operations.SearchModel.CurrentResult!.Item).Item,
+                grid.SelectedItem);
+
+            operations.SearchHighlightingEnabled = true;
+            PumpLayout(window);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, false, "hierarchy-search-highlights");
+
+            operations.SearchHighlightingEnabled = false;
+            PumpLayout(window);
+            AssertCellOwnership(grid, DataGridVisualLayoutMode.Virtualized, true, "hierarchy-search-no-highlights");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     private static void AssertMatchedFlatDataPage(Control page, DataGridVisualLayoutMode expectedMode)
     {
         Window window = CreateHostWindow(page);
@@ -152,6 +380,56 @@ public sealed class FlatVisualLayoutSamplePageTests
         {
             window.Close();
         }
+    }
+
+    private static void AssertVirtualSurfacePageLayout(Control page)
+    {
+        Window window = CreateHostWindow(page);
+        try
+        {
+            window.Show();
+            PumpLayout(window);
+
+            Border status = page.FindControl<Border>("StatusPanel")!;
+            DataGrid grid = page.GetVisualDescendants().OfType<DataGrid>().Single();
+            Rect statusBounds = GetBoundsRelativeTo(status, page);
+            Rect gridBounds = GetBoundsRelativeTo(grid, page);
+
+            Assert.True(
+                gridBounds.Top >= statusBounds.Bottom,
+                $"Grid starts at {gridBounds.Top:F1}, above status bottom {statusBounds.Bottom:F1}.");
+            Assert.True(gridBounds.Height > 0, "Grid must retain a visible viewport.");
+            Assert.True(
+                gridBounds.Bottom <= page.Bounds.Height + 0.5,
+                $"Grid bottom {gridBounds.Bottom:F1} exceeds page height {page.Bounds.Height:F1}.");
+
+            SaveScreenshotWhenRequested(window, page.GetType().Name);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static Rect GetBoundsRelativeTo(Control control, Visual relativeTo)
+    {
+        Matrix transform = control.TransformToVisual(relativeTo) ?? Matrix.Identity;
+        return new Rect(control.Bounds.Size).TransformToAABB(transform);
+    }
+
+    private static void SaveScreenshotWhenRequested(Window window, string fileName)
+    {
+        string? outputDirectory = Environment.GetEnvironmentVariable("AVALONIA_SCREENSHOT_DIR");
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+        using var frame = window.CaptureRenderedFrame();
+        Assert.NotNull(frame);
+        using FileStream stream = File.Create(Path.Combine(outputDirectory, $"{fileName}.png"));
+        frame.Save(stream, new Avalonia.Media.Imaging.PngBitmapEncoderOptions());
     }
 
     private static void AssertMatchedHierarchyPage(Control page, DataGridVisualLayoutMode expectedMode)
@@ -218,6 +496,30 @@ public sealed class FlatVisualLayoutSamplePageTests
                 grid.GetVisualDescendants().OfType<DataGridRow>(),
                 candidate => candidate.GetVisualDescendants().Any(descendant => ReferenceEquals(descendant, cell)));
         }
+    }
+
+    private static void AssertAllColumnsEditable(DataGrid grid, object item)
+    {
+        Assert.False(grid.IsReadOnly);
+        Assert.NotEmpty(grid.Columns);
+        Assert.All(
+            grid.Columns,
+            column =>
+            {
+                Assert.False(column.IsReadOnly);
+                IDataGridColumnValueAccessor accessor = Assert.IsAssignableFrom<IDataGridColumnValueAccessor>(
+                    DataGridColumnMetadata.GetValueAccessor(column));
+                Assert.True(accessor.CanWrite, $"Column '{column.Header}' does not have a writable typed accessor.");
+                object value = accessor.GetValue(item);
+                accessor.SetValue(item, value);
+            });
+    }
+
+    private static void Execute(ICommand command)
+    {
+        Assert.True(command.CanExecute(null));
+        command.Execute(null);
+        Dispatcher.UIThread.RunJobs();
     }
 
     private static Window CreateHostWindow(Control content)

--- a/src/DataGridSample/Models/OptimizedCellSampleRow.cs
+++ b/src/DataGridSample/Models/OptimizedCellSampleRow.cs
@@ -2,16 +2,57 @@ using System;
 
 namespace DataGridSample.Models;
 
-public sealed record OptimizedCellSampleRow(
-    string Id,
-    string Name,
-    string Category,
-    string Owner,
-    string Region,
-    string State,
-    string Detail,
-    bool IsActive,
-    DateTime Date,
-    TimeSpan Time,
-    string Phone,
-    double SliderValue);
+public sealed class OptimizedCellSampleRow
+{
+    public OptimizedCellSampleRow(
+        string id,
+        string name,
+        string category,
+        string owner,
+        string region,
+        string state,
+        string detail,
+        bool isActive,
+        DateTime date,
+        TimeSpan time,
+        string phone,
+        double sliderValue)
+    {
+        Id = id;
+        Name = name;
+        Category = category;
+        Owner = owner;
+        Region = region;
+        State = state;
+        Detail = detail;
+        IsActive = isActive;
+        Date = date;
+        Time = time;
+        Phone = phone;
+        SliderValue = sliderValue;
+    }
+
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string Category { get; set; }
+
+    public string Owner { get; set; }
+
+    public string Region { get; set; }
+
+    public string State { get; set; }
+
+    public string Detail { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public DateTime Date { get; set; }
+
+    public TimeSpan Time { get; set; }
+
+    public string Phone { get; set; }
+
+    public double SliderValue { get; set; }
+}

--- a/src/DataGridSample/Models/OptimizedHierarchyCellSampleNode.cs
+++ b/src/DataGridSample/Models/OptimizedHierarchyCellSampleNode.cs
@@ -30,33 +30,36 @@ public sealed class OptimizedHierarchyCellSampleNode
         Phone = $"(555) {id % 1_000:D3}-{id % 10_000:D4}";
         Category = $"Category-{id % 997:D3}";
         SliderValue = (id % 1_000) / 10d;
+        IsActive = id % 2 == 0;
     }
 
     public int Id { get; }
 
-    public string Name { get; }
+    public string Name { get; set; }
 
-    public string Kind { get; }
+    public string Kind { get; set; }
 
-    public string Owner { get; }
+    public string Owner { get; set; }
 
-    public string Region { get; }
+    public string Region { get; set; }
 
-    public string State { get; }
+    public string State { get; set; }
 
-    public string Detail { get; }
+    public string Detail { get; set; }
 
     public bool HasChildren => Children.Count != 0;
 
-    public DateTime Date { get; }
+    public bool IsActive { get; set; }
 
-    public TimeSpan Time { get; }
+    public DateTime Date { get; set; }
 
-    public string Phone { get; }
+    public TimeSpan Time { get; set; }
 
-    public string Category { get; }
+    public string Phone { get; set; }
 
-    public double SliderValue { get; }
+    public string Category { get; set; }
+
+    public double SliderValue { get; set; }
 
     public IReadOnlyList<OptimizedHierarchyCellSampleNode> Children { get; }
 

--- a/src/DataGridSample/Pages/VirtualSurfaceFlatDataPage.axaml
+++ b/src/DataGridSample/Pages/VirtualSurfaceFlatDataPage.axaml
@@ -10,54 +10,85 @@
     <viewModels:OptimizedFlatCellPathsViewModelFactory x:Key="ViewModelFactory" />
   </UserControl.Resources>
 
-  <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="8">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,Auto,*" RowSpacing="8">
     <StackPanel Spacing="3">
       <TextBlock Classes="h2" Text="Virtual Cell Surface — Flat Data" />
       <TextBlock TextWrapping="Wrap"
-                 Text="The fastest fixed-height architecture: visible items are projected into lightweight records and all compatible display cells are recorded by one surface. Selection is driven by a view-model-owned SelectionModel, and the text baseline matches the optimized benchmark endpoint." />
+                 Text="The fastest fixed-height architecture with model-driven selection, editing, sorting, filtering, and search. Click a header to sort, click a cell or press F2 to edit, and use the explicit apply buttons for large workloads." />
     </StackPanel>
 
-    <WrapPanel Grid.Row="1" Orientation="Horizontal">
-      <TextBlock Margin="0,0,6,8" VerticalAlignment="Center" Text="Surface mode" />
-      <ComboBox Width="270" Margin="0,0,14,8"
-                ItemsSource="{CompiledBinding VirtualModes}"
-                SelectedItem="{CompiledBinding SelectedVirtualMode, Mode=TwoWay}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate x:DataType="models:VirtualSurfaceModeOption">
-            <TextBlock Text="{CompiledBinding Name}" />
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
-      <TextBlock Margin="0,0,6,8" VerticalAlignment="Center" Text="Rows" />
-      <NumericUpDown Width="125" Margin="0,0,8,8" Minimum="1000" Maximum="1000000"
-                     Increment="25000" Value="{CompiledBinding TargetRowCount, Mode=TwoWay}" />
-      <Button Margin="0,0,14,8" Content="Load workload"
-              Command="{CompiledBinding LoadRepresentativeWorkloadCommand}" />
-      <Button Margin="0,0,6,8" Content="First" Command="{CompiledBinding JumpToFirstCommand}" />
-      <Button Margin="0,0,6,8" Content="Middle" Command="{CompiledBinding JumpToMiddleCommand}" />
-      <Button Margin="0,0,14,8" Content="Last" Command="{CompiledBinding JumpToLastCommand}" />
-      <Button Margin="0,0,8,8" Content="Refresh heap"
-              Command="{CompiledBinding RefreshManagedMemoryCommand}" />
-    </WrapPanel>
+    <StackPanel Grid.Row="1" Spacing="6">
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Surface mode" />
+        <ComboBox Width="270" Margin="0,0,14,0"
+                  ItemsSource="{CompiledBinding VirtualModes}"
+                  SelectedItem="{CompiledBinding SelectedVirtualMode, Mode=TwoWay}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate x:DataType="models:VirtualSurfaceModeOption">
+              <TextBlock Text="{CompiledBinding Name}" />
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Rows" />
+        <NumericUpDown Width="125" Margin="0,0,8,0" Minimum="1000" Maximum="1000000"
+                       Increment="25000" Value="{CompiledBinding TargetRowCount, Mode=TwoWay}" />
+        <Button Margin="0,0,8,0" Content="Load workload"
+                Command="{CompiledBinding LoadRepresentativeWorkloadCommand}" />
+      </WrapPanel>
+      <WrapPanel Orientation="Horizontal">
+        <Button Margin="0,0,6,0" Content="First" Command="{CompiledBinding JumpToFirstCommand}" />
+        <Button Margin="0,0,6,0" Content="Middle" Command="{CompiledBinding JumpToMiddleCommand}" />
+        <Button Margin="0,0,14,0" Content="Last" Command="{CompiledBinding JumpToLastCommand}" />
+        <Button Margin="0,0,8,0" Content="Refresh heap"
+                Command="{CompiledBinding RefreshManagedMemoryCommand}" />
+      </WrapPanel>
+    </StackPanel>
 
-    <Border Grid.Row="2" Padding="10,8" Background="#08000000" CornerRadius="5">
-      <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" ColumnSpacing="14">
+    <StackPanel Grid.Row="2" Spacing="6">
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Search" />
+        <TextBox Width="190" Margin="0,0,6,0"
+                 PlaceholderText="Visible columns"
+                 Text="{CompiledBinding Operations.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <Button Margin="0,0,6,0" Content="Apply" Command="{CompiledBinding Operations.ApplySearchCommand}" />
+        <Button Margin="0,0,6,0" Content="Clear" Command="{CompiledBinding Operations.ClearSearchCommand}" />
+        <Button Margin="0,0,6,0" Content="Previous" Command="{CompiledBinding Operations.PreviousSearchResultCommand}" />
+        <Button Margin="0,0,14,0" Content="Next" Command="{CompiledBinding Operations.NextSearchResultCommand}" />
+        <CheckBox Margin="0,0,8,0" VerticalAlignment="Center"
+                  Content="Highlight matches (retained fallback)"
+                  IsChecked="{CompiledBinding Operations.SearchHighlightingEnabled, Mode=TwoWay}" />
+      </WrapPanel>
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Owner contains" />
+        <TextBox Width="120" Margin="0,0,6,0"
+                 PlaceholderText="Atlas"
+                 Text="{CompiledBinding Operations.OwnerFilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <Button Margin="0,0,6,0" Content="Filter" Command="{CompiledBinding Operations.ApplyOwnerFilterCommand}" />
+        <Button Margin="0,0,14,0" Content="Clear filter" Command="{CompiledBinding Operations.ClearOwnerFilterCommand}" />
+        <Button Margin="0,0,8,0" Content="Clear sorting" Command="{CompiledBinding Operations.ClearSortingCommand}" />
+      </WrapPanel>
+    </StackPanel>
+
+    <Border Name="StatusPanel" Grid.Row="3" Padding="10,8" Background="#08000000" CornerRadius="5">
+      <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="14">
         <TextBlock FontWeight="SemiBold" Text="Visual layout: rowless virtual cell surface" />
         <TextBlock Grid.Column="1" Text="{CompiledBinding SelectedVirtualMode.ExpectedBackend}" />
         <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Margin="0,4,0,0" TextWrapping="Wrap"
                    Text="{CompiledBinding SelectedVirtualMode.Description}" />
+        <TextBlock Grid.Row="2" Grid.ColumnSpan="2" Margin="0,4,0,0" TextWrapping="Wrap"
+                   Text="{CompiledBinding Operations.RenderingSummary}" />
       </Grid>
     </Border>
 
-    <Grid Grid.Row="3" RowDefinitions="Auto,*" RowSpacing="8">
-      <StackPanel Orientation="Horizontal" Spacing="14">
+    <Grid Grid.Row="4" RowDefinitions="Auto,*" RowSpacing="8">
+      <WrapPanel Name="SummaryPanel" Orientation="Horizontal">
         <TextBlock Text="{CompiledBinding Summary}" />
-        <TextBlock Text="{CompiledBinding ManagedMemorySummary}" />
-      </StackPanel>
+        <TextBlock Margin="14,0,0,0" Text="{CompiledBinding ManagedMemorySummary}" />
+        <TextBlock Margin="14,0,0,0" Text="{CompiledBinding Operations.OperationSummary}" />
+      </WrapPanel>
 
       <DataGrid Name="VirtualSurfaceGrid"
                 Grid.Row="1"
-                Height="520"
                 AutomationProperties.Name="Virtual cell surface flat-data workload grid"
                 Theme="{StaticResource DataGridFlatTheme}"
                 VisualLayoutMode="Virtualized"
@@ -65,17 +96,21 @@
                 AutoScrollToSelectedItem="True"
                 CanUserReorderColumns="False"
                 CanUserResizeColumns="False"
-                CanUserSortColumns="False"
+                CanUserSortColumns="True"
                 ColumnDefinitionsSource="{CompiledBinding ActiveVirtualColumns}"
+                FastPathOptions="{CompiledBinding Operations.FastPathOptions}"
+                FilteringModel="{CompiledBinding Operations.FilteringModel}"
                 GridLinesVisibility="Horizontal"
                 HeadersVisibility="Column"
-                IsReadOnly="True"
+                IsReadOnly="False"
                 ItemsSource="{CompiledBinding Items}"
                 RowHeight="32"
+                SearchModel="{CompiledBinding Operations.SearchModel}"
                 Selection="{CompiledBinding SelectionModel}"
                 SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}"
                 SelectionMode="Single"
                 SelectionUnit="FullRow"
+                SortingModel="{CompiledBinding Operations.SortingModel}"
                 UseLogicalScrollable="True" />
     </Grid>
   </Grid>

--- a/src/DataGridSample/Pages/VirtualSurfaceHierarchyPage.axaml
+++ b/src/DataGridSample/Pages/VirtualSurfaceHierarchyPage.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behaviors="clr-namespace:DataGridSample.Behaviors"
+             xmlns:filtering="clr-namespace:Avalonia.Controls.DataGridFiltering;assembly=Avalonia.Controls.DataGrid"
              xmlns:models="clr-namespace:DataGridSample.Models"
              xmlns:viewModels="clr-namespace:DataGridSample.ViewModels"
              x:Class="DataGridSample.Pages.VirtualSurfaceHierarchyPage"
@@ -8,63 +9,95 @@
              behaviors:DataContextFactoryBehavior.Factory="{StaticResource ViewModelFactory}">
   <UserControl.Resources>
     <viewModels:OptimizedHierarchyCellPathsViewModelFactory x:Key="ViewModelFactory" />
+    <filtering:DataGridHierarchicalFilteringAdapterFactory x:Key="HierarchyFilteringAdapterFactory" />
   </UserControl.Resources>
 
-  <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="8">
+  <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,Auto,*" RowSpacing="8">
     <StackPanel Spacing="3">
       <TextBlock Classes="h2" Text="Virtual Cell Surface — Hierarchical Model" />
       <TextBlock TextWrapping="Wrap"
-                 Text="The hierarchy model still owns expansion and flattened nodes, while fixed-height visible rows and compatible cells are drawn by one rowless surface. Selection is driven by a view-model-owned hierarchical SelectionModel. Default dimensions generate 149,792 nodes." />
+                 Text="The hierarchy model owns expansion, sibling sorting, and flattened nodes while the virtual surface provides model-driven selection, editing, ancestor-preserving filtering, and search. Click a header to sort or a cell to edit." />
     </StackPanel>
 
-    <WrapPanel Grid.Row="1" Orientation="Horizontal">
-      <TextBlock Margin="0,0,6,8" VerticalAlignment="Center" Text="Surface mode" />
-      <ComboBox Width="280" Margin="0,0,14,8"
-                ItemsSource="{CompiledBinding VirtualModes}"
-                SelectedItem="{CompiledBinding SelectedVirtualMode, Mode=TwoWay}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate x:DataType="models:VirtualSurfaceModeOption">
-            <TextBlock Text="{CompiledBinding Name}" />
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
-      <TextBlock Margin="0,0,4,8" VerticalAlignment="Center" Text="Roots" />
-      <NumericUpDown Width="75" Margin="0,0,8,8" Minimum="1" Maximum="128"
-                     Value="{CompiledBinding RootCount, Mode=TwoWay}" />
-      <TextBlock Margin="0,0,4,8" VerticalAlignment="Center" Text="Branching" />
-      <NumericUpDown Width="70" Margin="0,0,8,8" Minimum="2" Maximum="12"
-                     Value="{CompiledBinding BranchingFactor, Mode=TwoWay}" />
-      <TextBlock Margin="0,0,4,8" VerticalAlignment="Center" Text="Depth" />
-      <NumericUpDown Width="65" Margin="0,0,8,8" Minimum="1" Maximum="5"
-                     Value="{CompiledBinding Depth, Mode=TwoWay}" />
-      <Button Margin="0,0,12,8" Content="Load workload"
-              Command="{CompiledBinding LoadRepresentativeWorkloadCommand}" />
-      <Button Margin="0,0,6,8" Content="Expand all" Command="{CompiledBinding ExpandAllCommand}" />
-      <Button Margin="0,0,12,8" Content="Collapse all" Command="{CompiledBinding CollapseAllCommand}" />
-      <Button Margin="0,0,6,8" Content="First" Command="{CompiledBinding JumpToFirstCommand}" />
-      <Button Margin="0,0,6,8" Content="Middle" Command="{CompiledBinding JumpToMiddleCommand}" />
-      <Button Margin="0,0,8,8" Content="Last" Command="{CompiledBinding JumpToLastCommand}" />
-    </WrapPanel>
+    <StackPanel Grid.Row="1" Spacing="6">
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Surface mode" />
+        <ComboBox Width="280" Margin="0,0,14,0"
+                  ItemsSource="{CompiledBinding VirtualModes}"
+                  SelectedItem="{CompiledBinding SelectedVirtualMode, Mode=TwoWay}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate x:DataType="models:VirtualSurfaceModeOption">
+              <TextBlock Text="{CompiledBinding Name}" />
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+        <TextBlock Margin="0,0,4,0" VerticalAlignment="Center" Text="Roots" />
+        <NumericUpDown Width="75" Margin="0,0,8,0" Minimum="1" Maximum="128"
+                       Value="{CompiledBinding RootCount, Mode=TwoWay}" />
+        <TextBlock Margin="0,0,4,0" VerticalAlignment="Center" Text="Branching" />
+        <NumericUpDown Width="70" Margin="0,0,8,0" Minimum="2" Maximum="12"
+                       Value="{CompiledBinding BranchingFactor, Mode=TwoWay}" />
+        <TextBlock Margin="0,0,4,0" VerticalAlignment="Center" Text="Depth" />
+        <NumericUpDown Width="65" Margin="0,0,8,0" Minimum="1" Maximum="5"
+                       Value="{CompiledBinding Depth, Mode=TwoWay}" />
+        <Button Margin="0,0,8,0" Content="Load workload"
+                Command="{CompiledBinding LoadRepresentativeWorkloadCommand}" />
+      </WrapPanel>
+      <WrapPanel Orientation="Horizontal">
+        <Button Margin="0,0,6,0" Content="Expand all" Command="{CompiledBinding ExpandAllCommand}" />
+        <Button Margin="0,0,14,0" Content="Collapse all" Command="{CompiledBinding CollapseAllCommand}" />
+        <Button Margin="0,0,6,0" Content="First" Command="{CompiledBinding JumpToFirstCommand}" />
+        <Button Margin="0,0,6,0" Content="Middle" Command="{CompiledBinding JumpToMiddleCommand}" />
+        <Button Margin="0,0,8,0" Content="Last" Command="{CompiledBinding JumpToLastCommand}" />
+      </WrapPanel>
+    </StackPanel>
 
-    <Border Grid.Row="2" Padding="10,8" Background="#08000000" CornerRadius="5">
-      <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" ColumnSpacing="14">
+    <StackPanel Grid.Row="2" Spacing="6">
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Search" />
+        <TextBox Width="190" Margin="0,0,6,0"
+                 PlaceholderText="Visible columns"
+                 Text="{CompiledBinding Operations.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <Button Margin="0,0,6,0" Content="Apply" Command="{CompiledBinding Operations.ApplySearchCommand}" />
+        <Button Margin="0,0,6,0" Content="Clear" Command="{CompiledBinding Operations.ClearSearchCommand}" />
+        <Button Margin="0,0,6,0" Content="Previous" Command="{CompiledBinding Operations.PreviousSearchResultCommand}" />
+        <Button Margin="0,0,14,0" Content="Next" Command="{CompiledBinding Operations.NextSearchResultCommand}" />
+        <CheckBox Margin="0,0,8,0" VerticalAlignment="Center"
+                  Content="Highlight matches (retained fallback)"
+                  IsChecked="{CompiledBinding Operations.SearchHighlightingEnabled, Mode=TwoWay}" />
+      </WrapPanel>
+      <WrapPanel Orientation="Horizontal">
+        <TextBlock Margin="0,0,6,0" VerticalAlignment="Center" Text="Owner contains" />
+        <TextBox Width="120" Margin="0,0,6,0"
+                 PlaceholderText="Atlas"
+                 Text="{CompiledBinding Operations.OwnerFilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <Button Margin="0,0,6,0" Content="Filter" Command="{CompiledBinding Operations.ApplyOwnerFilterCommand}" />
+        <Button Margin="0,0,14,0" Content="Clear filter" Command="{CompiledBinding Operations.ClearOwnerFilterCommand}" />
+        <Button Margin="0,0,8,0" Content="Clear sorting" Command="{CompiledBinding Operations.ClearSortingCommand}" />
+      </WrapPanel>
+    </StackPanel>
+
+    <Border Name="StatusPanel" Grid.Row="3" Padding="10,8" Background="#08000000" CornerRadius="5">
+      <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="14">
         <TextBlock FontWeight="SemiBold" Text="Visual layout: rowless virtual cell surface" />
         <TextBlock Grid.Column="1" Text="{CompiledBinding SelectedVirtualMode.ExpectedBackend}" />
         <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Margin="0,4,0,0" TextWrapping="Wrap"
                    Text="{CompiledBinding SelectedVirtualMode.Description}" />
+        <TextBlock Grid.Row="2" Grid.ColumnSpan="2" Margin="0,4,0,0" TextWrapping="Wrap"
+                   Text="{CompiledBinding Operations.RenderingSummary}" />
       </Grid>
     </Border>
 
-    <Grid Grid.Row="3" RowDefinitions="Auto,*" RowSpacing="8">
-      <StackPanel Orientation="Horizontal" Spacing="14">
+    <Grid Grid.Row="4" RowDefinitions="Auto,*" RowSpacing="8">
+      <WrapPanel Name="SummaryPanel" Orientation="Horizontal">
         <TextBlock Text="{CompiledBinding TargetNodeSummary}" />
-        <TextBlock Text="{CompiledBinding VisibleNodeSummary}" />
-        <TextBlock Text="{CompiledBinding Summary}" />
-      </StackPanel>
+        <TextBlock Margin="14,0,0,0" Text="{CompiledBinding VisibleNodeSummary}" />
+        <TextBlock Margin="14,0,0,0" Text="{CompiledBinding Summary}" />
+        <TextBlock Margin="14,0,0,0" Text="{CompiledBinding Operations.OperationSummary}" />
+      </WrapPanel>
 
       <DataGrid Name="VirtualSurfaceGrid"
                 Grid.Row="1"
-                Height="520"
                 AutomationProperties.Name="Virtual cell surface hierarchical workload grid"
                 Theme="{StaticResource DataGridFlatTheme}"
                 VisualLayoutMode="Virtualized"
@@ -72,19 +105,24 @@
                 AutoScrollToSelectedItem="True"
                 CanUserReorderColumns="False"
                 CanUserResizeColumns="False"
-                CanUserSortColumns="False"
+                CanUserSortColumns="True"
                 Classes.hierarchical="True"
                 ColumnDefinitionsSource="{CompiledBinding ActiveVirtualColumns}"
+                FastPathOptions="{CompiledBinding Operations.FastPathOptions}"
+                FilteringAdapterFactory="{StaticResource HierarchyFilteringAdapterFactory}"
+                FilteringModel="{CompiledBinding Operations.FilteringModel}"
                 GridLinesVisibility="Horizontal"
                 HeadersVisibility="Column"
                 HierarchicalModel="{CompiledBinding Model}"
                 HierarchicalRowsEnabled="True"
-                IsReadOnly="True"
+                IsReadOnly="False"
                 RowHeight="32"
+                SearchModel="{CompiledBinding Operations.SearchModel}"
                 Selection="{CompiledBinding SelectionModel}"
                 SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}"
                 SelectionMode="Single"
                 SelectionUnit="FullRow"
+                SortingModel="{CompiledBinding Operations.SortingModel}"
                 UseLogicalScrollable="True" />
     </Grid>
   </Grid>

--- a/src/DataGridSample/ViewModels/OptimizedFlatCellPathsViewModel.cs
+++ b/src/DataGridSample/ViewModels/OptimizedFlatCellPathsViewModel.cs
@@ -65,6 +65,9 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
         _activeVirtualColumns = new DataGridColumnDefinitionList(_virtualColumnsByMode[_selectedVirtualMode.Key]);
         _items = CreateRows(PreviewRowCount);
         SelectionModel = new SelectionModel<OptimizedCellSampleRow> { SingleSelect = true };
+        Operations = new VirtualSurfaceDataOperationsViewModel(
+            nameof(OptimizedCellSampleRow.Owner),
+            nameof(OptimizedCellSampleRow.Owner));
         _summary = $"Preview: {_items.Count:n0} rows. Load the representative workload for manual profiling.";
         _managedMemorySummary = CreateManagedMemorySummary();
 
@@ -90,6 +93,8 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
     public IList<DataGridColumnDefinition> ActiveVirtualColumns => _activeVirtualColumns;
 
     public SelectionModel<OptimizedCellSampleRow> SelectionModel { get; }
+
+    public VirtualSurfaceDataOperationsViewModel Operations { get; }
 
     public OptimizedCellPathOption SelectedPath
     {
@@ -270,26 +275,35 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
     private static IList<DataGridColumnDefinition> CreateVirtualTextColumns() =>
         new DataGridColumnDefinition[]
         {
-            CreateVirtualTextColumn("ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, 90),
-            CreateVirtualTextColumn("Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, 240),
-            CreateVirtualTextColumn("Owner", nameof(OptimizedCellSampleRow.Owner), static row => row.Owner, 130),
-            CreateVirtualTextColumn("Detail", nameof(OptimizedCellSampleRow.Detail), static row => row.Detail, 300),
+            CreateVirtualTextColumn(
+                "ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, static (row, value) => row.Id = value, 90),
+            CreateVirtualTextColumn(
+                "Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, static (row, value) => row.Name = value, 240),
+            CreateVirtualTextColumn(
+                "Owner", nameof(OptimizedCellSampleRow.Owner), static row => row.Owner, static (row, value) => row.Owner = value, 130),
+            CreateVirtualTextColumn(
+                "Detail", nameof(OptimizedCellSampleRow.Detail), static row => row.Detail, static (row, value) => row.Detail = value, 300),
         };
 
     private static IList<DataGridColumnDefinition> CreateVirtualVariantColumns(DataGridColumnDefinition variant) =>
         new DataGridColumnDefinition[]
         {
-            CreateVirtualTextColumn("ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, 90),
-            CreateVirtualTextColumn("Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, 240),
-            CreateVirtualTextColumn("Owner", nameof(OptimizedCellSampleRow.Owner), static row => row.Owner, 130),
+            CreateVirtualTextColumn(
+                "ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, static (row, value) => row.Id = value, 90),
+            CreateVirtualTextColumn(
+                "Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, static (row, value) => row.Name = value, 240),
+            CreateVirtualTextColumn(
+                "Owner", nameof(OptimizedCellSampleRow.Owner), static row => row.Owner, static (row, value) => row.Owner = value, 130),
             variant,
         };
 
     private static IList<DataGridColumnDefinition> CreateAllVirtualColumns() =>
         new DataGridColumnDefinition[]
         {
-            CreateVirtualTextColumn("ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, 90),
-            CreateVirtualTextColumn("Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, 220),
+            CreateVirtualTextColumn(
+                "ID", nameof(OptimizedCellSampleRow.Id), static row => row.Id, static (row, value) => row.Id = value, 90),
+            CreateVirtualTextColumn(
+                "Name", nameof(OptimizedCellSampleRow.Name), static row => row.Name, static (row, value) => row.Name = value, 220),
             CreateVirtualCheckBoxColumn(),
             CreateVirtualDateColumn(),
             CreateVirtualTimeColumn(),
@@ -303,13 +317,16 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
         string header,
         string propertyName,
         Func<OptimizedCellSampleRow, string> getter,
+        Action<OptimizedCellSampleRow, string> setter,
         double width) =>
         new()
         {
             Header = header,
-            Binding = ColumnDefinitionBindingFactory.CreateBinding(propertyName, getter),
+            Binding = ColumnDefinitionBindingFactory.CreateBinding(propertyName, getter, setter),
+            ColumnKey = propertyName,
+            SortMemberPath = propertyName,
             Width = new DataGridLength(width),
-            IsReadOnly = true,
+            IsReadOnly = false,
             TrackDirectTextValueChanges = false,
         };
 
@@ -319,9 +336,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Active",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, bool>(
                 nameof(OptimizedCellSampleRow.IsActive),
-                static row => row.IsActive),
+                static row => row.IsActive,
+                static (row, value) => row.IsActive = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.IsActive),
+            SortMemberPath = nameof(OptimizedCellSampleRow.IsActive),
             Width = new DataGridLength(110),
-            IsReadOnly = true,
+            IsReadOnly = false,
         };
 
     private static DataGridDatePickerColumnDefinition CreateVirtualDateColumn() =>
@@ -330,9 +350,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Date",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, DateTime>(
                 nameof(OptimizedCellSampleRow.Date),
-                static row => row.Date),
+                static row => row.Date,
+                static (row, value) => row.Date = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.Date),
+            SortMemberPath = nameof(OptimizedCellSampleRow.Date),
             Width = new DataGridLength(150),
-            IsReadOnly = true,
+            IsReadOnly = false,
             SelectedDateFormat = CalendarDatePickerFormat.Custom,
             CustomDateFormatString = "yyyy-MM-dd",
         };
@@ -343,9 +366,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Time",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, TimeSpan>(
                 nameof(OptimizedCellSampleRow.Time),
-                static row => row.Time),
+                static row => row.Time,
+                static (row, value) => row.Time = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.Time),
+            SortMemberPath = nameof(OptimizedCellSampleRow.Time),
             Width = new DataGridLength(135),
-            IsReadOnly = true,
+            IsReadOnly = false,
             ClockIdentifier = "24HourClock",
             UseSeconds = true,
         };
@@ -356,9 +382,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Phone",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, string>(
                 nameof(OptimizedCellSampleRow.Phone),
-                static row => row.Phone),
+                static row => row.Phone,
+                static (row, value) => row.Phone = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.Phone),
+            SortMemberPath = nameof(OptimizedCellSampleRow.Phone),
             Width = new DataGridLength(170),
-            IsReadOnly = true,
+            IsReadOnly = false,
             Mask = "(000) 000-0000",
         };
 
@@ -368,9 +397,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Autocomplete",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, string>(
                 nameof(OptimizedCellSampleRow.Category),
-                static row => row.Category),
+                static row => row.Category,
+                static (row, value) => row.Category = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.Category),
+            SortMemberPath = nameof(OptimizedCellSampleRow.Category),
             Width = new DataGridLength(170),
-            IsReadOnly = true,
+            IsReadOnly = false,
             ItemsSource = s_categories,
         };
 
@@ -380,9 +412,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "Slider text",
             Binding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, double>(
                 nameof(OptimizedCellSampleRow.SliderValue),
-                static row => row.SliderValue),
+                static row => row.SliderValue,
+                static (row, value) => row.SliderValue = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.SliderValue),
+            SortMemberPath = nameof(OptimizedCellSampleRow.SliderValue),
             Width = new DataGridLength(145),
-            IsReadOnly = true,
+            IsReadOnly = false,
             Minimum = 0,
             Maximum = 100,
             ShowValueText = true,
@@ -395,9 +430,12 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
             Header = "ComboBox text",
             TextBinding = ColumnDefinitionBindingFactory.CreateBinding<OptimizedCellSampleRow, string>(
                 nameof(OptimizedCellSampleRow.Category),
-                static row => row.Category),
+                static row => row.Category,
+                static (row, value) => row.Category = value),
+            ColumnKey = nameof(OptimizedCellSampleRow.Category),
+            SortMemberPath = nameof(OptimizedCellSampleRow.Category),
             Width = new DataGridLength(180),
-            IsReadOnly = true,
+            IsReadOnly = false,
             IsEditable = true,
             ItemsSource = s_categories,
         };
@@ -477,11 +515,11 @@ public sealed class OptimizedFlatCellPathsViewModel : ReactiveObject
                 region,
                 state,
                 $"{category} workload shard {id % 4_096:D4} owned by {owner}",
-                IsActive: id % 2 == 0,
-                Date: new DateTime(2020, 1, 1).AddDays(id % 3_650),
-                Time: TimeSpan.FromSeconds(id % 86_400),
-                Phone: $"(555) {id % 1_000:D3}-{id % 10_000:D4}",
-                SliderValue: (id % 1_000) / 10d);
+                isActive: id % 2 == 0,
+                date: new DateTime(2020, 1, 1).AddDays(id % 3_650),
+                time: TimeSpan.FromSeconds(id % 86_400),
+                phone: $"(555) {id % 1_000:D3}-{id % 10_000:D4}",
+                sliderValue: (id % 1_000) / 10d);
         }
 
         return rows;

--- a/src/DataGridSample/ViewModels/OptimizedHierarchyCellPathsViewModel.cs
+++ b/src/DataGridSample/ViewModels/OptimizedHierarchyCellPathsViewModel.cs
@@ -73,6 +73,9 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             CreateTree(rootCount: 4, branchingFactor: 4, depth: 3);
         _model = CreateModel(previewRoots);
         SelectionModel = new SelectionModel<HierarchicalNode> { SingleSelect = true };
+        Operations = new VirtualSurfaceDataOperationsViewModel(
+            nameof(OptimizedHierarchyCellSampleNode.Owner),
+            nameof(OptimizedHierarchyCellSampleNode.Owner));
         _totalNodeCount = previewCount;
         _summary = $"Preview: {_totalNodeCount:n0} total nodes, {_model.Flattened.Count:n0} visible. Load the representative workload for profiling.";
         _managedMemorySummary = CreateManagedMemorySummary();
@@ -105,6 +108,8 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
     public IList<DataGridColumnDefinition> ActiveVirtualColumns => _activeVirtualColumns;
 
     public SelectionModel<HierarchicalNode> SelectionModel { get; }
+
+    public VirtualSurfaceDataOperationsViewModel Operations { get; }
 
     public OptimizedCellPathOption SelectedPath
     {
@@ -352,27 +357,34 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
     private static IList<DataGridColumnDefinition> CreateVirtualTextColumns() =>
         new DataGridColumnDefinition[]
         {
-            CreateHierarchyColumn(HierarchyColumnPath.Standard),
-            CreateVirtualTextColumn("Kind", nameof(OptimizedHierarchyCellSampleNode.Kind), static item => item.Kind, 130),
-            CreateVirtualTextColumn("Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, 130),
-            CreateVirtualTextColumn("Region", nameof(OptimizedHierarchyCellSampleNode.Region), static item => item.Region, 140),
-            CreateVirtualTextColumn("Detail", nameof(OptimizedHierarchyCellSampleNode.Detail), static item => item.Detail, 280),
+            CreateVirtualHierarchyColumn(),
+            CreateVirtualTextColumn(
+                "Kind", nameof(OptimizedHierarchyCellSampleNode.Kind), static item => item.Kind, static (item, value) => item.Kind = value, 130),
+            CreateVirtualTextColumn(
+                "Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, static (item, value) => item.Owner = value, 130),
+            CreateVirtualTextColumn(
+                "Region", nameof(OptimizedHierarchyCellSampleNode.Region), static item => item.Region, static (item, value) => item.Region = value, 140),
+            CreateVirtualTextColumn(
+                "Detail", nameof(OptimizedHierarchyCellSampleNode.Detail), static item => item.Detail, static (item, value) => item.Detail = value, 280),
         };
 
     private static IList<DataGridColumnDefinition> CreateVirtualVariantColumns(DataGridColumnDefinition variant) =>
         new DataGridColumnDefinition[]
         {
-            CreateHierarchyColumn(HierarchyColumnPath.Standard),
-            CreateVirtualTextColumn("Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, 130),
-            CreateVirtualTextColumn("Region", nameof(OptimizedHierarchyCellSampleNode.Region), static item => item.Region, 140),
+            CreateVirtualHierarchyColumn(),
+            CreateVirtualTextColumn(
+                "Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, static (item, value) => item.Owner = value, 130),
+            CreateVirtualTextColumn(
+                "Region", nameof(OptimizedHierarchyCellSampleNode.Region), static item => item.Region, static (item, value) => item.Region = value, 140),
             variant,
         };
 
     private static IList<DataGridColumnDefinition> CreateAllVirtualColumns() =>
         new DataGridColumnDefinition[]
         {
-            CreateHierarchyColumn(HierarchyColumnPath.Standard),
-            CreateVirtualTextColumn("Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, 130),
+            CreateVirtualHierarchyColumn(),
+            CreateVirtualTextColumn(
+                "Owner", nameof(OptimizedHierarchyCellSampleNode.Owner), static item => item.Owner, static (item, value) => item.Owner = value, 130),
             CreateVirtualCheckBoxColumn(),
             CreateVirtualDateColumn(),
             CreateVirtualTimeColumn(),
@@ -386,25 +398,53 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
         string header,
         string propertyName,
         Func<OptimizedHierarchyCellSampleNode, string> getter,
+        Action<OptimizedHierarchyCellSampleNode, string> setter,
         double width) =>
         new()
         {
             Header = header,
-            Binding = CreateNodeBinding(propertyName, getter),
+            Binding = CreateNodeBinding(propertyName, getter, setter),
+            ColumnKey = propertyName,
+            SortMemberPath = propertyName,
+            Options = CreateDataOperationOptions(getter, setter),
             Width = new DataGridLength(width),
-            IsReadOnly = true,
+            IsReadOnly = false,
+            TrackDirectTextValueChanges = false,
+        };
+
+    private static DataGridHierarchicalColumnDefinition CreateVirtualHierarchyColumn() =>
+        new()
+        {
+            Header = "Name",
+            Binding = CreateNodeBinding(
+                nameof(OptimizedHierarchyCellSampleNode.Name),
+                static item => item.Name,
+                static (item, value) => item.Name = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Name),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Name),
+            Options = CreateDataOperationOptions(
+                static item => item.Name,
+                static (item, value) => item.Name = value),
+            Width = new DataGridLength(1.8, DataGridLengthUnitType.Star),
+            IsReadOnly = false,
             TrackDirectTextValueChanges = false,
         };
 
     private static DataGridCheckBoxColumnDefinition CreateVirtualCheckBoxColumn() =>
         new()
         {
-            Header = "Has children",
+            Header = "Active",
             Binding = CreateNodeBinding(
-                nameof(OptimizedHierarchyCellSampleNode.HasChildren),
-                static item => item.HasChildren),
+                nameof(OptimizedHierarchyCellSampleNode.IsActive),
+                static item => item.IsActive,
+                static (item, value) => item.IsActive = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.IsActive),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.IsActive),
+            Options = CreateDataOperationOptions(
+                static item => item.IsActive,
+                static (item, value) => item.IsActive = value),
             Width = new DataGridLength(125),
-            IsReadOnly = true,
+            IsReadOnly = false,
         };
 
     private static DataGridDatePickerColumnDefinition CreateVirtualDateColumn() =>
@@ -413,9 +453,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "Date",
             Binding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.Date),
-                static item => item.Date),
+                static item => item.Date,
+                static (item, value) => item.Date = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Date),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Date),
+            Options = CreateDataOperationOptions(
+                static item => item.Date,
+                static (item, value) => item.Date = value),
             Width = new DataGridLength(150),
-            IsReadOnly = true,
+            IsReadOnly = false,
             SelectedDateFormat = CalendarDatePickerFormat.Custom,
             CustomDateFormatString = "yyyy-MM-dd",
         };
@@ -426,9 +472,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "Time",
             Binding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.Time),
-                static item => item.Time),
+                static item => item.Time,
+                static (item, value) => item.Time = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Time),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Time),
+            Options = CreateDataOperationOptions(
+                static item => item.Time,
+                static (item, value) => item.Time = value),
             Width = new DataGridLength(135),
-            IsReadOnly = true,
+            IsReadOnly = false,
             ClockIdentifier = "24HourClock",
             UseSeconds = true,
         };
@@ -439,9 +491,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "Phone",
             Binding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.Phone),
-                static item => item.Phone),
+                static item => item.Phone,
+                static (item, value) => item.Phone = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Phone),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Phone),
+            Options = CreateDataOperationOptions(
+                static item => item.Phone,
+                static (item, value) => item.Phone = value),
             Width = new DataGridLength(170),
-            IsReadOnly = true,
+            IsReadOnly = false,
             Mask = "(000) 000-0000",
         };
 
@@ -451,9 +509,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "Autocomplete",
             Binding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.Category),
-                static item => item.Category),
+                static item => item.Category,
+                static (item, value) => item.Category = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Category),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Category),
+            Options = CreateDataOperationOptions(
+                static item => item.Category,
+                static (item, value) => item.Category = value),
             Width = new DataGridLength(175),
-            IsReadOnly = true,
+            IsReadOnly = false,
             ItemsSource = s_categories,
         };
 
@@ -463,9 +527,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "Slider text",
             Binding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.SliderValue),
-                static item => item.SliderValue),
+                static item => item.SliderValue,
+                static (item, value) => item.SliderValue = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.SliderValue),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.SliderValue),
+            Options = CreateDataOperationOptions(
+                static item => item.SliderValue,
+                static (item, value) => item.SliderValue = value),
             Width = new DataGridLength(145),
-            IsReadOnly = true,
+            IsReadOnly = false,
             Minimum = 0,
             Maximum = 100,
             ShowValueText = true,
@@ -478,9 +548,15 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
             Header = "ComboBox text",
             TextBinding = CreateNodeBinding(
                 nameof(OptimizedHierarchyCellSampleNode.Category),
-                static item => item.Category),
+                static item => item.Category,
+                static (item, value) => item.Category = value),
+            ColumnKey = nameof(OptimizedHierarchyCellSampleNode.Category),
+            SortMemberPath = nameof(OptimizedHierarchyCellSampleNode.Category),
+            Options = CreateDataOperationOptions(
+                static item => item.Category,
+                static (item, value) => item.Category = value),
             Width = new DataGridLength(185),
-            IsReadOnly = true,
+            IsReadOnly = false,
             IsEditable = true,
             ItemsSource = s_categories,
         };
@@ -565,10 +641,26 @@ public sealed class OptimizedHierarchyCellPathsViewModel : ReactiveObject
 
     private static DataGridBindingDefinition CreateNodeBinding<TValue>(
         string propertyName,
-        Func<OptimizedHierarchyCellSampleNode, TValue> getter) =>
+        Func<OptimizedHierarchyCellSampleNode, TValue> getter,
+        Action<OptimizedHierarchyCellSampleNode, TValue>? setter = null) =>
         ColumnDefinitionBindingFactory.CreateBinding<HierarchicalNode, TValue>(
             propertyName,
-            node => getter((OptimizedHierarchyCellSampleNode)node.Item));
+            node => getter((OptimizedHierarchyCellSampleNode)node.Item),
+            setter == null
+                ? null
+                : (node, value) => setter((OptimizedHierarchyCellSampleNode)node.Item, value));
+
+    private static DataGridColumnDefinitionOptions CreateDataOperationOptions<TValue>(
+        Func<OptimizedHierarchyCellSampleNode, TValue> getter,
+        Action<OptimizedHierarchyCellSampleNode, TValue>? setter)
+    {
+        var accessor = new DataGridColumnValueAccessor<OptimizedHierarchyCellSampleNode, TValue>(getter, setter);
+        return new DataGridColumnDefinitionOptions
+        {
+            FilterValueAccessor = accessor,
+            SortValueAccessor = accessor,
+        };
+    }
 
     private static HierarchicalModel<OptimizedHierarchyCellSampleNode> CreateModel(
         IReadOnlyList<OptimizedHierarchyCellSampleNode> roots)

--- a/src/DataGridSample/ViewModels/VirtualSurfaceDataOperationsViewModel.cs
+++ b/src/DataGridSample/ViewModels/VirtualSurfaceDataOperationsViewModel.cs
@@ -1,0 +1,205 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridFiltering;
+using Avalonia.Controls.DataGridSearching;
+using Avalonia.Controls.DataGridSorting;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+
+namespace DataGridSample.ViewModels;
+
+public sealed class VirtualSurfaceDataOperationsViewModel : ReactiveObject
+{
+    private readonly object _filterColumnId;
+    private readonly string _filterPropertyPath;
+    private string _searchQuery = string.Empty;
+    private string _ownerFilterText = string.Empty;
+    private bool _searchHighlightingEnabled;
+
+    public VirtualSurfaceDataOperationsViewModel(object filterColumnId, string filterPropertyPath)
+    {
+        _filterColumnId = filterColumnId ?? throw new ArgumentNullException(nameof(filterColumnId));
+        _filterPropertyPath = string.IsNullOrWhiteSpace(filterPropertyPath)
+            ? throw new ArgumentException("A filter property path is required.", nameof(filterPropertyPath))
+            : filterPropertyPath;
+
+        SortingModel = new SortingModel();
+        FilteringModel = new FilteringModel { OwnsViewFilter = true };
+        SearchModel = new SearchModel
+        {
+            HighlightMode = SearchHighlightMode.None,
+            HighlightCurrent = false,
+            WrapNavigation = true,
+            UpdateSelectionOnNavigate = true,
+        };
+        FastPathOptions = new DataGridFastPathOptions
+        {
+            UseAccessorsOnly = true,
+            ThrowOnMissingAccessor = true,
+            EnableHighPerformanceSearching = true,
+            HighPerformanceSearchTrackItemChanges = false,
+        };
+
+        ApplySearchCommand = ReactiveCommand.Create(ApplySearch);
+        ClearSearchCommand = ReactiveCommand.Create(ClearSearch);
+        PreviousSearchResultCommand = ReactiveCommand.Create(() => SearchModel.MovePrevious());
+        NextSearchResultCommand = ReactiveCommand.Create(() => SearchModel.MoveNext());
+        ApplyOwnerFilterCommand = ReactiveCommand.Create(ApplyOwnerFilter);
+        ClearOwnerFilterCommand = ReactiveCommand.Create(ClearOwnerFilter);
+        ClearSortingCommand = ReactiveCommand.Create(ClearSorting);
+
+        SortingModel.SortingChanged += (_, _) => RaiseOperationStateChanged();
+        FilteringModel.FilteringChanged += (_, _) => RaiseOperationStateChanged();
+        SearchModel.ResultsChanged += (_, _) => RaiseOperationStateChanged();
+        SearchModel.CurrentChanged += (_, _) =>
+        {
+            this.RaisePropertyChanged(nameof(SearchResultSummary));
+            this.RaisePropertyChanged(nameof(OperationSummary));
+        };
+    }
+
+    public SortingModel SortingModel { get; }
+
+    public FilteringModel FilteringModel { get; }
+
+    public SearchModel SearchModel { get; }
+
+    public DataGridFastPathOptions FastPathOptions { get; }
+
+    public string SearchQuery
+    {
+        get => _searchQuery;
+        set => this.RaiseAndSetIfChanged(ref _searchQuery, value ?? string.Empty);
+    }
+
+    public string OwnerFilterText
+    {
+        get => _ownerFilterText;
+        set => this.RaiseAndSetIfChanged(ref _ownerFilterText, value ?? string.Empty);
+    }
+
+    public bool SearchHighlightingEnabled
+    {
+        get => _searchHighlightingEnabled;
+        set
+        {
+            if (_searchHighlightingEnabled == value)
+            {
+                return;
+            }
+
+            this.RaiseAndSetIfChanged(ref _searchHighlightingEnabled, value);
+            SearchModel.HighlightMode = value
+                ? SearchHighlightMode.TextAndCell
+                : SearchHighlightMode.None;
+            SearchModel.HighlightCurrent = value;
+            this.RaisePropertyChanged(nameof(RenderingSummary));
+        }
+    }
+
+    public string SearchResultSummary => SearchModel.Results.Count == 0
+        ? "No search results"
+        : $"{Math.Max(0, SearchModel.CurrentIndex + 1):n0} of {SearchModel.Results.Count:n0} matches";
+
+    public string OperationSummary =>
+        $"Sort keys: {SortingModel.Descriptors.Count:n0} · " +
+        $"Filters: {FilteringModel.Descriptors.Count:n0} · {SearchResultSummary}";
+
+    public string RenderingSummary =>
+        SearchModel.Descriptors.Count > 0 && SearchHighlightingEnabled
+            ? "Search highlighting uses the retained compatibility renderer. Disable highlights to restore the fastest rowless surface."
+            : "Sorting, filtering, and non-highlighted search keep the fastest rowless virtual surface active.";
+
+    public ReactiveCommand<RxVoid, RxVoid> ApplySearchCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ClearSearchCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> PreviousSearchResultCommand { get; }
+
+    public ReactiveCommand<RxVoid, bool> NextSearchResultCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ApplyOwnerFilterCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ClearOwnerFilterCommand { get; }
+
+    public ReactiveCommand<RxVoid, RxVoid> ClearSortingCommand { get; }
+
+    private void ApplySearch()
+    {
+        ApplySearchPresentation();
+        string query = SearchQuery.Trim();
+        if (query.Length == 0)
+        {
+            SearchModel.Clear();
+        }
+        else
+        {
+            SearchModel.SetOrUpdate(new SearchDescriptor(
+                query,
+                matchMode: SearchMatchMode.Contains,
+                termMode: SearchTermCombineMode.Any,
+                scope: SearchScope.VisibleColumns,
+                comparison: StringComparison.OrdinalIgnoreCase,
+                normalizeWhitespace: true));
+        }
+
+        RaiseOperationStateChanged();
+    }
+
+    private void ClearSearch()
+    {
+        SearchQuery = string.Empty;
+        SearchModel.Clear();
+        RaiseOperationStateChanged();
+    }
+
+    private void ApplySearchPresentation()
+    {
+        SearchModel.HighlightMode = SearchHighlightingEnabled
+            ? SearchHighlightMode.TextAndCell
+            : SearchHighlightMode.None;
+        SearchModel.HighlightCurrent = SearchHighlightingEnabled;
+        SearchModel.UpdateSelectionOnNavigate = true;
+        SearchModel.WrapNavigation = true;
+    }
+
+    private void ApplyOwnerFilter()
+    {
+        string value = OwnerFilterText.Trim();
+        if (value.Length == 0)
+        {
+            FilteringModel.Remove(_filterColumnId);
+        }
+        else
+        {
+            FilteringModel.SetOrUpdate(new FilteringDescriptor(
+                columnId: _filterColumnId,
+                @operator: FilteringOperator.Contains,
+                propertyPath: _filterPropertyPath,
+                value: value,
+                stringComparison: StringComparison.OrdinalIgnoreCase));
+        }
+
+        RaiseOperationStateChanged();
+    }
+
+    private void ClearOwnerFilter()
+    {
+        OwnerFilterText = string.Empty;
+        FilteringModel.Remove(_filterColumnId);
+        RaiseOperationStateChanged();
+    }
+
+    private void ClearSorting()
+    {
+        SortingModel.Clear();
+        RaiseOperationStateChanged();
+    }
+
+    private void RaiseOperationStateChanged()
+    {
+        this.RaisePropertyChanged(nameof(SearchResultSummary));
+        this.RaisePropertyChanged(nameof(OperationSummary));
+        this.RaisePropertyChanged(nameof(RenderingSummary));
+    }
+}

--- a/tests/ProDataGrid.FlatLayout.Benchmarks/README.md
+++ b/tests/ProDataGrid.FlatLayout.Benchmarks/README.md
@@ -3,6 +3,12 @@
 This BenchmarkDotNet project compares the `Nested`, `Flat`, and `Virtualized`
 layout modes with the same hierarchical data, viewport, and cell configurations.
 
+`VirtualSurfaceSortingBenchmarks` measures accessor-backed sorting with the
+250,000-row flat virtual-surface showcase workload. It guards the key-extraction
+path used by header sorting independently of rendering and layout.
+`VirtualSurfaceSortInteractionBenchmarks` measures the corresponding header-model
+interaction in the real showcase, both with and without an active search.
+
 `HierarchyCollapseLayoutBenchmarks` measures the pending Avalonia layout pass
 after collapse. `HierarchyCollapseEndToEndBenchmarks` measures collapse plus layout
 completion. Iteration setup expands and lays out the hierarchy outside the measured
@@ -32,6 +38,25 @@ DOTNET_TieredCompilation=0 dotnet run \
   --unrollFactor 1 \
   --allStats
 ```
+
+Run the representative virtual-surface sorting workload:
+
+```bash
+dotnet run \
+  --project tests/ProDataGrid.FlatLayout.Benchmarks/ProDataGrid.FlatLayout.Benchmarks.csproj \
+  -c Release --no-build -- \
+  --filter '*VirtualSurfaceSortingBenchmarks*' \
+  --launchCount 3 \
+  --warmupCount 3 \
+  --iterationCount 10 \
+  --invocationCount 1 \
+  --unrollFactor 1 \
+  --allStats
+```
+
+Replace the filter with `*VirtualSurfaceSortInteractionBenchmarks*` to include
+collection-view refresh, virtual-grid reconciliation, layout, and active-search
+maintenance.
 
 Set `PRODATAGRID_BENCHMARK_CELL_PATH` to run one cell path:
 

--- a/tests/ProDataGrid.FlatLayout.Benchmarks/VirtualSurfaceSortingBenchmarks.cs
+++ b/tests/ProDataGrid.FlatLayout.Benchmarks/VirtualSurfaceSortingBenchmarks.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel;
+using Avalonia.Collections;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.DataGridSearching;
+using Avalonia.Controls.DataGridSorting;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using DataGridSample.Models;
+using DataGridSample.Pages;
+using DataGridSample.ViewModels;
+using ReactiveUI.Avalonia;
+
+namespace ProDataGrid.FlatLayout.Benchmarks;
+
+[MemoryDiagnoser]
+[MedianColumn]
+public class VirtualSurfaceSortingBenchmarks
+{
+    private const int RowCount = 250_000;
+    private static readonly string[] s_owners =
+        { "Atlas", "Beacon", "Cirrus", "Delta", "Ember", "Flux", "Gaia", "Helix" };
+
+    private SortRow[] _rows = null!;
+    private DataGridSortDescription _sort = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rows = new SortRow[RowCount];
+        for (int index = 0; index < _rows.Length; index++)
+        {
+            _rows[index] = new SortRow(
+                index + 1,
+                s_owners[(index / 6) % s_owners.Length]);
+        }
+
+        var accessor = new DataGridColumnValueAccessor<SortRow, string>(static row => row.Owner);
+        _sort = DataGridSortDescription.FromAccessor(
+            accessor,
+            ListSortDirection.Ascending,
+            propertyPath: nameof(SortRow.Owner));
+    }
+
+    [Benchmark]
+    public object[] SortOwner() => _sort.OrderBy(_rows).ToArray();
+
+    private sealed record SortRow(int Id, string Owner);
+}
+
+[MemoryDiagnoser]
+[MedianColumn]
+public class VirtualSurfaceSortInteractionBenchmarks
+{
+    private static bool s_applicationInitialized;
+    private Window _window = null!;
+    private OptimizedFlatCellPathsViewModel _viewModel = null!;
+    private ListSortDirection _direction;
+
+    [Params(false, true)]
+    public bool ActiveSearch { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        EnsureApplication();
+        var page = new VirtualSurfaceFlatDataPage();
+        _window = new Window
+        {
+            Width = 1_200,
+            Height = 760,
+            Content = page,
+        };
+        _window.Show();
+        PumpLayout();
+
+        _viewModel = page.DataContext as OptimizedFlatCellPathsViewModel
+            ?? throw new InvalidOperationException("The virtual-surface page did not create its ViewModel.");
+        _viewModel.TargetRowCount = 250_000;
+        WaitWithDispatcher(_viewModel.LoadRepresentativeWorkloadAsync());
+        PumpLayout();
+
+        if (ActiveSearch)
+        {
+            _viewModel.Operations.SearchModel.HighlightMode = SearchHighlightMode.None;
+            _viewModel.Operations.SearchModel.SetOrUpdate(new SearchDescriptor(
+                "Delta",
+                matchMode: SearchMatchMode.Contains,
+                scope: SearchScope.VisibleColumns,
+                comparison: StringComparison.OrdinalIgnoreCase));
+            PumpLayout();
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _window.Close();
+
+    [Benchmark]
+    public int SortOwnerFromHeaderModel()
+    {
+        _direction = _direction == ListSortDirection.Ascending
+            ? ListSortDirection.Descending
+            : ListSortDirection.Ascending;
+        _viewModel.Operations.SortingModel.SetOrUpdate(new SortingDescriptor(
+            nameof(OptimizedCellSampleRow.Owner),
+            _direction,
+            nameof(OptimizedCellSampleRow.Owner)));
+        PumpLayout();
+        return _viewModel.Operations.SearchModel.Results.Count;
+    }
+
+    private static void EnsureApplication()
+    {
+        if (s_applicationInitialized)
+        {
+            return;
+        }
+
+        AppContext.SetSwitch("ProDataGrid.Diagnostics.IsEnabled", false);
+        AppBuilder.Configure<BenchmarkApplication>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = true })
+            .UseReactiveUI(static _ => { })
+            .SetupWithoutStarting();
+        s_applicationInitialized = true;
+    }
+
+    private static void WaitWithDispatcher(Task task)
+    {
+        while (!task.IsCompleted)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Yield();
+        }
+
+        task.GetAwaiter().GetResult();
+    }
+
+    private void PumpLayout()
+    {
+        Dispatcher.UIThread.RunJobs();
+        _window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+}


### PR DESCRIPTION
## Summary

This change completes the virtual-cell-surface showcase integration and addresses the sorting and layout regressions found while exercising the large workloads.

- enables model-driven selection, editing, sorting, filtering, and search across the flat and hierarchical virtual-surface modes
- keeps non-highlighted search on the fastest rowless renderer and clearly labels highlighted search as the retained compatibility fallback
- fixes the showcase layout so controls, status content, summaries, and the grid no longer overlap or overflow the viewport
- optimizes accessor-backed sorting and sort-time search maintenance
- adds focused product-path benchmarks and headless layout regression coverage

## Root causes

Sorting paid for the accessor getter during every comparer invocation, producing millions of repeated getter calls for a 250,000-row sort.

An active search treated the collection-view reset raised by sorting as an arbitrary data reset. It reformatted and rescanned all visible columns for every row even though sorting changed only row order.

The showcase grids also used a fixed `Height="520"` inside a star-sized row. When the available content area was smaller, that fixed child overflowed upward into status and operation controls. Wide single-row toolbars then wrapped at arbitrary positions.

## Implementation

### Sorting and search

- accessor-backed sort descriptions now extract one typed sort key per item and reuse it through the LINQ ordering pipeline
- primary and secondary sorting preserve missing, null, direction, and stable ordering behavior
- `DataGridCollectionView` identifies a reset caused only by sort-descriptor changes
- high-performance search remaps existing results by item identity for a sort-only reset instead of recomputing match text
- ambiguous duplicate references and non-sort resets retain the full-recompute fallback
- collection-view and selection preflight lists are pre-sized when the source count is known to reduce resize allocation

### Showcase behavior and layout

- flat and hierarchical virtual-surface samples expose sorting, owner filtering, search navigation, and editing through ViewModel-owned models and commands
- all virtual modes use editable accessors where the underlying cell supports editing
- hierarchy filtering uses the hierarchical filtering adapter and keeps ancestors visible
- fixed grid heights were removed
- workload, navigation, search, and filter controls use deliberate responsive rows
- status and summary regions wrap without clipping the grid

## Benchmark results

Environment: Apple M3 Pro, macOS 26.6, .NET SDK 10.0.201, .NET 10.0.5 Arm64, BenchmarkDotNet 0.15.8, Concurrent Workstation GC. High-priority process setup was denied by the host, so comparisons use medians and allocation evidence; the product-path timing distribution still contains GC-driven outliers.

Workload: 250,000 flat virtual-surface rows sorted by the accessor-backed Owner column.

### Pure accessor sort

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Median | 55.101 ms | 37.411 ms | -32.1% |
| Allocated | 6.68 MB | 8.59 MB | +1.91 MB |

The typed key cache trades approximately 1.91 MB per 250k-row sort for eliminating repeated getter calls.

### Complete page interaction

This includes sorting-model propagation, collection-view refresh, selection reconciliation, virtual-grid layout, and active-search maintenance.

| Scenario | Before median | After median | Median delta | Before allocation | After allocation | Allocation delta |
|---|---:|---:|---:|---:|---:|---:|
| No active search | 136.228 ms | 131.014 ms | -3.8% | 48.46 MB | 37.99 MB | -21.6% |
| Active non-highlighted search | 256.067 ms | 154.408 ms | -39.7% | 189.36 MB | 45.12 MB | -76.2% |

Exact benchmark commands are documented in `tests/ProDataGrid.FlatLayout.Benchmarks/README.md`. The product-path benchmark is `VirtualSurfaceSortInteractionBenchmarks`.

## Validation

- 93 focused core tests passed for collection view, accessor sorting, search remapping, selection reconciliation, and related behavior
- all 370 `DataGridSample.UnitTests` passed
- flat and hierarchical showcase pages rendered and were visually inspected at 1200×760
- the headless regression asserts that the grid remains below status content and inside the viewport
- `git diff --check` passed

## Commit structure

1. enable virtual-surface sample data operations
2. optimize virtual-surface sorting
3. add virtual-surface sorting benchmarks
