### PR TITLE
Stabilize automation peers and async hierarchy expansion

### DIFF
--- a/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
@@ -64,6 +64,35 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
+    public void HierarchicalLeafRow_ExposesLeafExpandCollapseProvider()
+    {
+        HierarchicalModel model = CreateModel(new TreeItem("Leaf"));
+        var grid = new DataGrid
+        {
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+        };
+        var row = new DataGridRow
+        {
+            OwningGrid = grid,
+            DataContext = model.Root,
+        };
+        var peer = new DataGridRowAutomationPeer(row);
+
+        IExpandCollapseProvider provider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            peer.GetProvider<IExpandCollapseProvider>());
+
+        Assert.Equal(AutomationControlType.TreeItem, peer.GetAutomationControlType());
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
+
+        provider.Expand();
+        provider.Collapse();
+
+        Assert.False(model.Root!.IsExpanded);
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
+    }
+
+    [AvaloniaFact]
     public void Provider_Is_Stable_While_Hierarchical_Row_Data_Is_Recycled()
     {
         var model = CreateModel(new TreeItem("Root", new TreeItem("Child")));
@@ -429,7 +458,7 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
-    public void OffscreenLeaf_DoesNotExposeExpandCollapseProvider()
+    public void OffscreenLeaf_ExposesLeafExpandCollapseProvider()
     {
         var children = Enumerable.Range(0, 80)
             .Select(index => new TreeItem($"Leaf {index}"))
@@ -470,8 +499,15 @@ public sealed class DataGridRowAutomationPeerTests
             Assert.Single(selectionProvider.GetSelection()));
 
         Assert.Equal(AutomationControlType.TreeItem, leafPeer.GetAutomationControlType());
-        Assert.Null(leafPeer.GetProvider<IExpandCollapseProvider>());
+        IExpandCollapseProvider provider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            leafPeer.GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
         Assert.NotNull(leafPeer.GetProvider<ISelectionItemProvider>());
+
+        provider.Expand();
+        provider.Collapse();
+
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
 
         window.Close();
     }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
@@ -64,7 +64,7 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
-    public void Provider_Is_Conditional_And_Follows_Recycled_Row_Data()
+    public void Provider_Is_Stable_While_Hierarchical_Row_Data_Is_Recycled()
     {
         var model = CreateModel(new TreeItem("Root", new TreeItem("Child")));
         model.Expand(model.Root!);
@@ -76,17 +76,22 @@ public sealed class DataGridRowAutomationPeerTests
         };
         var peer = new DataGridRowAutomationPeer(row);
 
-        Assert.Null(peer.GetProvider<IExpandCollapseProvider>());
+        IExpandCollapseProvider provider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            peer.GetProvider<IExpandCollapseProvider>());
+        ISelectionItemProvider selectionProvider = Assert.IsAssignableFrom<ISelectionItemProvider>(
+            peer.GetProvider<ISelectionItemProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
 
         row.DataContext = model.Root;
 
-        IExpandCollapseProvider provider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
-            peer.GetProvider<IExpandCollapseProvider>());
         Assert.Equal(ExpandCollapseState.Expanded, provider.ExpandCollapseState);
 
         row.DataContext = "flat row";
 
-        Assert.Null(peer.GetProvider<IExpandCollapseProvider>());
+        Assert.Same(provider, peer.GetProvider<IExpandCollapseProvider>());
+        Assert.Same(selectionProvider, peer.GetProvider<ISelectionItemProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
+        Assert.False(selectionProvider.IsSelected);
     }
 
     [AvaloniaFact]
@@ -106,7 +111,7 @@ public sealed class DataGridRowAutomationPeerTests
 
         grid.HierarchicalModel = newModel;
 
-        Assert.Null(peer.GetProvider<IExpandCollapseProvider>());
+        Assert.Same(staleProvider, peer.GetProvider<IExpandCollapseProvider>());
         Assert.Equal(ExpandCollapseState.LeafNode, staleProvider.ExpandCollapseState);
         staleProvider.Expand();
         Assert.False(oldModel.Root!.IsExpanded);
@@ -427,7 +432,7 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
-    public void OffscreenLeaf_DoesNotExposeExpandCollapseProvider()
+    public void OffscreenLeaf_ExposesStableLeafExpandCollapseProvider()
     {
         var children = Enumerable.Range(0, 80)
             .Select(index => new TreeItem($"Leaf {index}"))
@@ -468,7 +473,9 @@ public sealed class DataGridRowAutomationPeerTests
             Assert.Single(selectionProvider.GetSelection()));
 
         Assert.Equal(AutomationControlType.TreeItem, leafPeer.GetAutomationControlType());
-        Assert.Null(leafPeer.GetProvider<IExpandCollapseProvider>());
+        IExpandCollapseProvider expandCollapse = Assert.IsAssignableFrom<
+            IExpandCollapseProvider>(leafPeer.GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, expandCollapse.ExpandCollapseState);
         Assert.NotNull(leafPeer.GetProvider<ISelectionItemProvider>());
 
         window.Close();
@@ -681,7 +688,10 @@ public sealed class DataGridRowAutomationPeerTests
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(0, stateNotifications);
-        Assert.Null(rowPeer.GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(
+            ExpandCollapseState.LeafNode,
+            Assert.IsAssignableFrom<IExpandCollapseProvider>(
+                rowPeer.GetProvider<IExpandCollapseProvider>()).ExpandCollapseState);
 
         row.DataContext = model.Root;
         stateNotifications = 0;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
@@ -93,6 +93,33 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
+    public void UnexposedHierarchyProvider_DoesNotRaisePatternChangeWhileRowRecycles()
+    {
+        HierarchicalModel model = CreateModel(new TreeItem("Root", new TreeItem("Child")));
+        var grid = new DataGrid { HierarchicalModel = model };
+        var row = new DataGridRow
+        {
+            OwningGrid = grid,
+            DataContext = model.Root,
+        };
+        var peer = new DataGridRowAutomationPeer(row);
+        int notifications = 0;
+        peer.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty)
+            {
+                notifications++;
+            }
+        };
+
+        row.DataContext = null;
+
+        Assert.Equal(0, notifications);
+        Assert.Null(peer.GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(AutomationControlType.DataItem, peer.GetAutomationControlType());
+    }
+
+    [AvaloniaFact]
     public void Provider_Is_Stable_While_Hierarchical_Row_Data_Is_Recycled()
     {
         var model = CreateModel(new TreeItem("Root", new TreeItem("Child")));
@@ -536,6 +563,8 @@ public sealed class DataGridRowAutomationPeerTests
         Assert.True(grid.IsAttachedToVisualTree());
         var gridPeer = new DataGridAutomationPeer(grid);
         var peer = new DataGridUnrealizedRowAutomationPeer(gridPeer, model.Root!, rowIndex: 0);
+        _ = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            peer.GetProvider<IExpandCollapseProvider>());
         int callbackThreadId = -1;
         int stateNotifications = 0;
         peer.PropertyChanged += (_, e) =>
@@ -722,6 +751,8 @@ public sealed class DataGridRowAutomationPeerTests
         Assert.Null(rowPeer.GetProvider<IExpandCollapseProvider>());
 
         row.DataContext = model.Root;
+        _ = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            rowPeer.GetProvider<IExpandCollapseProvider>());
         stateNotifications = 0;
         callbackThreadId = -1;
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Automation/DataGridRowAutomationPeerTests.cs
@@ -72,26 +72,23 @@ public sealed class DataGridRowAutomationPeerTests
         var row = new DataGridRow
         {
             OwningGrid = grid,
-            DataContext = model.GetNode(1)
+            DataContext = model.Root
         };
         var peer = new DataGridRowAutomationPeer(row);
 
         IExpandCollapseProvider provider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
             peer.GetProvider<IExpandCollapseProvider>());
-        ISelectionItemProvider selectionProvider = Assert.IsAssignableFrom<ISelectionItemProvider>(
-            peer.GetProvider<ISelectionItemProvider>());
-        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
-
-        row.DataContext = model.Root;
-
         Assert.Equal(ExpandCollapseState.Expanded, provider.ExpandCollapseState);
+
+        row.DataContext = model.GetNode(1);
+
+        Assert.Same(provider, peer.GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
 
         row.DataContext = "flat row";
 
         Assert.Same(provider, peer.GetProvider<IExpandCollapseProvider>());
-        Assert.Same(selectionProvider, peer.GetProvider<ISelectionItemProvider>());
         Assert.Equal(ExpandCollapseState.LeafNode, provider.ExpandCollapseState);
-        Assert.False(selectionProvider.IsSelected);
     }
 
     [AvaloniaFact]
@@ -432,7 +429,7 @@ public sealed class DataGridRowAutomationPeerTests
     }
 
     [AvaloniaFact]
-    public void OffscreenLeaf_ExposesStableLeafExpandCollapseProvider()
+    public void OffscreenLeaf_DoesNotExposeExpandCollapseProvider()
     {
         var children = Enumerable.Range(0, 80)
             .Select(index => new TreeItem($"Leaf {index}"))
@@ -473,9 +470,7 @@ public sealed class DataGridRowAutomationPeerTests
             Assert.Single(selectionProvider.GetSelection()));
 
         Assert.Equal(AutomationControlType.TreeItem, leafPeer.GetAutomationControlType());
-        IExpandCollapseProvider expandCollapse = Assert.IsAssignableFrom<
-            IExpandCollapseProvider>(leafPeer.GetProvider<IExpandCollapseProvider>());
-        Assert.Equal(ExpandCollapseState.LeafNode, expandCollapse.ExpandCollapseState);
+        Assert.Null(leafPeer.GetProvider<IExpandCollapseProvider>());
         Assert.NotNull(leafPeer.GetProvider<ISelectionItemProvider>());
 
         window.Close();
@@ -688,10 +683,7 @@ public sealed class DataGridRowAutomationPeerTests
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(0, stateNotifications);
-        Assert.Equal(
-            ExpandCollapseState.LeafNode,
-            Assert.IsAssignableFrom<IExpandCollapseProvider>(
-                rowPeer.GetProvider<IExpandCollapseProvider>()).ExpandCollapseState);
+        Assert.Null(rowPeer.GetProvider<IExpandCollapseProvider>());
 
         row.DataContext = model.Root;
         stateNotifications = 0;

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDetachedConstraintTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Columns/DataGridDetachedConstraintTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests;
+
+public class DataGridDetachedConstraintTests
+{
+    [AvaloniaTheory]
+    [InlineData(DataGridTheme.SimpleV2, true)]
+    [InlineData(DataGridTheme.SimpleV2, false)]
+    [InlineData(DataGridTheme.FluentV2, true)]
+    [InlineData(DataGridTheme.FluentV2, false)]
+    public void Detached_grid_accepts_constraint_changes_and_reapplies_them_on_attach(
+        DataGridTheme theme, bool minimum)
+    {
+        var column = new DataGridTextColumn { Header = new string('W', 40), Width = DataGridLength.Auto };
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            ItemsSource = new[] { "row" },
+            MinColumnWidth = minimum ? 320 : 20,
+            MaxColumnWidth = minimum ? 1000 : 160
+        };
+        grid.Columns.Add(column);
+        grid.Columns.Add(new DataGridTextColumn { Header = "Remainder", Width = new DataGridLength(1, DataGridLengthUnitType.Star) });
+        var window = new Window { Width = 500, Height = 200, Content = grid };
+        window.SetThemeStyles(theme);
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            // Auto sizing retains an intrinsic desired width when star layout or
+            // a constraint limits its display width. Model that public width state.
+            column.Width = new DataGridLength(1, DataGridLengthUnitType.Auto, 600, minimum ? 320 : 160);
+            Assert.True(column.Width.DesiredValue > column.Width.DisplayValue);
+            window.Content = null;
+            Assert.Null(column.OwningGrid);
+            if (minimum) grid.MinColumnWidth = 160;
+            else grid.MaxColumnWidth = 300;
+            window.Content = grid;
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            Assert.Same(grid, column.OwningGrid);
+            Assert.InRange(column.ActualWidth, grid.MinColumnWidth, grid.MaxColumnWidth);
+            Assert.InRange(column.ActualWidth, minimum ? 160 : 299, minimum ? 1000 : 301);
+            window.Close();
+            // Closed windows can still receive application dynamic-resource updates.
+            if (minimum) grid.MinColumnWidth = 100;
+            else grid.MaxColumnWidth = 400;
+        }
+        finally { window.Close(); }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalColumnTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/DataGridHierarchicalColumnTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.DataGridHierarchical;
@@ -87,6 +89,55 @@ public class DataGridHierarchicalColumnTests
     }
 
     [AvaloniaFact]
+    public async Task Presenter_Toggle_Preserves_UI_Context_During_Async_Expansion()
+    {
+        var root = new AsyncItem("root");
+        root.Children.Add(new AsyncItem("child"));
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = async (item, cancellationToken) =>
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return ((AsyncItem)item).Children;
+            }
+        });
+        model.SetRoot(root);
+
+        var grid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            HierarchicalModel = model,
+            HierarchicalRowsEnabled = true,
+            ItemsSource = model.ObservableFlattened
+        };
+        var column = new TestHierarchicalColumn
+        {
+            Binding = new Binding(nameof(HierarchicalNode.Item))
+        };
+        grid.ColumnsInternal.Add(column);
+        grid.ApplyTemplate();
+        grid.UpdateLayout();
+
+        var cell = new DataGridCell { DataContext = model.Root };
+        var presenter = Assert.IsType<DataGridHierarchicalPresenter>(
+            column.Generate(cell, model.Root!));
+        cell.Content = presenter;
+        presenter.DataContext = model.Root;
+
+        presenter.RaiseEvent(new RoutedEventArgs(
+            DataGridHierarchicalPresenter.ToggleRequestedEvent,
+            presenter));
+
+        for (var attempt = 0; attempt < 100 && model.Count < 2; attempt++)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(model.Root!.IsExpanded);
+        Assert.Equal(2, model.Count);
+    }
+
+    [AvaloniaFact]
     public void ReusedPresenterRebindsContent()
     {
         var column = new TestHierarchicalColumn
@@ -112,5 +163,12 @@ public class DataGridHierarchicalColumnTests
     private sealed class TestHierarchicalColumn : DataGridHierarchicalColumn
     {
         public Control Generate(DataGridCell cell, object item) => GenerateElement(cell, item);
+    }
+
+    private sealed class AsyncItem(string name)
+    {
+        public string Name { get; } = name;
+
+        public List<AsyncItem> Children { get; } = [];
     }
 }

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalHeadlessTests.cs
@@ -964,7 +964,9 @@ public class HierarchicalHeadlessTests
         Assert.False(leafRelease.Handled);
         Assert.Equal(2, model.Count);
         Assert.Equal(-1, grid.SelectedIndex);
-        Assert.Null(new DataGridRowAutomationPeer(leafRow).GetProvider<IExpandCollapseProvider>());
+        IExpandCollapseProvider leafProvider = Assert.IsAssignableFrom<IExpandCollapseProvider>(
+            new DataGridRowAutomationPeer(leafRow).GetProvider<IExpandCollapseProvider>());
+        Assert.Equal(ExpandCollapseState.LeafNode, leafProvider.ExpandCollapseState);
         window.Close();
     }
 

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -19,8 +19,8 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
 
     public class HierarchicalModelTests
     {
-        private class Item
-        {
+    private class Item
+    {
             public Item(string name)
         {
             Name = name;
@@ -30,6 +30,32 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         public string Name { get; }
 
         public ObservableCollection<Item> Children { get; set; }
+    }
+
+    private sealed class TrackingSynchronizationContext : SynchronizationContext
+    {
+        private int _postCount;
+
+        public int PostCount => Volatile.Read(ref _postCount);
+
+        public override void Post(SendOrPostCallback callback, object? state)
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+            Interlocked.Increment(ref _postCount);
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                var previousContext = Current;
+                SetSynchronizationContext(this);
+                try
+                {
+                    callback(state);
+                }
+                finally
+                {
+                    SetSynchronizationContext(previousContext);
+                }
+            });
+        }
     }
 
     private sealed class DuplicateItem
@@ -2292,6 +2318,39 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         Assert.Equal(2, model.Count);
         Assert.False(model.Root!.IsLoading);
         Assert.True(model.Root!.IsExpanded);
+    }
+
+    [Fact]
+    public async Task ChildrenSelectorAsync_PreservesCallerSynchronizationContext()
+    {
+        var root = new Item("root");
+        root.Children.Add(new Item("child"));
+        var model = new HierarchicalModel(new HierarchicalOptions
+        {
+            ChildrenSelectorAsync = async (item, ct) =>
+            {
+                await Task.Delay(10, ct).ConfigureAwait(false);
+                return ((Item)item).Children;
+            }
+        });
+        var context = new TrackingSynchronizationContext();
+        var previousContext = SynchronizationContext.Current;
+        SynchronizationContext? notificationContext = null;
+
+        model.SetRoot(root);
+        model.FlattenedChanged += (_, _) => notificationContext = SynchronizationContext.Current;
+
+        SynchronizationContext.SetSynchronizationContext(context);
+        try
+        {
+            await model.ExpandAsync(model.Root!);
+            Assert.Same(context, notificationContext);
+            Assert.True(context.PostCount > 0);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
     }
 
     [Fact]

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Hierarchical/HierarchicalModelTests.cs
@@ -2335,16 +2335,21 @@ namespace Avalonia.Controls.DataGridTests.Hierarchical;
         });
         var context = new TrackingSynchronizationContext();
         var previousContext = SynchronizationContext.Current;
-        SynchronizationContext? notificationContext = null;
+        var notificationContexts = new List<SynchronizationContext?>();
 
         model.SetRoot(root);
-        model.FlattenedChanged += (_, _) => notificationContext = SynchronizationContext.Current;
+        model.Root!.PropertyChanged += (_, _) => notificationContexts.Add(SynchronizationContext.Current);
+        model.NodeLoading += (_, _) => notificationContexts.Add(SynchronizationContext.Current);
+        model.NodeLoaded += (_, _) => notificationContexts.Add(SynchronizationContext.Current);
+        model.NodeExpanded += (_, _) => notificationContexts.Add(SynchronizationContext.Current);
+        model.FlattenedChanged += (_, _) => notificationContexts.Add(SynchronizationContext.Current);
 
         SynchronizationContext.SetSynchronizationContext(context);
         try
         {
             await model.ExpandAsync(model.Root!);
-            Assert.Same(context, notificationContext);
+            Assert.NotEmpty(notificationContexts);
+            Assert.All(notificationContexts, notificationContext => Assert.Same(context, notificationContext));
             Assert.True(context.PostCount > 0);
         }
         finally

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
@@ -122,13 +122,14 @@ internal
         protected override object? GetProviderCore(Type providerType)
         {
             if (providerType == typeof(IExpandCollapseProvider) &&
-                !TryGetActiveNode(out _, out _))
+                _row.OwningGrid?.HierarchicalModel is null)
             {
                 return null;
             }
 
             if (providerType == typeof(ISelectionItemProvider) &&
-                !TryGetSelectableRow(out _))
+                (_row.OwningGrid is not DataGrid selectionGrid ||
+                 !DataGridAutomationPeer.SupportsRowSelection(selectionGrid.SelectionUnit)))
             {
                 return null;
             }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
@@ -125,7 +125,7 @@ internal
             if (providerType == typeof(IExpandCollapseProvider))
             {
                 if (!_isExpandCollapseProviderExposed &&
-                    !TryGetActiveNode(out _, out _))
+                    !TryGetOwnedNode(out _, out _))
                 {
                     return null;
                 }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
@@ -22,6 +22,7 @@ internal
         private HierarchicalNode? _node;
         private ExpandCollapseState _lastExpandCollapseState;
         private bool _lastIsSelected;
+        private bool _isExpandCollapseProviderExposed;
 
         public DataGridRowAutomationPeer(DataGridRow owner)
             : base(owner)
@@ -121,15 +122,19 @@ internal
 
         protected override object? GetProviderCore(Type providerType)
         {
-            if (providerType == typeof(IExpandCollapseProvider) &&
-                _row.OwningGrid?.HierarchicalModel is null)
+            if (providerType == typeof(IExpandCollapseProvider))
             {
-                return null;
+                if (!_isExpandCollapseProviderExposed &&
+                    !TryGetActiveNode(out _, out _))
+                {
+                    return null;
+                }
+
+                _isExpandCollapseProviderExposed = true;
             }
 
             if (providerType == typeof(ISelectionItemProvider) &&
-                (_row.OwningGrid is not DataGrid selectionGrid ||
-                 !DataGridAutomationPeer.SupportsRowSelection(selectionGrid.SelectionUnit)))
+                !TryGetSelectableRow(out _))
             {
                 return null;
             }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridRowAutomationPeer.cs
@@ -294,7 +294,7 @@ internal
 
         private void RaiseExpandCollapseChanges(ExpandCollapseState oldState, ExpandCollapseState newState)
         {
-            if (oldState == newState)
+            if (!_isExpandCollapseProviderExposed || oldState == newState)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
@@ -382,7 +382,7 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
         ExpandCollapseState oldState,
         ExpandCollapseState newState)
     {
-        if (oldState != newState)
+        if (_isExpandCollapseProviderExposed && oldState != newState)
         {
             RaisePropertyChangedEvent(
                 ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty,

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
@@ -34,6 +34,7 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
     private int _rowIndex;
     private ExpandCollapseState _lastExpandCollapseState;
     private bool _lastIsSelected;
+    private bool _isExpandCollapseProviderExposed;
 
     internal DataGridUnrealizedRowAutomationPeer(
         DataGridAutomationPeer owner,
@@ -209,14 +210,20 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
 
     protected override object? GetProviderCore(Type providerType)
     {
-        if (providerType == typeof(IExpandCollapseProvider) &&
-            _owner.Owner.HierarchicalModel is null)
+        if (providerType == typeof(IExpandCollapseProvider))
         {
-            return null;
+            if (!_isExpandCollapseProviderExposed &&
+                !TryGetActiveNode(out _))
+            {
+                return null;
+            }
+
+            _isExpandCollapseProviderExposed = true;
         }
 
         if (providerType == typeof(ISelectionItemProvider) &&
-            !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner.SelectionUnit))
+            (!TryGetCurrentRowIndex(out _) ||
+             !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner.SelectionUnit)))
         {
             return null;
         }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
@@ -213,7 +213,7 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
         if (providerType == typeof(IExpandCollapseProvider))
         {
             if (!_isExpandCollapseProviderExposed &&
-                !TryGetActiveNode(out _))
+                !TryGetOwnedNode(out _))
             {
                 return null;
             }

--- a/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
+++ b/src/Avalonia.Controls.DataGrid/Automation/Peers/DataGridUnrealizedRowAutomationPeer.cs
@@ -210,14 +210,13 @@ sealed class DataGridUnrealizedRowAutomationPeer : UnrealizedElementAutomationPe
     protected override object? GetProviderCore(Type providerType)
     {
         if (providerType == typeof(IExpandCollapseProvider) &&
-            !TryGetActiveNode(out _))
+            _owner.Owner.HierarchicalModel is null)
         {
             return null;
         }
 
         if (providerType == typeof(ISelectionItemProvider) &&
-            (!TryGetCurrentRowIndex(out _) ||
-             !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner.SelectionUnit)))
+            !DataGridAutomationPeer.SupportsRowSelection(_owner.Owner.SelectionUnit))
         {
             return null;
         }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.Columns.cs
@@ -1573,7 +1573,12 @@ internal
                 double oldValue = (double)e.OldValue;
                 foreach (DataGridColumn column in ColumnsInternal.GetDisplayedColumns())
                 {
-                    OnColumnMinWidthChanged(column, Math.Max(column.MinWidth, oldValue));
+                    // Detached grids retain their columns but release column ownership.
+                    // Width coercion will apply the new constraint when they are attached again.
+                    if (ReferenceEquals(column.OwningGrid, this))
+                    {
+                        OnColumnMinWidthChanged(column, Math.Max(column.MinWidth, oldValue));
+                    }
                 }
             }
         }
@@ -1585,7 +1590,10 @@ internal
                 var oldValue = (double)e.OldValue;
                 foreach (DataGridColumn column in ColumnsInternal.GetDisplayedColumns())
                 {
-                    OnColumnMaxWidthChanged(column, Math.Min(column.MaxWidth, oldValue));
+                    if (ReferenceEquals(column.OwningGrid, this))
+                    {
+                        OnColumnMaxWidthChanged(column, Math.Min(column.MaxWidth, oldValue));
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/DataGridHierarchicalColumn.cs
@@ -411,7 +411,7 @@ internal
                 : null;
         }
 
-        private void PresenterOnToggleRequested(object? sender, EventArgs e)
+        private async void PresenterOnToggleRequested(object? sender, EventArgs e)
         {
             if (OwningGrid?.HierarchicalModel == null)
             {
@@ -437,7 +437,7 @@ internal
                     OwningGrid.PrepareHierarchicalAnchor(row.Slot);
                 }
 
-                OwningGrid.HierarchicalModel.Toggle(node);
+                await OwningGrid.HierarchicalModel.ToggleAsync(node);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1012,15 +1012,32 @@ namespace Avalonia.Controls.DataGridHierarchical
 
         public void Expand(HierarchicalNode node)
         {
-            ExpandAsync(node, CancellationToken.None).GetAwaiter().GetResult();
+            ExpandAsyncCore(
+                node,
+                CancellationToken.None,
+                continueOnCapturedContext: false).GetAwaiter().GetResult();
         }
 
         public void Expand(IEnumerable items)
         {
-            ExpandAsync(items, CancellationToken.None).GetAwaiter().GetResult();
+            ExpandAsyncCore(
+                items,
+                CancellationToken.None,
+                continueOnCapturedContext: false).GetAwaiter().GetResult();
         }
 
-        public async Task ExpandAsync(HierarchicalNode node, CancellationToken cancellationToken = default)
+        public Task ExpandAsync(
+            HierarchicalNode node,
+            CancellationToken cancellationToken = default) =>
+            ExpandAsyncCore(
+                node,
+                cancellationToken,
+                SynchronizationContext.Current != null);
+
+        private async Task ExpandAsyncCore(
+            HierarchicalNode node,
+            CancellationToken cancellationToken,
+            bool continueOnCapturedContext)
         {
             if (node == null)
             {
@@ -1028,7 +1045,8 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
 
             var loadState = GetLoadState(node);
-            await loadState.ExpandGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await loadState.ExpandGate.WaitAsync(cancellationToken)
+                .ConfigureAwait(continueOnCapturedContext);
             try
             {
                 var parentIndex = GetFlattenedIndex(node);
@@ -1055,7 +1073,9 @@ namespace Avalonia.Controls.DataGridHierarchical
 
                 try
                 {
-                    await EnsureChildrenMaterializedAsync(node, forceReload: false, cancellationToken).ConfigureAwait(false);
+                    await EnsureChildrenMaterializedAsync(
+                            node, forceReload: false, cancellationToken)
+                        .ConfigureAwait(continueOnCapturedContext);
                 }
                 catch
                 {
@@ -1095,7 +1115,18 @@ namespace Avalonia.Controls.DataGridHierarchical
             }
         }
 
-        public async Task ExpandAsync(IEnumerable items, CancellationToken cancellationToken = default)
+        public Task ExpandAsync(
+            IEnumerable items,
+            CancellationToken cancellationToken = default) =>
+            ExpandAsyncCore(
+                items,
+                cancellationToken,
+                SynchronizationContext.Current != null);
+
+        private async Task ExpandAsyncCore(
+            IEnumerable items,
+            CancellationToken cancellationToken,
+            bool continueOnCapturedContext)
         {
             if (items == null)
             {
@@ -1117,7 +1148,9 @@ namespace Avalonia.Controls.DataGridHierarchical
                     continue;
                 }
 
-                await ExpandAsync(node, cancellationToken).ConfigureAwait(false);
+                await ExpandAsyncCore(
+                        node, cancellationToken, continueOnCapturedContext)
+                    .ConfigureAwait(continueOnCapturedContext);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
+++ b/src/Avalonia.Controls.DataGrid/Hierarchical/HierarchicalModel.cs
@@ -1074,7 +1074,10 @@ namespace Avalonia.Controls.DataGridHierarchical
                 try
                 {
                     await EnsureChildrenMaterializedAsync(
-                            node, forceReload: false, cancellationToken)
+                            node,
+                            forceReload: false,
+                            cancellationToken,
+                            continueOnCapturedContext: continueOnCapturedContext)
                         .ConfigureAwait(continueOnCapturedContext);
                 }
                 catch


### PR DESCRIPTION
## Summary

- keep an already-exposed expand/collapse provider stable while realized and unrealized rows are recycled, while preserving leaf and row-selection pattern availability contracts
- reject stale hierarchy nodes and stale worker callbacks after row or model replacement
- preserve the caller synchronization context across asynchronous child materialization so UI-bound hierarchy state is published on the owning UI thread
- keep synchronous expansion paths context-free to avoid blocking on a captured UI context
- add focused regression coverage for automation recycling, model replacement, worker callbacks, caller-context continuation, cancellation, and concurrent expansion

## Validation

- `dotnet test src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj -c Release -p:CollectCoverage=false -p:WarningLevel=0 --no-build --no-restore`
  - Passed: 2,826; Failed: 0; Skipped: 0
- focused automation, hierarchy, and synchronization-context selection
  - Passed: 16; Failed: 0; Skipped: 0
- `git diff --check origin/master..HEAD`
  - clean

The full suite caught a leaf-pattern regression in the initial automation change; commit `ff7c2049` narrows provider stability to patterns already exposed and restores the existing leaf and selection-unit contracts.